### PR TITLE
Feat : Add Structured JSON loger with LOG_LEVEL

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -9,12 +9,16 @@ import { createPublicRateLimiter } from "./middleware/rateLimit.js"
 import publicRouter from "./routes/publicRoutes.js"
 import { AppError } from "./errors/AppError.js"
 import { ErrorCode } from "./errors/errorCodes.js"
+import { requestLogger } from "./middleware/requestLogger.js"
 
 export function createApp() {
   const app = express()
 
   // Core middleware
   app.use(requestIdMiddleware)
+
+  //  Logger 
+  app.use(requestLogger);
 
   if (env.NODE_ENV !== "production") {
     app.use(createLogger())

--- a/backend/src/middleware/requestLogger.ts
+++ b/backend/src/middleware/requestLogger.ts
@@ -1,0 +1,42 @@
+import { Request, Response, NextFunction } from 'express';
+import { randomUUID } from 'crypto';
+import { logger } from '../utils/logger.js';
+
+declare global {
+     namespace Express {
+          interface Request {
+               requestId: string;
+          }
+     }
+}
+
+
+export function requestLogger(req: Request, res: Response, next: NextFunction): void {
+     const requestId = (req.headers['x-request-id'] as string | undefined) ?? randomUUID();
+     req.requestId = requestId;
+
+     res.setHeader('X-Request-ID', requestId);
+
+     const startedAt = Date.now();
+
+     logger.debug('Incoming request', {
+          requestId,
+          method: req.method,
+          path: req.path,
+     });
+
+     res.on('finish', () => {
+          const durationMs = Date.now() - startedAt;
+          const level = res.statusCode >= 500 ? 'error' : res.statusCode >= 400 ? 'warn' : 'info';
+
+          logger[level]('Request completed', {
+               requestId,
+               method: req.method,
+               path: req.path,
+               status: res.statusCode,
+               durationMs,
+          });
+     });
+
+     next();
+}

--- a/backend/src/utils/logger.ts
+++ b/backend/src/utils/logger.ts
@@ -1,0 +1,64 @@
+type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+const LEVELS: Record<LogLevel, number> = {
+     debug: 0,
+     info: 1,
+     warn: 2,
+     error: 3
+}
+
+function getConfigLevel(): LogLevel {
+     const raw = (process.env.LOG_LEVEL ?? 'info').toLowerCase();
+     if (raw in LEVELS) return raw as LogLevel;
+     process.stderr.write(
+          JSON.stringify({ level: 'warn', message: `Invalid LOG_LEVEL "${raw}", defaulting to "info"` }) + '\n',
+     );
+     return 'info';
+}
+
+const configLevel = getConfigLevel();
+
+function shouldLog(level: LogLevel): boolean {
+     return LEVELS[level] >= LEVELS[configLevel];
+}
+
+type LogFields = Record<string, unknown>;
+
+function write(level: LogLevel, message: string, fields?: LogFields): void {
+     if (!shouldLog(level)) return;
+
+     const entry: Record<string, unknown> = {
+          timestamp: new Date().toISOString(),
+          level,
+          message,
+          ...fields,
+     };
+
+     // Never leak secrets
+     const REDACTED_KEYS = new Set([
+          'password', 'secret', 'token', 'authorization', 'apiKey', 'api_key',
+          'privateKey', 'private_key', 'accessToken', 'access_token',
+     ]);
+     for (const key of REDACTED_KEYS) {
+          if (key in entry) entry[key] = '[REDACTED]';
+     }
+
+     process.stdout.write(JSON.stringify(entry) + '\n');
+}
+
+export const logger = {
+     debug: (message: string, fields?: LogFields) => write('debug', message, fields),
+     info: (message: string, fields?: LogFields) => write('info', message, fields),
+     warn: (message: string, fields?: LogFields) => write('warn', message, fields),
+     error: (message: string, fields?: LogFields, err?: unknown) => {
+          const errorFields: LogFields = {};
+          if (err instanceof Error) {
+               errorFields.errorMessage = err.message;
+
+               if (process.env.LOG_STACK_TRACES === 'true') {
+                    errorFields.stack = err.stack;
+               }
+          }
+          write('error', message, { ...fields, ...errorFields });
+     },
+};


### PR DESCRIPTION
## Structured JSON Logging with `LOG_LEVEL` [#20]

Replaces ad-hoc console output with structured JSON logging and a configurable log level. Logs are output as one JSON object per line, with `requestId`, `method`, `path`, `status`, and `durationMs` on every request. Sensitive keys (`token`, `authorization`, `apiKey`, etc.) are automatically redacted. Stack traces are suppressed unless `LOG_STACK_TRACES=true` is explicitly set.

`LOG_LEVEL` defaults to `info` — debug logs only appear when `LOG_LEVEL=debug`.

---

### Screenshots

**Before** 

<img width="666" height="224" alt="Screenshot From 2026-02-28 11-10-29" src="https://github.com/user-attachments/assets/816ffbfd-e3d8-497a-83f9-d91bf3d26175" />


**After** 

<img width="1884" height="232" alt="Screenshot From 2026-02-28 11-10-51" src="https://github.com/user-attachments/assets/75c0561e-343c-4fc8-85e4-86e5ac817e6a" />


## Close #20 