### PR TITLE
Wire backend config endpoint into frontend

### DIFF
--- a/frontend/components/BackendHealth.tsx
+++ b/frontend/components/BackendHealth.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { getHealth, HealthResponse } from "@/lib/config";
+
+type State =
+  | { type: "loading" }
+  | { type: "error"; message: string }
+  | { type: "success"; data: HealthResponse };
+
+export default function BackendHealth() {
+  const [state, setState] = useState<State>({ type: "loading" });
+
+  useEffect(() => {
+    getHealth()
+      .then((data) => setState({ type: "success", data }))
+      .catch((err: Error) =>
+        setState({ type: "error", message: err.message })
+      );
+  }, []);
+
+  return (
+    <div className="border p-4 rounded-lg mt-6 bg-white shadow-sm flex flex-col items-center justify-center ">
+      <h3 className="font-semibold mb-3 text-lg">
+        Backend Health
+      </h3>
+
+      {state.type === "loading" && (
+        <p className="text-gray-500">Loading...</p>
+      )}
+
+      {state.type === "error" && (
+        <p className="text-red-500">
+          Error: {state.message}
+        </p>
+      )}
+
+      {state.type === "success" && (
+        <div className="space-y-1">
+          <p>
+            <strong>OK:</strong> {state.data.ok ? "Yes" : "No"}
+          </p>
+          <p>
+            <strong>Service:</strong> {state.data.service}
+          </p>
+          <p>
+            <strong>Environment:</strong> {state.data.env}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,0 +1,18 @@
+const baseUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
+
+if (!baseUrl) {
+  throw new Error("Missing NEXT_PUBLIC_BACKEND_URL");
+}
+
+export async function apiFetch<T>(path: string): Promise<T> {
+  const res = await fetch(`${baseUrl}${path}`, {
+    cache: "no-store",
+  });
+
+  if (!res.ok) {
+    const message = await res.text();
+    throw new Error(message || `API error: ${res.status}`);
+  }
+
+  return res.json();
+}

--- a/frontend/lib/config.ts
+++ b/frontend/lib/config.ts
@@ -1,0 +1,12 @@
+import { apiFetch } from "./api";
+
+
+export interface HealthResponse {
+  ok: boolean;
+  service: string;
+  env: string;
+}
+
+export function getHealth(): Promise<HealthResponse> {
+  return apiFetch<HealthResponse>("/health");
+}

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
---


#  Final PR Content

## Summary

This PR introduces the first read-only integration between the frontend and backend.

The frontend now calls the backend `/health` endpoint and displays the result in a dedicated UI section. The implementation includes proper environment configuration, loading and error handling, and follows a scalable API integration pattern.

---

## Linked issue

Closes #10 

If no issue exists:

N/A – this PR implements the initial frontend-backend integration milestone.

---

## Changes

* Added `lib/api.ts` for backend communication
* Added `lib/config.ts` to define the health endpoint logic
* Created `BackendHealth.tsx` client component
* Integrated health component into the homepage
* Configured backend URL via `NEXT_PUBLIC_BACKEND_URL`
* Updated frontend README with integration details

---

## How to test

1. Start backend:

   ```
   cd backend
   npm run dev
   ```

2. Confirm backend health endpoint works:

   ```
   http://localhost:4000/health
   ```

3. Ensure frontend environment variable is set:

   ```
   NEXT_PUBLIC_BACKEND_URL=http://localhost:4000
   ```

4. Start frontend:

   ```
   cd frontend
   npm run dev
   ```

5. Visit:

   ```
   http://localhost:3000
   ```

Expected behavior:

* Shows loading state initially
* Displays backend status on success
* Shows error state if backend is stopped

To test error state:

* Stop backend and refresh page

---

## Screenshots (if UI)
<img width="1928" height="545" alt="image" src="https://github.com/user-attachments/assets/69d3204c-2d84-49d7-a2a5-97a7a8084e50" />

Include:

* Success state screenshot
* Error state screenshot
* Browser Network tab showing `/health` request

---

## Checklist

* [x] I linked an issue (or explained why one is not needed)
* [x] I tested locally
* [x] I did not commit secrets
* [x] I updated docs if needed

---
