### PR TITLE
fix: standardize wallet and payment terminology across UI

### DIFF
--- a/frontend/app/dashboard/tenant/payments/page.tsx
+++ b/frontend/app/dashboard/tenant/payments/page.tsx
@@ -114,7 +114,7 @@ export default function TenantPaymentsPage() {
           {/* Header */}
           <div className="mb-8">
             <h1 className="text-3xl font-bold text-foreground">Payments</h1>
-            <p className="mt-1 text-muted-foreground">Manage your rent payments and wallet balance</p>
+            <p className="mt-1 text-muted-foreground">Manage your rent payments and wallet</p>
           </div>
 
           {/* Quick Stats */}
@@ -159,7 +159,7 @@ export default function TenantPaymentsPage() {
             {[
               { id: "upcoming", label: "Upcoming Payments" },
               { id: "history", label: "Payment History" },
-              { id: "wallet", label: "My Wallet" },
+              { id: "wallet", label: "Your Wallet" },
             ].map((tab) => (
               <button
                 key={tab.id}
@@ -294,7 +294,7 @@ export default function TenantPaymentsPage() {
               <Card className="border-3 border-foreground p-6 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
                 <h3 className="mb-4 text-lg font-bold">Your Wallet</h3>
                 <div className="mb-6 border-3 border-foreground bg-primary/10 p-6">
-                  <p className="text-sm text-muted-foreground">Available Balance</p>
+                  <p className="text-sm text-muted-foreground">Wallet Balance</p>
                   <p className="text-4xl font-bold">{formatCurrency(walletBalance)}</p>
                   <p className="mt-2 text-sm text-muted-foreground">Last top-up: {walletData.lastTopUp}</p>
                 </div>

--- a/frontend/app/dashboard/tenant/settings/page.tsx
+++ b/frontend/app/dashboard/tenant/settings/page.tsx
@@ -357,12 +357,12 @@ export default function TenantSettingsPage() {
                     <Link href="/dashboard/tenant/payments">
                       <Button variant="outline" size="sm" className="border-2 border-foreground bg-transparent font-bold">
                         <Wallet className="mr-1 h-4 w-4" />
-                        Top Up
+                        Top Up Wallet
                       </Button>
                     </Link>
                   </div>
                   <div className="border-3 border-foreground bg-primary/10 p-4">
-                    <p className="text-sm text-muted-foreground">Available Balance</p>
+                    <p className="text-sm text-muted-foreground">Wallet Balance</p>
                     <p className="text-2xl font-bold">₦150,000</p>
                   </div>
                 </div>


### PR DESCRIPTION
closes #8 

Make UI copy consistent and not misleading while using mock data:

Terminology Standardization:
- 'Available Balance' → 'Wallet Balance' (consistent across all pages)
- 'My Wallet' → 'Your Wallet' (consistent tab and section labels)
- 'Top Up' → 'Top Up Wallet' (consistent button labels)
- Payment terminology remains consistent (no changes needed)

Files Updated:
- frontend/app/dashboard/tenant/payments/page.tsx
  - Updated tab label from 'My Wallet' to 'Your Wallet'
  - Changed 'Available Balance' to 'Wallet Balance' in wallet tab
  - Updated page subtitle for consistency

- frontend/app/dashboard/tenant/settings/page.tsx
  - Changed 'Available Balance' to 'Wallet Balance'
  - Updated button text from 'Top Up' to 'Top Up Wallet'

No breaking UI changes - only text labels updated. All lint and build checks pass.

Before/After:
- Before: Mixed terminology (Available Balance, My Wallet, Top Up)
- After: Consistent terminology (Wallet Balance, Your Wallet, Top Up Wallet)

Here's the screenshot of the update i made

<img width="1366" height="736" alt="image" src="https://github.com/user-attachments/assets/a30c0755-6c67-4a62-a49f-0b5b722f7619" />


<img width="1366" height="736" alt="image" src="https://github.com/user-attachments/assets/49bc96e6-8942-4dd1-b1c6-a7481eb7741f" />
