### PR TITLE
feat: add backend connectivity indicator for dev/testing

### DIFF
--- a/frontend/components/BackendHealth.tsx
+++ b/frontend/components/BackendHealth.tsx
@@ -1,7 +1,12 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { CheckCircle2, XCircle, Server } from "lucide-react";
 import { getHealth, HealthResponse } from "@/lib/config";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Spinner } from "@/components/ui/spinner";
 
 type State =
   | { type: "loading" }
@@ -9,45 +14,93 @@ type State =
   | { type: "success"; data: HealthResponse };
 
 export default function BackendHealth() {
-  const [state, setState] = useState<State>({ type: "loading" });
+  const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL || "Not configured";
+  const [state, setState] = useState<State>(() => {
+    if (!process.env.NEXT_PUBLIC_BACKEND_URL) {
+      return { type: "error", message: "NEXT_PUBLIC_BACKEND_URL environment variable is not configured" };
+    }
+    return { type: "loading" };
+  });
 
   useEffect(() => {
+    if (!process.env.NEXT_PUBLIC_BACKEND_URL) {
+      return;
+    }
+
     getHealth()
       .then((data) => setState({ type: "success", data }))
-      .catch((err: Error) =>
-        setState({ type: "error", message: err.message })
-      );
+      .catch((err: Error) => {
+        const errorMessage = err.message || "Unknown error";
+        console.error("Backend health check failed:", err);
+        setState({ type: "error", message: errorMessage });
+      });
   }, []);
 
   return (
-    <div className="border p-4 rounded-lg mt-6 bg-white shadow-sm flex flex-col items-center justify-center ">
-      <h3 className="font-semibold mb-3 text-lg">
-        Backend Health
-      </h3>
-
-      {state.type === "loading" && (
-        <p className="text-gray-500">Loading...</p>
-      )}
-
-      {state.type === "error" && (
-        <p className="text-red-500">
-          Error: {state.message}
-        </p>
-      )}
-
-      {state.type === "success" && (
-        <div className="space-y-1">
-          <p>
-            <strong>OK:</strong> {state.data.ok ? "Yes" : "No"}
-          </p>
-          <p>
-            <strong>Service:</strong> {state.data.service}
-          </p>
-          <p>
-            <strong>Environment:</strong> {state.data.env}
-          </p>
+    <Card className="border-3 border-foreground shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Server className="h-5 w-5" />
+          Backend Connectivity
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <span className="text-sm font-medium text-muted-foreground">
+              Backend URL:
+            </span>
+            <code className="text-xs bg-muted px-2 py-1 rounded border">
+              {backendUrl}
+            </code>
+          </div>
         </div>
-      )}
-    </div>
+
+        {state.type === "loading" && (
+          <Alert>
+            <Spinner className="h-4 w-4" />
+            <AlertTitle>Checking connection...</AlertTitle>
+            <AlertDescription>
+              Connecting to backend service
+            </AlertDescription>
+          </Alert>
+        )}
+
+        {state.type === "error" && (
+          <Alert variant="destructive">
+            <XCircle className="h-4 w-4" />
+            <AlertTitle>Connection Failed</AlertTitle>
+            <AlertDescription>
+              {state.message || "Unable to connect to backend service"}
+            </AlertDescription>
+          </Alert>
+        )}
+
+        {state.type === "success" && (
+          <Alert>
+            <CheckCircle2 className="h-4 w-4 text-green-600" />
+            <AlertTitle>Connected</AlertTitle>
+            <AlertDescription>
+              <div className="space-y-2 mt-2">
+                <div className="flex items-center gap-2">
+                  <span className="text-sm">Status:</span>
+                  <Badge variant={state.data.status === "ok" ? "default" : "destructive"}>
+                    {state.data.status === "ok" ? "Healthy" : "Unhealthy"}
+                  </Badge>
+                </div>
+                <div className="flex items-center gap-2">
+                  <span className="text-sm">Version:</span>
+                  <Badge variant="outline">{state.data.version}</Badge>
+                </div>
+                <div className="flex items-center gap-2">
+                  <span className="text-sm">Uptime:</span>
+                  <Badge variant="secondary">{state.data.uptimeSeconds}s</Badge>
+                </div>
+              </div>
+            </AlertDescription>
+          </Alert>
+        )}
+      </CardContent>
+    </Card>
   );
 }

--- a/frontend/components/BackendHealthCompact.tsx
+++ b/frontend/components/BackendHealthCompact.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { CheckCircle2, XCircle, Server, Loader2, X } from "lucide-react";
+import { getHealth, HealthResponse } from "@/lib/config";
+import { Badge } from "@/components/ui/badge";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { Button } from "@/components/ui/button";
+
+type State =
+  | { type: "loading" }
+  | { type: "error"; message: string }
+  | { type: "success"; data: HealthResponse };
+
+// Only show in development or if explicitly enabled via env var
+const shouldShow = 
+  process.env.NODE_ENV !== "production" || 
+  process.env.NEXT_PUBLIC_SHOW_BACKEND_HEALTH === "true";
+
+export default function BackendHealthCompact() {
+  const [isVisible, setIsVisible] = useState(() => {
+    // Check localStorage for user preference
+    if (typeof window !== "undefined") {
+      const saved = localStorage.getItem("backendHealthVisible");
+      return saved !== null ? saved === "true" : shouldShow;
+    }
+    return shouldShow;
+  });
+  const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL || "Not configured";
+  const [state, setState] = useState<State>(() => {
+    if (!process.env.NEXT_PUBLIC_BACKEND_URL) {
+      return { type: "error", message: "NEXT_PUBLIC_BACKEND_URL environment variable is not configured" };
+    }
+    return { type: "loading" };
+  });
+
+  useEffect(() => {
+    if (!process.env.NEXT_PUBLIC_BACKEND_URL) {
+      return;
+    }
+
+    getHealth()
+      .then((data) => setState({ type: "success", data }))
+      .catch((err: Error) => {
+        const errorMessage = err.message || "Unknown error";
+        console.error("Backend health check failed:", err);
+        setState({ type: "error", message: errorMessage });
+      });
+  }, []);
+
+  const getStatusIcon = () => {
+    if (state.type === "loading") {
+      return <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />;
+    }
+    if (state.type === "error") {
+      return <XCircle className="h-3 w-3 text-destructive" />;
+    }
+    return <CheckCircle2 className="h-3 w-3 text-green-600" />;
+  };
+
+  const getStatusText = () => {
+    if (state.type === "loading") return "Checking...";
+    if (state.type === "error") return "Error";
+    return state.data.status === "ok" ? "Connected" : "Unhealthy";
+  };
+
+  const handleToggle = () => {
+    const newVisibility = !isVisible;
+    setIsVisible(newVisibility);
+    if (typeof window !== "undefined") {
+      localStorage.setItem("backendHealthVisible", String(newVisibility));
+    }
+  };
+
+  const getTooltipContent = () => {
+    if (state.type === "loading") {
+      return "Checking backend connection...";
+    }
+    if (state.type === "error") {
+      return `Backend Error: ${state.message}`;
+    }
+    return (
+      <div className="space-y-1 text-xs">
+        <div><strong>Backend:</strong> {backendUrl}</div>
+        <div><strong>Status:</strong> {state.data.status}</div>
+        <div><strong>Version:</strong> {state.data.version}</div>
+        <div><strong>Uptime:</strong> {state.data.uptimeSeconds}s</div>
+        <div className="pt-1 mt-1 border-t border-foreground/20">
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              handleToggle();
+            }}
+            className="text-xs text-muted-foreground hover:text-foreground"
+          >
+            Hide indicator
+          </button>
+        </div>
+      </div>
+    );
+  };
+
+  // Don't render if not in dev mode or explicitly disabled
+  if (!shouldShow && !isVisible) {
+    return null;
+  }
+
+  // If user has hidden it, show a small button to restore it
+  if (!isVisible) {
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleToggle}
+            className="h-6 px-2 text-xs text-muted-foreground hover:text-foreground"
+          >
+            <Server className="h-3 w-3" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">
+          <div className="text-xs">Show backend health</div>
+        </TooltipContent>
+      </Tooltip>
+    );
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <div className="flex items-center gap-1.5 px-2 py-1 border border-foreground/20 rounded-md bg-muted/50 hover:bg-muted transition-colors cursor-help group">
+          <Server className="h-3 w-3 text-muted-foreground" />
+          {getStatusIcon()}
+          <span className="text-xs font-medium text-muted-foreground">
+            {getStatusText()}
+          </span>
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              handleToggle();
+            }}
+            className="opacity-0 group-hover:opacity-100 transition-opacity ml-1"
+            aria-label="Hide backend health indicator"
+          >
+            <X className="h-3 w-3 text-muted-foreground hover:text-foreground" />
+          </button>
+        </div>
+      </TooltipTrigger>
+      <TooltipContent side="bottom" className="max-w-xs">
+        {getTooltipContent()}
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/frontend/components/header.tsx
+++ b/frontend/components/header.tsx
@@ -5,6 +5,7 @@ import { usePathname } from "next/navigation"
 import { useState } from "react"
 import { Button } from "@/components/ui/button"
 import { Menu, X, Home } from "lucide-react"
+import BackendHealthCompact from "@/components/BackendHealthCompact"
 
 const navLinks = [
   { href: "/properties", label: "Find a Home" },
@@ -51,6 +52,9 @@ export function Header() {
           </nav>
 
           <div className="hidden md:flex items-center gap-3">
+            <div className="hidden lg:block">
+              <BackendHealthCompact />
+            </div>
             <Link href="/login">
               <Button
                 variant="outline"

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,18 +1,28 @@
 const baseUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
 
-if (!baseUrl) {
-  throw new Error("Missing NEXT_PUBLIC_BACKEND_URL");
-}
-
 export async function apiFetch<T>(path: string): Promise<T> {
-  const res = await fetch(`${baseUrl}${path}`, {
-    cache: "no-store",
-  });
-
-  if (!res.ok) {
-    const message = await res.text();
-    throw new Error(message || `API error: ${res.status}`);
+  if (!baseUrl) {
+    throw new Error("Missing NEXT_PUBLIC_BACKEND_URL");
   }
 
-  return res.json();
+  try {
+    const res = await fetch(`${baseUrl}${path}`, {
+      cache: "no-store",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+
+    if (!res.ok) {
+      const message = await res.text();
+      throw new Error(message || `API error: ${res.status}`);
+    }
+
+    return res.json();
+  } catch (error) {
+    if (error instanceof TypeError && error.message === "Failed to fetch") {
+      throw new Error(`Cannot connect to backend at ${baseUrl}. Please ensure the backend server is running.`);
+    }
+    throw error;
+  }
 }

--- a/frontend/lib/config.ts
+++ b/frontend/lib/config.ts
@@ -2,9 +2,9 @@ import { apiFetch } from "./api";
 
 
 export interface HealthResponse {
-  ok: boolean;
-  service: string;
-  env: string;
+  status: string;
+  version: string;
+  uptimeSeconds: number;
 }
 
 export function getHealth(): Promise<HealthResponse> {


### PR DESCRIPTION
- Add BackendHealth component with loading/success/error states
- Add BackendHealthCompact component for header display
- Use NEXT_PUBLIC_BACKEND_URL env var for backend URL
- Display backend URL, status, version, and uptime
- Only visible in dev mode (or when NEXT_PUBLIC_SHOW_BACKEND_HEALTH=true)
- Add toggle to hide/show indicator with localStorage persistence
- Place compact indicator in header (visible on large screens)
- Remove from homepage for better UX
- Improve error handling in apiFetch with better error messages
- Update HealthResponse interface to match actual backend response format

All states implemented:
- Loading: spinner with 'Checking...' text
- Success: green checkmark with connection details
- Error: red X with error message

Lint and build pass successfully.

here's the screenshot on how the backend dev mode is
 i added it in the navbar for it not to be disfiguring the homepage
 
<img width="1366" height="736" alt="image" src="https://github.com/user-attachments/assets/74dfb1e3-0571-491b-82c5-b165a6d81b1c" />


closes #3 