### PR TITLE
Rate limiting for public endpoints

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -5,6 +5,10 @@ NODE_ENV=development
 # CORS (comma-separated origins)
 CORS_ORIGINS=http://localhost:3000
 
+# Rate limiting (public endpoints: /health, /soroban/config)
+# RATE_LIMIT_WINDOW_MS=60000
+# RATE_LIMIT_MAX_REQUESTS=100
+
 # App state
 NODE_ENV=development
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -88,6 +88,27 @@ Soroban-related code should live in `src/soroban/`.
 
 Environment variables:
 
+- `RATE_LIMIT_WINDOW_MS` (optional, default `60000`)
+- `RATE_LIMIT_MAX_REQUESTS` (optional, default `100`)
 - `SOROBAN_RPC_URL`
 - `SOROBAN_NETWORK_PASSPHRASE`
 - `SOROBAN_CONTRACT_ID` (optional)
+
+## Rate limiting
+
+Public endpoints (`GET /health`, `GET /soroban/config`) are rate limited per IP to reduce abuse and protect uptime.
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `RATE_LIMIT_WINDOW_MS` | Time window in milliseconds | `60000` (1 minute) |
+| `RATE_LIMIT_MAX_REQUESTS` | Max requests per IP per window | `100` |
+
+When a client exceeds the limit, the server responds with **429 Too Many Requests** and a JSON body in the standard error format:
+
+```json
+{
+  "error": "Too many requests. Please try again later."
+}
+```
+
+Defaults are suitable for local development; set lower limits in production if needed.

--- a/backend/eslint.config.mjs
+++ b/backend/eslint.config.mjs
@@ -1,6 +1,7 @@
 import js from "@eslint/js"
 
 export default [
+  { ignores: ["dist/**"] },
   js.configs.recommended,
   {
     languageOptions: {

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -11,6 +11,7 @@
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
+        "express-rate-limit": "^8.2.1",
         "morgan": "^1.10.0",
         "zod": "^3.25.76"
       },
@@ -1517,6 +1518,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
+      "integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.0.1"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/express/node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -1875,6 +1894,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -14,6 +14,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
+    "express-rate-limit": "^8.2.1",
     "morgan": "^1.10.0",
     "zod": "^3.25.76"
   },
@@ -21,10 +22,10 @@
     "@eslint/js": "^9.39.0",
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
-    "@types/node": "^22.10.2",
     "@types/morgan": "^1.9.9",
+    "@types/node": "^22.10.2",
     "eslint": "^9.39.2",
-    "typescript": "^5.7.2",
-    "tsx": "^4.20.0"
+    "tsx": "^4.20.0",
+    "typescript": "^5.7.2"
   }
 }

--- a/backend/src/middleware/rateLimit.ts
+++ b/backend/src/middleware/rateLimit.ts
@@ -1,0 +1,21 @@
+import rateLimit from 'express-rate-limit'
+import type { Request, Response } from 'express'
+import type { Env } from '../schemas/env.js'
+
+/**
+ * Rate limiter for public endpoints (/health, /soroban/config).
+ * Returns HTTP 429 with standard error format when the limit is exceeded.
+ */
+export function createPublicRateLimiter(env: Env) {
+  return rateLimit({
+    windowMs: env.RATE_LIMIT_WINDOW_MS,
+    limit: env.RATE_LIMIT_MAX_REQUESTS,
+    standardHeaders: true,
+    legacyHeaders: false,
+    handler: (_req: Request, res: Response) => {
+      res.status(429).json({
+        error: 'Too many requests. Please try again later.',
+      })
+    },
+  })
+}

--- a/backend/src/schemas/env.ts
+++ b/backend/src/schemas/env.ts
@@ -4,6 +4,8 @@ export const envSchema = z.object({
   PORT: z.coerce.number().default(4000),
   NODE_ENV: z.string().default('development'),
   CORS_ORIGINS: z.string().default('http://localhost:3000'),
+  RATE_LIMIT_WINDOW_MS: z.coerce.number().default(60_000),
+  RATE_LIMIT_MAX_REQUESTS: z.coerce.number().default(100),
   SOROBAN_RPC_URL: z.string().url().default('https://soroban-testnet.stellar.org'),
   SOROBAN_NETWORK_PASSPHRASE: z.string().default('Test SDF Network ; September 2015'),
   SOROBAN_CONTRACT_ID: z.string().optional(),


### PR DESCRIPTION

Closes #21 

Summary
Adds rate limiting for public endpoints (GET /health, GET /soroban/config) so they can’t be spammed. Limits are configurable via env; when exceeded, the API returns 429 with the same error shape as the rest of the backend.



Changes
Env: RATE_LIMIT_WINDOW_MS and RATE_LIMIT_MAX_REQUESTS in src/schemas/env.ts and .env.example (defaults: 60s window, 100 requests per IP).
Middleware: src/middleware/rateLimit.ts using express-rate-limit; on limit exceeded returns 429 and { "error": "Too many requests. Please try again later." }.
Routes: Rate limiter applied only to the public router that serves /health and /soroban/config in src/index.ts.
Docs: backend/README.md updated with a “Rate limiting” section (env vars, behavior, 429 response).
Tooling: ESLint ignore for dist/** in eslint.config.mjs so lint runs only on source. Fixed use of version in src/index.ts by reading it from package.json.


How to test
Under the limit: Start the backend (npm run dev), then:
curl -s http://localhost:4000/health and curl -s http://localhost:4000/soroban/config
Both should return 200 and JSON.
Over the limit: Send more than 100 requests in a minute to the same endpoint from the same machine (e.g. loop with curl or a small script). The next request should get 429 and body:
{"error":"Too many requests. Please try again later."}
Config: Set e.g. RATE_LIMIT_MAX_REQUESTS=3 and RATE_LIMIT_WINDOW_MS=60000, restart, then send 4 requests within a minute; the 4th should be 429.
Lint/build:
npm run lint && npm run typecheck && npm run build
should all pass.

<img width="1440" height="900" alt="Screen Shot 2026-02-27 at 5 54 19 PM" src="https://github.com/user-attachments/assets/bd262068-97ea-4b32-a1d8-331148df5eb9" />





