### PR TITLE
feat/Emit events for credit/debit + document event schema

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -77,3 +77,25 @@ Recommended contributor expectations for deployment-related issues:
 - `debit(user: Address, amount: i128)` (admin-auth)
 - `balance(user: Address) -> i128`
 - `set_admin(new_admin: Address)` (admin-auth)
+
+### Events
+
+The `rent_wallet` contract emits Soroban events to support indexing and auditability.
+
+- **`credit`**
+  - **Topic**
+    - `("credit", user: Address)`
+  - **Data**
+    - `(amount: i128, new_balance: i128)`
+
+- **`debit`**
+  - **Topic**
+    - `("debit", user: Address)`
+  - **Data**
+    - `(amount: i128, new_balance: i128)`
+
+For both events:
+
+- **`user`** is the address whose balance was modified.
+- **`amount`** is the delta applied (always positive).
+- **`new_balance`** is the resulting balance after applying the delta.

--- a/contracts/rent_wallet/src/lib.rs
+++ b/contracts/rent_wallet/src/lib.rs
@@ -54,11 +54,12 @@ impl RentWallet {
 
         let mut b = balances(&env);
         let cur = b.get(user.clone()).unwrap_or(0);
-        b.set(user.clone(), cur + amount);
+        let new_balance = cur + amount;
+        b.set(user.clone(), new_balance);
         put_balances(&env, b);
 
         env.events()
-            .publish((Symbol::new(&env, "credit"), user), amount);
+            .publish((Symbol::new(&env, "credit"), user), (amount, new_balance));
     }
 
     pub fn debit(env: Env, user: Address, amount: i128) {
@@ -72,11 +73,12 @@ impl RentWallet {
         if cur < amount {
             panic!("insufficient balance")
         }
-        b.set(user.clone(), cur - amount);
+        let new_balance = cur - amount;
+        b.set(user.clone(), new_balance);
         put_balances(&env, b);
 
         env.events()
-            .publish((Symbol::new(&env, "debit"), user), amount);
+            .publish((Symbol::new(&env, "debit"), user), (amount, new_balance));
     }
 
     pub fn balance(env: Env, user: Address) -> i128 {


### PR DESCRIPTION
## Summary
Emit balance-change events for the rent_wallet contract to support indexing/auditability. credit and debit now publish events that include the affected address, the amount, and the resulting balance.

## Linked issue
Closes #9 

## Changes
Updated rent_wallet contract events:
credit now emits topic ("credit", user) with data (amount, new_balance)
debit now emits topic ("debit", user) with data (amount, new_balance)
Updated contracts/README.md to document the event schema and semantics.

## How to test
cd contracts
cargo test

## Screenshots (if UI)

## Checklist

- [x] I linked an issue (or explained why one is not needed)
- [x] I tested locally
- [x] I did not commit secrets
- [x] I updated docs if needed
