### PR TITLE
Remove agent functionality and replace with whistleblower model

### DIFF
--- a/frontend/app/dashboard/agent/applications/page.tsx
+++ b/frontend/app/dashboard/agent/applications/page.tsx
@@ -1,323 +1,55 @@
-"use client"
+"use client";
 
-import { useState } from "react"
-import Link from "next/link"
-import {
-  Home,
-  Building2,
-  MessageSquare,
-  Settings,
-  Star,
-  Briefcase,
-  CheckCircle,
-  XCircle,
-  Clock,
-  MapPin,
-  Calendar,
-  ArrowRight,
-} from "lucide-react"
-import { Button } from "@/components/ui/button"
-import { Card } from "@/components/ui/card"
-import { DashboardHeader } from "@/components/dashboard-header"
-import { agentApplications as applications } from "@/lib/mockData"
+import Link from "next/link";
+import { AlertCircle, Home, Users } from "lucide-react";
+import { Card } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { DashboardHeader } from "@/components/dashboard-header";
 
-export default function AgentApplicationsPage() {
-  const [statusFilter, setStatusFilter] = useState<"all" | "pending" | "accepted" | "declined">("all")
-
-  const filteredApplications = applications.filter((app) => {
-    return statusFilter === "all" || app.status === statusFilter
-  })
-
-  const formatCurrency = (amount: number) => {
-    return new Intl.NumberFormat("en-NG", {
-      style: "currency",
-      currency: "NGN",
-      minimumFractionDigits: 0,
-    }).format(amount)
-  }
-
-  const getStatusColor = (status: string) => {
-    switch (status) {
-      case "accepted":
-        return "bg-secondary"
-      case "declined":
-        return "bg-destructive text-destructive-foreground"
-      default:
-        return "bg-accent"
-    }
-  }
-
-  const getStatusIcon = (status: string) => {
-    switch (status) {
-      case "accepted":
-        return <CheckCircle className="h-5 w-5" />
-      case "declined":
-        return <XCircle className="h-5 w-5" />
-      default:
-        return <Clock className="h-5 w-5" />
-    }
-  }
-
+export default function AgentApplicationsPageDeprecated() {
   return (
     <div className="min-h-screen bg-background">
       <DashboardHeader />
 
-      {/* Sidebar */}
-      <aside className="fixed left-0 top-0 z-40 h-screen w-64 border-r-3 border-foreground bg-card pt-20">
-        <div className="flex h-full flex-col px-4 py-6">
-          <div className="mb-8 border-3 border-foreground bg-secondary p-4 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
-            <p className="text-sm font-medium text-foreground">Logged in as</p>
-            <p className="text-lg font-bold text-foreground">Adebayo Johnson</p>
-            <p className="text-sm text-muted-foreground">Property Agent</p>
-            <div className="mt-2 flex items-center gap-1">
-              <Star className="h-4 w-4 fill-accent text-accent" />
-              <span className="text-sm font-bold">4.8</span>
-              <span className="text-xs text-muted-foreground">(127 reviews)</span>
-            </div>
-          </div>
-
-          <nav className="flex-1 space-y-2">
-            <Link
-              href="/dashboard/agent"
-              className="flex items-center gap-3 border-3 border-foreground bg-card p-3 font-bold transition-all hover:bg-muted hover:shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]"
-            >
-              <Home className="h-5 w-5" />
-              Dashboard
-            </Link>
-            <Link
-              href="/dashboard/agent/properties"
-              className="flex items-center gap-3 border-3 border-foreground bg-card p-3 font-bold transition-all hover:bg-muted hover:shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]"
-            >
-              <Building2 className="h-5 w-5" />
-              My Properties
-            </Link>
-            <Link
-              href="/dashboard/agent/applications"
-              className="flex items-center gap-3 border-3 border-foreground bg-primary p-3 font-bold shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]"
-            >
-              <Briefcase className="h-5 w-5" />
-              Applications
-            </Link>
-            <Link
-              href="/messages"
-              className="flex items-center gap-3 border-3 border-foreground bg-card p-3 font-bold transition-all hover:bg-muted hover:shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]"
-            >
-              <MessageSquare className="h-5 w-5" />
-              Messages
-              <span className="ml-auto flex h-6 w-6 items-center justify-center border-2 border-foreground bg-destructive text-xs font-bold text-destructive-foreground">
-                5
-              </span>
-            </Link>
-            <Link
-              href="/dashboard/agent/settings"
-              className="flex items-center gap-3 border-3 border-foreground bg-card p-3 font-bold transition-all hover:bg-muted hover:shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]"
-            >
-              <Settings className="h-5 w-5" />
-              Settings
-            </Link>
-          </nav>
-        </div>
-      </aside>
-
-      {/* Main Content */}
       <main className="ml-64 min-h-screen pt-20">
-        <div className="p-8">
-          {/* Header */}
-          <div className="mb-8">
-            <h1 className="text-3xl font-bold text-foreground">My Applications</h1>
-            <p className="mt-1 text-muted-foreground">Track your applications to manage properties</p>
-          </div>
-
-          {/* Stats */}
-          <div className="mb-8 grid grid-cols-4 gap-4">
-            <Card className="border-3 border-foreground p-4 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
-              <div className="flex items-center gap-3">
-                <div className="flex h-10 w-10 items-center justify-center border-2 border-foreground bg-muted">
-                  <Briefcase className="h-5 w-5" />
-                </div>
-                <div>
-                  <p className="text-sm text-muted-foreground">Total</p>
-                  <p className="text-xl font-bold">{applications.length}</p>
-                </div>
+        <div className="container mx-auto px-4 py-8">
+          <Card className="border-3 border-foreground p-8 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] max-w-2xl mx-auto">
+            <div className="flex flex-col items-center text-center space-y-6">
+              <div className="flex h-16 w-16 items-center justify-center border-3 border-foreground bg-destructive/10 rounded-full">
+                <AlertCircle className="h-8 w-8 text-destructive" />
               </div>
-            </Card>
-            <Card className="border-3 border-foreground p-4 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
-              <div className="flex items-center gap-3">
-                <div className="flex h-10 w-10 items-center justify-center border-2 border-foreground bg-accent">
-                  <Clock className="h-5 w-5" />
-                </div>
-                <div>
-                  <p className="text-sm text-muted-foreground">Pending</p>
-                  <p className="text-xl font-bold">{applications.filter((a) => a.status === "pending").length}</p>
-                </div>
-              </div>
-            </Card>
-            <Card className="border-3 border-foreground p-4 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
-              <div className="flex items-center gap-3">
-                <div className="flex h-10 w-10 items-center justify-center border-2 border-foreground bg-secondary">
-                  <CheckCircle className="h-5 w-5" />
-                </div>
-                <div>
-                  <p className="text-sm text-muted-foreground">Accepted</p>
-                  <p className="text-xl font-bold">{applications.filter((a) => a.status === "accepted").length}</p>
-                </div>
-              </div>
-            </Card>
-            <Card className="border-3 border-foreground p-4 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
-              <div className="flex items-center gap-3">
-                <div className="flex h-10 w-10 items-center justify-center border-2 border-foreground bg-destructive">
-                  <XCircle className="h-5 w-5 text-destructive-foreground" />
-                </div>
-                <div>
-                  <p className="text-sm text-muted-foreground">Declined</p>
-                  <p className="text-xl font-bold">{applications.filter((a) => a.status === "declined").length}</p>
-                </div>
-              </div>
-            </Card>
-          </div>
-
-          {/* Filter Tabs */}
-          <div className="mb-6 flex gap-4">
-            {[
-              { id: "all", label: "All Applications" },
-              { id: "pending", label: "Pending" },
-              { id: "accepted", label: "Accepted" },
-              { id: "declined", label: "Declined" },
-            ].map((tab) => (
-              <button
-                key={tab.id}
-                onClick={() => setStatusFilter(tab.id as typeof statusFilter)}
-                className={`border-3 border-foreground px-6 py-3 font-bold transition-all ${
-                  statusFilter === tab.id
-                    ? "bg-foreground text-background shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]"
-                    : "bg-card hover:bg-muted"
-                }`}
-              >
-                {tab.label}
-              </button>
-            ))}
-          </div>
-
-          {/* Applications List */}
-          <div className="space-y-4">
-            {filteredApplications.length === 0 ? (
-              <Card className="border-3 border-foreground p-12 text-center shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
-                <Briefcase className="mx-auto h-16 w-16 text-muted-foreground" />
-                <h3 className="mt-4 text-xl font-bold">No Applications</h3>
-                <p className="mt-2 text-muted-foreground">
-                  No applications found with this status.
+              
+              <div>
+                <h1 className="text-3xl font-bold mb-2">Agent Role Deprecated</h1>
+                <p className="text-muted-foreground text-lg">
+                  Agent applications are no longer available.
                 </p>
-              </Card>
-            ) : (
-              filteredApplications.map((application) => (
-                <Card
-                  key={application.id}
-                  className="border-3 border-foreground p-6 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]"
-                >
-                  <div className="flex items-start justify-between">
-                    <div className="flex gap-6">
-                      {/* Property Info */}
-                      <div className="flex h-24 w-24 shrink-0 items-center justify-center border-3 border-foreground bg-muted">
-                        <Building2 className="h-10 w-10 text-muted-foreground" />
-                      </div>
-                      <div>
-                        <div className="flex items-center gap-3">
-                          <h3 className="text-xl font-bold">{application.property.title}</h3>
-                          <span
-                            className={`flex items-center gap-1 border-2 border-foreground px-3 py-1 text-sm font-bold ${getStatusColor(
-                              application.status
-                            )}`}
-                          >
-                            {getStatusIcon(application.status)}
-                            {application.status.charAt(0).toUpperCase() + application.status.slice(1)}
-                          </span>
-                        </div>
-                        <p className="mt-1 flex items-center gap-1 text-muted-foreground">
-                          <MapPin className="h-4 w-4" />
-                          {application.property.location}
-                        </p>
-                        <p className="mt-2 text-xl font-bold text-primary">
-                          {formatCurrency(application.property.price)}
-                          <span className="text-sm font-normal text-muted-foreground">/year</span>
-                        </p>
+              </div>
 
-                        <div className="mt-4 flex items-center gap-6 text-sm text-muted-foreground">
-                          <span className="flex items-center gap-1">
-                            <Calendar className="h-4 w-4" />
-                            Applied: {application.appliedAt}
-                          </span>
-                          {application.status === "accepted" && application.acceptedAt && (
-                            <span className="flex items-center gap-1 text-secondary">
-                              <CheckCircle className="h-4 w-4" />
-                              Accepted: {application.acceptedAt}
-                            </span>
-                          )}
-                          {application.status === "declined" && application.declinedAt && (
-                            <span className="flex items-center gap-1 text-destructive">
-                              <XCircle className="h-4 w-4" />
-                              Declined: {application.declinedAt}
-                            </span>
-                          )}
-                        </div>
-                      </div>
-                    </div>
+              <div className="w-full border-t-2 border-foreground pt-6 space-y-4">
+                <p className="text-sm text-muted-foreground">
+                  We have transitioned to a whistleblower model. If you're a current tenant, you can become a whistleblower to help verify properties.
+                </p>
+              </div>
 
-                    {/* Landlord Info */}
-                    <div className="flex items-center gap-3 border-3 border-foreground bg-muted/50 px-4 py-3">
-                      <div className="flex h-12 w-12 items-center justify-center border-2 border-foreground bg-accent font-bold">
-                        {application.landlord.avatar}
-                      </div>
-                      <div>
-                        <p className="font-bold">{application.landlord.name}</p>
-                        <p className="text-sm text-muted-foreground">Landlord</p>
-                      </div>
-                    </div>
-                  </div>
-
-                  {/* Application Message */}
-                  <div className="mt-4 border-t-2 border-foreground pt-4">
-                    <p className="text-sm text-muted-foreground">Your message:</p>
-                    <p className="mt-1 text-foreground">&ldquo;{application.message}&rdquo;</p>
-                    {application.status === "declined" && application.declineReason && (
-                      <div className="mt-3 border-3 border-destructive bg-destructive/10 p-3">
-                        <p className="text-sm font-bold text-destructive">Reason: {application.declineReason}</p>
-                      </div>
-                    )}
-                  </div>
-
-                  {/* Actions */}
-                  <div className="mt-4 flex justify-end gap-3">
-                    {application.status === "accepted" && (
-                      <Link href="/messages">
-                        <Button className="border-3 border-foreground bg-secondary font-bold shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
-                          <MessageSquare className="mr-2 h-4 w-4" />
-                          Message Landlord
-                        </Button>
-                      </Link>
-                    )}
-                    {application.status === "pending" && (
-                      <Button
-                        variant="outline"
-                        className="border-3 border-foreground bg-transparent font-bold"
-                      >
-                        Withdraw Application
-                      </Button>
-                    )}
-                    {application.status === "declined" && (
-                      <Link href="/dashboard/agent">
-                        <Button className="border-3 border-foreground bg-primary font-bold shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
-                          Find More Properties
-                          <ArrowRight className="ml-2 h-4 w-4" />
-                        </Button>
-                      </Link>
-                    )}
-                  </div>
-                </Card>
-              ))
-            )}
-          </div>
+              <div className="flex gap-4 pt-4">
+                <Link href="/">
+                  <Button className="border-3 border-foreground bg-primary font-bold shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
+                    <Home className="mr-2 h-4 w-4" />
+                    Go to Homepage
+                  </Button>
+                </Link>
+                <Link href="/whistleblower/signup">
+                  <Button variant="outline" className="border-3 border-foreground font-bold shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
+                    <Users className="mr-2 h-4 w-4" />
+                    Become a Whistleblower
+                  </Button>
+                </Link>
+              </div>
+            </div>
+          </Card>
         </div>
       </main>
     </div>
-  )
+  );
 }

--- a/frontend/app/dashboard/agent/apply/page.tsx
+++ b/frontend/app/dashboard/agent/apply/page.tsx
@@ -1,185 +1,55 @@
-'use client'
+"use client";
 
-import React, { useState } from "react";
+import Link from "next/link";
+import { AlertCircle, Home, Users } from "lucide-react";
+import { Card } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { DashboardHeader } from "@/components/dashboard-header";
 
-import Link from 'next/link'
-import { ArrowLeft, CheckCircle, Send, MapPin, Bed, Bath, Square } from 'lucide-react'
-import { Button } from '@/components/ui/button'
-import { Card } from '@/components/ui/card'
-import { Checkbox } from '@/components/ui/checkbox'
-
-export default function AgentApplyPage() {
-  const [agreeToTerms, setAgreeToTerms] = useState(false)
-  const [applicationSubmitted, setApplicationSubmitted] = useState(false)
-
-  // Mock property data - in real app, would come from URL params or database
-  const property = {
-    id: 3,
-    title: 'Spacious 4 Bedroom Duplex',
-    location: 'Ikoyi, Lagos',
-    price: 5500000,
-    beds: 4,
-    baths: 3,
-    sqm: 220,
-    landlord: { name: 'Chief Okonkwo', avatar: 'CO' },
-    postedAt: '2 days ago',
-  }
-
-  const handleSubmit: React.ComponentProps<'form'>['onSubmit'] = (e) => {
-    e.preventDefault()
-    if (!agreeToTerms) return
-    setApplicationSubmitted(true)
-  }
-
-  if (applicationSubmitted) {
-    return (
-      <div className="min-h-screen bg-background pt-24 pb-12">
-        <div className="container mx-auto px-4">
-          <div className="mx-auto max-w-2xl">
-            <Card className="border-3 border-foreground p-6 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] text-center md:p-8">
-              <div className="mb-4 flex justify-center">
-                <div className="flex h-16 w-16 items-center justify-center border-3 border-foreground bg-secondary">
-                  <CheckCircle className="h-8 w-8" />
-                </div>
-              </div>
-              <h1 className="mb-4 font-mono text-2xl font-black md:text-3xl">Application Submitted!</h1>
-              <p className="mb-6 text-muted-foreground">Your application to manage <strong>{property.title}</strong> has been submitted successfully.</p>
-              
-              <div className="mb-6 border-3 border-foreground bg-muted p-4">
-                <p className="text-sm font-bold mb-2">Application ID: APP-2024-001234</p>
-                <p className="text-xs text-muted-foreground">You'll receive an email confirmation shortly. The landlord will review your application within 3-5 business days.</p>
-              </div>
-
-              <div className="flex flex-col gap-3 md:flex-row md:justify-center md:gap-4">
-                <Link href="/dashboard/agent/applications">
-                  <Button className="w-full border-3 border-foreground bg-primary font-bold shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] md:w-auto">
-                    View My Applications
-                  </Button>
-                </Link>
-                <Link href="/dashboard/agent">
-                  <Button variant="outline" className="w-full border-3 border-foreground bg-card font-bold shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] md:w-auto">
-                    Back to Dashboard
-                  </Button>
-                </Link>
-              </div>
-            </Card>
-          </div>
-        </div>
-      </div>
-    )
-  }
-
+export default function AgentApplyPageDeprecated() {
   return (
-    <div className="min-h-screen bg-background pt-24 pb-12">
-      <div className="container mx-auto px-4">
-        <Link href="/dashboard/agent" className="inline-flex items-center gap-2 text-sm font-bold mb-6 border-3 border-foreground p-2 hover:bg-muted">
-          <ArrowLeft className="h-4 w-4" />
-          Back
-        </Link>
+    <div className="min-h-screen bg-background">
+      <DashboardHeader />
 
-        <div className="mx-auto max-w-3xl space-y-6">
-          {/* Property Summary */}
-          <Card className="border-3 border-foreground p-4 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] md:p-6">
-            <h2 className="mb-4 font-mono text-lg font-bold">Property Details</h2>
-            
-            <div className="space-y-4">
+      <main className="ml-64 min-h-screen pt-20">
+        <div className="container mx-auto px-4 py-8">
+          <Card className="border-3 border-foreground p-8 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] max-w-2xl mx-auto">
+            <div className="flex flex-col items-center text-center space-y-6">
+              <div className="flex h-16 w-16 items-center justify-center border-3 border-foreground bg-destructive/10 rounded-full">
+                <AlertCircle className="h-8 w-8 text-destructive" />
+              </div>
+              
               <div>
-                <h3 className="text-lg font-bold md:text-xl">{property.title}</h3>
-                <p className="mt-1 flex items-center gap-1 text-sm text-muted-foreground">
-                  <MapPin className="h-4 w-4" />
-                  {property.location}
+                <h1 className="text-3xl font-bold mb-2">Agent Role Deprecated</h1>
+                <p className="text-muted-foreground text-lg">
+                  Agent applications are no longer accepted.
                 </p>
               </div>
 
-              <div className="flex flex-wrap gap-3">
-                <div className="flex items-center gap-2 border-2 border-foreground bg-muted px-2 py-1 md:gap-2 md:px-3">
-                  <Bed className="h-4 w-4" />
-                  <span className="text-xs font-bold md:text-sm">{property.beds} Beds</span>
-                </div>
-                <div className="flex items-center gap-2 border-2 border-foreground bg-muted px-2 py-1 md:gap-2 md:px-3">
-                  <Bath className="h-4 w-4" />
-                  <span className="text-xs font-bold md:text-sm">{property.baths} Baths</span>
-                </div>
-                <div className="flex items-center gap-2 border-2 border-foreground bg-muted px-2 py-1 md:gap-2 md:px-3">
-                  <Square className="h-4 w-4" />
-                  <span className="text-xs font-bold md:text-sm">{property.sqm} m²</span>
-                </div>
+              <div className="w-full border-t-2 border-foreground pt-6 space-y-4">
+                <p className="text-sm text-muted-foreground">
+                  We have transitioned to a whistleblower model. If you're a current tenant, you can become a whistleblower to help verify properties.
+                </p>
               </div>
 
-              <div className="border-t-2 border-foreground pt-4">
-                <p className="text-sm text-muted-foreground mb-1">Annual Rent</p>
-                <p className="font-mono text-2xl font-black">₦{property.price.toLocaleString()}</p>
-              </div>
-
-              <div className="border-t-2 border-foreground pt-4">
-                <p className="text-sm text-muted-foreground">Landlord</p>
-                <p className="font-bold">{property.landlord.name}</p>
+              <div className="flex gap-4 pt-4">
+                <Link href="/">
+                  <Button className="border-3 border-foreground bg-primary font-bold shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
+                    <Home className="mr-2 h-4 w-4" />
+                    Go to Homepage
+                  </Button>
+                </Link>
+                <Link href="/whistleblower/signup">
+                  <Button variant="outline" className="border-3 border-foreground font-bold shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
+                    <Users className="mr-2 h-4 w-4" />
+                    Become a Whistleblower
+                  </Button>
+                </Link>
               </div>
             </div>
           </Card>
-
-          {/* Application Form */}
-          <Card className="border-3 border-foreground p-4 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] md:p-6">
-            <h2 className="mb-4 font-mono text-lg font-bold">Agent Information</h2>
-            
-            <form onSubmit={handleSubmit} className="space-y-6">
-              <div className="border-3 border-foreground bg-card p-4">
-                <p className="text-sm text-muted-foreground mb-2">Your Details</p>
-                <p className="font-bold">Adebayo Johnson</p>
-                <p className="text-sm text-muted-foreground">adebayo@sheltaflex.com</p>
-                <p className="text-sm text-muted-foreground">+234 (0) 802 123 4567</p>
-              </div>
-
-              <div className="space-y-2">
-                <h3 className="font-bold">Why should the landlord choose you?</h3>
-                <textarea
-                  placeholder="Tell the landlord about your experience, track record, and why you're the best fit for this property..."
-                  defaultValue="I have 5+ years of experience managing premium properties in Ikoyi. I have successfully managed over 30 properties with 100% tenant satisfaction ratings."
-                  rows={5}
-                  className="w-full border-3 border-foreground p-3 font-mono text-sm shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]"
-                />
-              </div>
-
-              <div className="space-y-3 border-3 border-foreground bg-muted p-4">
-                <h3 className="font-bold">Commission Structure</h3>
-                <p className="text-sm text-muted-foreground">
-                  <strong>Inspection Fee:</strong> Vary by agent (paid by tenant)
-                </p>
-                <p className="text-sm text-muted-foreground">
-                  <strong>Management Commission:</strong> To be negotiated with landlord
-                </p>
-              </div>
-
-              <div className="border-t-2 border-foreground pt-4">
-                <div className="flex items-start gap-3">
-                  <Checkbox
-                    id="terms"
-                    checked={agreeToTerms}
-                    onCheckedChange={(checked) => setAgreeToTerms(checked as boolean)}
-                    className="mt-1"
-                  />
-                  <label htmlFor="terms" className="text-sm text-foreground cursor-pointer">
-                    I confirm that the information provided is accurate and I agree to Sheltaflex&apos;s{' '}
-                    <Link href="/terms-of-service" className="font-bold border-b-2 border-foreground hover:text-primary">
-                      Terms of Service
-                    </Link>
-                    . I understand that providing false information may result in account suspension.
-                  </label>
-                </div>
-              </div>
-
-              <Button
-                type="submit"
-                disabled={!agreeToTerms}
-                className="w-full border-3 border-foreground bg-primary py-4 font-bold shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] transition-all hover:translate-x-0.5 hover:translate-y-0.5 hover:shadow-[2px_2px_0px_0px_rgba(26,26,26,1)] disabled:opacity-50"
-              >
-                <Send className="mr-2 h-4 w-4" />
-                Submit Application
-              </Button>
-            </form>
-          </Card>
         </div>
-      </div>
+      </main>
     </div>
-  )
+  );
 }

--- a/frontend/app/dashboard/agent/page.tsx
+++ b/frontend/app/dashboard/agent/page.tsx
@@ -1,453 +1,64 @@
-"use client"
+"use client";
 
-import { useState } from "react"
-import Link from "next/link"
-import {
-  Home,
-  Building2,
-  MessageSquare,
-  Settings,
-  MapPin,
-  Bed,
-  Bath,
-  Square,
-  Eye,
-  CheckCircle,
-  Clock,
-  XCircle,
-  Star,
-  Send,
-  Search,
-  Filter,
-  Briefcase,
-  Menu,
-  X,
-} from "lucide-react"
-import { Button } from "@/components/ui/button"
-import { Card } from "@/components/ui/card"
-import { Input } from "@/components/ui/input"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select"
-import { DashboardHeader } from "@/components/dashboard-header"
-import {
-  agentAvailableProperties as availableProperties,
-  agentDashboardStats as stats,
-  agentManagedProperties as managedProperties,
-  agentMyApplications as myApplications,
-} from "@/lib/mockData"
+import Link from "next/link";
+import { AlertCircle, Home, Users } from "lucide-react";
+import { Card } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { DashboardHeader } from "@/components/dashboard-header";
 
-export default function AgentDashboard() {
-  const [activeTab, setActiveTab] = useState<"managed" | "available" | "applications">("managed")
-  const [searchQuery, setSearchQuery] = useState("")
-  const [locationFilter, setLocationFilter] = useState("all")
-  const [sidebarOpen, setSidebarOpen] = useState(false)
-
-  const filteredAvailable = availableProperties.filter((property) => {
-    const matchesSearch = property.title.toLowerCase().includes(searchQuery.toLowerCase())
-    const matchesLocation = locationFilter === "all" || property.location.toLowerCase().includes(locationFilter.toLowerCase())
-    return matchesSearch && matchesLocation
-  })
-
+export default function AgentDashboardDeprecated() {
   return (
     <div className="min-h-screen bg-background">
       <DashboardHeader />
 
-      {/* Mobile Menu Button */}
-      <button
-        onClick={() => setSidebarOpen(!sidebarOpen)}
-        className="fixed bottom-6 right-6 z-50 flex h-14 w-14 items-center justify-center border-3 border-foreground bg-primary shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] lg:hidden"
-      >
-        {sidebarOpen ? <X className="h-6 w-6" /> : <Menu className="h-6 w-6" />}
-      </button>
+      <main className="ml-64 min-h-screen pt-20">
+        <div className="container mx-auto px-4 py-8">
+          <Card className="border-3 border-foreground p-8 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] max-w-2xl mx-auto">
+            <div className="flex flex-col items-center text-center space-y-6">
+              <div className="flex h-16 w-16 items-center justify-center border-3 border-foreground bg-destructive/10 rounded-full">
+                <AlertCircle className="h-8 w-8 text-destructive" />
+              </div>
+              
+              <div>
+                <h1 className="text-3xl font-bold mb-2">Agent Role Deprecated</h1>
+                <p className="text-muted-foreground text-lg">
+                  The agent role has been removed from Sheltaflex.
+                </p>
+              </div>
 
-      {/* Mobile Overlay */}
-      {sidebarOpen && (
-        <button
-          type="button"
-          aria-label="Close sidebar"
-          className="fixed inset-0 z-40 bg-foreground/50 lg:hidden"
-          onClick={() => setSidebarOpen(false)}
-        />
-      )}
-
-      {/* Sidebar */}
-      <aside className={`fixed left-0 top-0 z-40 h-screen w-64 border-r-3 border-foreground bg-card pt-20 transition-transform lg:translate-x-0 ${sidebarOpen ? 'translate-x-0' : '-translate-x-full'}`}>
-        <div className="flex h-full flex-col px-4 py-6">
-          <div className="mb-8 border-3 border-foreground bg-secondary p-4 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
-            <p className="text-sm font-medium text-foreground">Logged in as</p>
-            <p className="text-lg font-bold text-foreground">Adebayo Johnson</p>
-            <p className="text-sm text-muted-foreground">Property Agent</p>
-            <div className="mt-2 flex items-center gap-1">
-              <Star className="h-4 w-4 fill-accent text-accent" />
-              <span className="text-sm font-bold">4.8</span>
-              <span className="text-xs text-muted-foreground">(127 reviews)</span>
-            </div>
-          </div>
-
-          <nav className="flex-1 space-y-2">
-            <Link
-              href="/dashboard/agent"
-              className="flex items-center gap-3 border-3 border-foreground bg-primary p-3 font-bold shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]"
-              onClick={() => setSidebarOpen(false)}
-            >
-              <Home className="h-5 w-5" />
-              Dashboard
-            </Link>
-            <Link
-              href="/dashboard/agent/properties"
-              className="flex items-center gap-3 border-3 border-foreground bg-card p-3 font-bold transition-all hover:bg-muted hover:shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]"
-              onClick={() => setSidebarOpen(false)}
-            >
-              <Building2 className="h-5 w-5" />
-              My Properties
-            </Link>
-            <Link
-              href="/dashboard/agent/applications"
-              className="flex items-center gap-3 border-3 border-foreground bg-card p-3 font-bold transition-all hover:bg-muted hover:shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]"
-              onClick={() => setSidebarOpen(false)}
-            >
-              <Briefcase className="h-5 w-5" />
-              Applications
-            </Link>
-            <Link
-              href="/messages"
-              className="flex items-center gap-3 border-3 border-foreground bg-card p-3 font-bold transition-all hover:bg-muted hover:shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]"
-              onClick={() => setSidebarOpen(false)}
-            >
-              <MessageSquare className="h-5 w-5" />
-              Messages
-              <span className="ml-auto flex h-6 w-6 items-center justify-center border-2 border-foreground bg-destructive text-xs font-bold text-destructive-foreground">
-                5
-              </span>
-            </Link>
-            <Link
-              href="/dashboard/agent/settings"
-              className="flex items-center gap-3 border-3 border-foreground bg-card p-3 font-bold transition-all hover:bg-muted hover:shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]"
-              onClick={() => setSidebarOpen(false)}
-            >
-              <Settings className="h-5 w-5" />
-              Settings
-            </Link>
-          </nav>
-        </div>
-      </aside>
-
-      {/* Main Content */}
-      <main className="min-h-screen pt-20 lg:ml-64">
-        <div className="p-4 md:p-6 lg:p-8">
-          {/* Header */}
-          <div className="mb-6 md:mb-8">
-            <h1 className="text-2xl font-bold text-foreground md:text-3xl lg:text-4xl">Welcome, Adebayo!</h1>
-            <p className="mt-2 text-sm text-muted-foreground md:text-base lg:text-lg">
-              Manage your properties and find new opportunities
-            </p>
-          </div>
-
-          {/* Stats Grid */}
-          <div className="mb-6 grid grid-cols-2 gap-3 md:mb-8 md:grid-cols-4 md:gap-6">
-            {stats.map((stat) => (
-              <Card
-                key={stat.label}
-                className="border-3 border-foreground p-3 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] md:p-6"
-              >
-                <div className="flex items-center gap-2 md:gap-4">
-                  <div
-                    className={`flex h-10 w-10 shrink-0 items-center justify-center border-3 border-foreground md:h-14 md:w-14 ${stat.color}`}
-                  >
-                    <stat.icon className="h-5 w-5 md:h-7 md:w-7" />
-                  </div>
-                  <div className="min-w-0">
-                    <p className="truncate text-xs font-medium text-muted-foreground md:text-sm">{stat.label}</p>
-                    <p className="truncate text-xl font-bold text-foreground md:text-3xl">{stat.value}</p>
-                  </div>
+              <div className="w-full border-t-2 border-foreground pt-6 space-y-4">
+                <p className="text-sm text-muted-foreground">
+                  We have transitioned to a whistleblower model where current tenants in buildings help with property discovery and verification.
+                </p>
+                
+                <div className="bg-muted/50 border-2 border-foreground p-4 space-y-2">
+                  <p className="font-bold">What changed?</p>
+                  <ul className="text-sm text-left space-y-1 list-disc list-inside text-muted-foreground">
+                    <li>Property verification is now done by resident whistleblowers</li>
+                    <li>Tenants can message residents (whistleblowers) for property questions</li>
+                    <li>Landlords manage properties directly without agents</li>
+                  </ul>
                 </div>
-              </Card>
-            ))}
-          </div>
+              </div>
 
-          {/* Tabs */}
-          <div className="mb-6 flex flex-wrap gap-2 md:gap-4">
-            <button
-              onClick={() => setActiveTab("managed")}
-              className={`border-3 border-foreground px-3 py-2 text-sm font-bold transition-all md:px-6 md:py-3 md:text-base ${
-                activeTab === "managed"
-                  ? "bg-foreground text-background shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]"
-                  : "bg-card hover:bg-muted"
-              }`}
-            >
-              Properties
-            </button>
-            <button
-              onClick={() => setActiveTab("available")}
-              className={`border-3 border-foreground px-3 py-2 text-sm font-bold transition-all md:px-6 md:py-3 md:text-base ${
-                activeTab === "available"
-                  ? "bg-foreground text-background shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]"
-                  : "bg-card hover:bg-muted"
-              }`}
-            >
-              Available
-            </button>
-            <button
-              onClick={() => setActiveTab("applications")}
-              className={`border-3 border-foreground px-3 py-2 text-sm font-bold transition-all md:px-6 md:py-3 md:text-base ${
-                activeTab === "applications"
-                  ? "bg-foreground text-background shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]"
-                  : "bg-card hover:bg-muted"
-              }`}
-            >
-              Applications
-              {myApplications.some((a) => a.status === "pending") && (
-                <span className="ml-2 inline-flex h-5 w-5 items-center justify-center border-2 border-foreground bg-accent text-xs md:h-6 md:w-6">
-                  {myApplications.filter((a) => a.status === "pending").length}
-                </span>
-              )}
-            </button>
-          </div>
-
-          {/* Managed Properties Tab */}
-          {activeTab === "managed" && (
-            <div className="grid gap-6">
-              {managedProperties.length === 0 ? (
-                <Card className="border-3 border-foreground p-12 text-center shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
-                  <Building2 className="mx-auto h-16 w-16 text-muted-foreground" />
-                  <h3 className="mt-4 text-xl font-bold">No Properties Yet</h3>
-                  <p className="mt-2 text-muted-foreground">
-                    Apply to manage properties from the Available Properties tab.
-                  </p>
-                  <Button
-                    onClick={() => setActiveTab("available")}
-                    className="mt-4 border-3 border-foreground bg-primary font-bold shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]"
-                  >
-                    Browse Available Properties
+              <div className="flex gap-4 pt-4">
+                <Link href="/">
+                  <Button className="border-3 border-foreground bg-primary font-bold shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
+                    <Home className="mr-2 h-4 w-4" />
+                    Go to Homepage
                   </Button>
-                </Card>
-              ) : (
-                managedProperties.map((property) => (
-                  <Card
-                    key={property.id}
-                    className="border-3 border-foreground p-0 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]"
-                  >
-                    <div className="flex flex-col md:flex-row">
-                      <div className="relative aspect-video w-full border-b-3 border-foreground bg-muted md:h-48 md:w-72 md:border-b-0 md:border-r-3">
-                        <div className="flex h-full items-center justify-center">
-                          <Building2 className="h-12 w-12 text-muted-foreground md:h-16 md:w-16" />
-                        </div>
-                      </div>
-
-                      <div className="flex flex-1 flex-col p-4 md:p-6">
-                        <div className="mb-3 flex flex-col gap-3 md:mb-4 md:flex-row md:items-start md:justify-between">
-                          <div>
-                            <h3 className="text-lg font-bold text-foreground md:text-xl">{property.title}</h3>
-                            <p className="mt-1 flex items-center gap-1 text-sm text-muted-foreground">
-                              <MapPin className="h-4 w-4" />
-                              {property.location}
-                            </p>
-                          </div>
-                          <div className="flex items-center gap-2 border-3 border-foreground bg-muted/50 px-3 py-2 md:gap-3 md:px-4">
-                            <div className="flex h-8 w-8 items-center justify-center border-2 border-foreground bg-accent text-sm font-bold md:h-10 md:w-10">
-                              {property.landlord.avatar}
-                            </div>
-                            <div>
-                              <p className="text-xs font-bold md:text-sm">{property.landlord.name}</p>
-                              <p className="text-xs text-muted-foreground">Landlord</p>
-                            </div>
-                          </div>
-                        </div>
-
-                        <div className="mb-3 flex flex-wrap gap-3 md:mb-4 md:gap-6">
-                          <span className="flex items-center gap-1 text-xs font-medium md:text-sm">
-                            <Bed className="h-4 w-4" /> {property.beds} Beds
-                          </span>
-                          <span className="flex items-center gap-1 text-xs font-medium md:text-sm">
-                            <Bath className="h-4 w-4" /> {property.baths} Baths
-                          </span>
-                          <span className="flex items-center gap-1 text-xs font-medium md:text-sm">
-                            <Square className="h-4 w-4" /> {property.sqm} sqm
-                          </span>
-                        </div>
-
-                        <div className="mt-auto flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-                          <p className="text-xl font-bold text-primary md:text-2xl">
-                            ₦{property.price.toLocaleString()}
-                            <span className="text-xs font-normal text-muted-foreground md:text-sm">/year</span>
-                          </p>
-                          <div className="flex flex-wrap items-center gap-3 md:gap-4">
-                            <span className="flex items-center gap-1 text-xs text-muted-foreground md:text-sm">
-                              <MessageSquare className="h-4 w-4" /> {property.inquiries} inquiries
-                            </span>
-                            <Link href={`/properties/${property.id}`}>
-                              <Button className="border-3 border-foreground bg-secondary text-sm font-bold shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] transition-all hover:translate-x-0.5 hover:translate-y-0.5 hover:shadow-[2px_2px_0px_0px_rgba(26,26,26,1)]">
-                                <Eye className="mr-2 h-4 w-4" />
-                                View
-                              </Button>
-                            </Link>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </Card>
-                ))
-              )}
-            </div>
-          )}
-
-          {/* Available Properties Tab */}
-          {activeTab === "available" && (
-            <div>
-              {/* Search and Filter */}
-              <div className="mb-6 flex flex-col gap-3 md:flex-row md:gap-4">
-                <div className="relative flex-1">
-                  <Search className="absolute left-4 top-1/2 h-5 w-5 -translate-y-1/2 text-muted-foreground" />
-                  <Input
-                    placeholder="Search properties..."
-                    value={searchQuery}
-                    onChange={(e) => setSearchQuery(e.target.value)}
-                    className="border-3 border-foreground py-4 pl-12 text-base shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] md:py-6 md:text-lg"
-                  />
-                </div>
-                <Select value={locationFilter} onValueChange={setLocationFilter}>
-                  <SelectTrigger className="w-full border-3 border-foreground py-4 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] md:w-48 md:py-6">
-                    <Filter className="mr-2 h-4 w-4" />
-                    <SelectValue placeholder="Location" />
-                  </SelectTrigger>
-                  <SelectContent className="border-3 border-foreground">
-                    <SelectItem value="all">All Locations</SelectItem>
-                    <SelectItem value="victoria island">Victoria Island</SelectItem>
-                    <SelectItem value="lekki">Lekki</SelectItem>
-                    <SelectItem value="ikoyi">Ikoyi</SelectItem>
-                    <SelectItem value="banana island">Banana Island</SelectItem>
-                    <SelectItem value="yaba">Yaba</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
-
-              <div className="grid gap-4 md:gap-6">
-                {filteredAvailable.map((property) => (
-                  <Card
-                    key={property.id}
-                    className="border-3 border-foreground p-0 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]"
-                  >
-                    <div className="flex flex-col md:flex-row">
-                      <div className="relative aspect-video w-full border-b-3 border-foreground bg-muted md:h-48 md:w-72 md:border-b-0 md:border-r-3">
-                        <div className="flex h-full items-center justify-center">
-                          <Building2 className="h-12 w-12 text-muted-foreground md:h-16 md:w-16" />
-                        </div>
-                        <div className="absolute left-3 top-3 border-2 border-foreground bg-accent px-2 py-1 text-xs font-bold md:px-3 md:text-sm">
-                          {property.postedAt}
-                        </div>
-                      </div>
-
-                      <div className="flex flex-1 flex-col p-4 md:p-6">
-                        <div className="mb-3 flex flex-col gap-3 md:mb-4 md:flex-row md:items-start md:justify-between">
-                          <div>
-                            <h3 className="text-lg font-bold text-foreground md:text-xl">{property.title}</h3>
-                            <p className="mt-1 flex items-center gap-1 text-sm text-muted-foreground">
-                              <MapPin className="h-4 w-4" />
-                              {property.location}
-                            </p>
-                          </div>
-                          <div className="flex items-center gap-2 border-3 border-foreground bg-muted/50 px-3 py-2 md:gap-3 md:px-4">
-                            <div className="flex h-8 w-8 items-center justify-center border-2 border-foreground bg-accent text-sm font-bold md:h-10 md:w-10">
-                              {property.landlord.avatar}
-                            </div>
-                            <div>
-                              <p className="text-sm font-bold">{property.landlord.name}</p>
-                              <p className="text-xs text-muted-foreground">Landlord</p>
-                            </div>
-                          </div>
-                        </div>
-
-                        <div className="mb-4 flex gap-6">
-                          <span className="flex items-center gap-1 text-sm font-medium">
-                            <Bed className="h-4 w-4" /> {property.beds} Beds
-                          </span>
-                          <span className="flex items-center gap-1 text-sm font-medium">
-                            <Bath className="h-4 w-4" /> {property.baths} Baths
-                          </span>
-                          <span className="flex items-center gap-1 text-sm font-medium">
-                            <Square className="h-4 w-4" /> {property.sqm} sqm
-                          </span>
-                        </div>
-
-                        <div className="mt-auto flex items-center justify-between">
-                          <p className="text-2xl font-bold text-primary">
-                            ₦{property.price.toLocaleString()}
-                            <span className="text-sm font-normal text-muted-foreground">/year</span>
-                          </p>
-                          <Link href="/dashboard/agent/apply">
-                            <Button className="border-3 border-foreground bg-primary font-bold shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] transition-all hover:translate-x-0.5 hover:translate-y-0.5 hover:shadow-[2px_2px_0px_0px_rgba(26,26,26,1)]">
-                              <Send className="mr-2 h-4 w-4" />
-                              Apply to Manage
-                            </Button>
-                          </Link>
-                        </div>
-                      </div>
-                    </div>
-                  </Card>
-                ))}
+                </Link>
+                <Link href="/whistleblower/signup">
+                  <Button variant="outline" className="border-3 border-foreground font-bold shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
+                    <Users className="mr-2 h-4 w-4" />
+                    Become a Whistleblower
+                  </Button>
+                </Link>
               </div>
             </div>
-          )}
-
-          {/* Applications Tab */}
-          {activeTab === "applications" && (
-            <div className="grid gap-4">
-              {myApplications.map((application) => (
-                <Card
-                  key={application.id}
-                  className="border-3 border-foreground p-6 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]"
-                >
-                  {(() => {
-                    let statusClass = "bg-muted";
-                    if (application.status === "accepted") statusClass = "bg-secondary";
-                    else if (application.status === "pending") statusClass = "bg-accent";
-
-                    return (
-                      <div className="flex items-center justify-between">
-                        <div>
-                          <h3 className="text-lg font-bold">{application.property}</h3>
-                          <p className="text-sm text-muted-foreground">
-                            Landlord: {application.landlord} • Applied {application.appliedAt}
-                          </p>
-                        </div>
-                        <div className="flex items-center gap-4">
-                          <div
-                            className={`flex items-center gap-2 border-3 border-foreground px-4 py-2 font-bold ${statusClass}`}
-                          >
-                            {application.status === "accepted" && (
-                              <CheckCircle className="h-4 w-4" />
-                            )}
-                            {application.status === "pending" && (
-                              <Clock className="h-4 w-4" />
-                            )}
-                            {application.status === "declined" && (
-                              <XCircle className="h-4 w-4" />
-                            )}
-                            <span className="capitalize">{application.status}</span>
-                          </div>
-                          {application.status === "pending" && (
-                            <Button
-                              variant="outline"
-                              className="border-3 border-foreground bg-transparent font-bold"
-                            >
-                              Withdraw
-                            </Button>
-                          )}
-                        </div>
-                      </div>
-                    );
-                  })()}
-                </Card>
-              ))}
-            </div>
-          )}
+          </Card>
         </div>
       </main>
     </div>
-  )
+  );
 }

--- a/frontend/app/dashboard/agent/properties/page.tsx
+++ b/frontend/app/dashboard/agent/properties/page.tsx
@@ -1,299 +1,55 @@
-"use client"
+"use client";
 
-import { useState } from "react"
-import Link from "next/link"
-import {
-  Home,
-  Building2,
-  MessageSquare,
-  Settings,
-  MapPin,
-  Bed,
-  Bath,
-  Square,
-  Eye,
-  Star,
-  Briefcase,
-  Search,
-  Filter,
-  Plus,
-  TrendingUp,
-  Clock,
-} from "lucide-react"
-import { Button } from "@/components/ui/button"
-import { Card } from "@/components/ui/card"
-import { Input } from "@/components/ui/input"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select"
-import { DashboardHeader } from "@/components/dashboard-header"
-import { agentManagedPropertiesWithMetrics as managedProperties } from "@/lib/mockData"
+import Link from "next/link";
+import { AlertCircle, Home, Users } from "lucide-react";
+import { Card } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { DashboardHeader } from "@/components/dashboard-header";
 
-export default function AgentPropertiesPage() {
-  const [searchQuery, setSearchQuery] = useState("")
-  const [statusFilter, setStatusFilter] = useState("all")
-
-  const filteredProperties = managedProperties.filter((property) => {
-    const matchesSearch = property.title.toLowerCase().includes(searchQuery.toLowerCase())
-    const matchesStatus = statusFilter === "all" || property.status === statusFilter
-    return matchesSearch && matchesStatus
-  })
-
-  const formatCurrency = (amount: number) => {
-    return new Intl.NumberFormat("en-NG", {
-      style: "currency",
-      currency: "NGN",
-      minimumFractionDigits: 0,
-    }).format(amount)
-  }
-
+export default function AgentPropertiesPageDeprecated() {
   return (
     <div className="min-h-screen bg-background">
       <DashboardHeader />
 
-      {/* Sidebar */}
-      <aside className="fixed left-0 top-0 z-40 h-screen w-64 border-r-3 border-foreground bg-card pt-20">
-        <div className="flex h-full flex-col px-4 py-6">
-          <div className="mb-8 border-3 border-foreground bg-secondary p-4 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
-            <p className="text-sm font-medium text-foreground">Logged in as</p>
-            <p className="text-lg font-bold text-foreground">Adebayo Johnson</p>
-            <p className="text-sm text-muted-foreground">Property Agent</p>
-            <div className="mt-2 flex items-center gap-1">
-              <Star className="h-4 w-4 fill-accent text-accent" />
-              <span className="text-sm font-bold">4.8</span>
-              <span className="text-xs text-muted-foreground">(127 reviews)</span>
-            </div>
-          </div>
-
-          <nav className="flex-1 space-y-2">
-            <Link
-              href="/dashboard/agent"
-              className="flex items-center gap-3 border-3 border-foreground bg-card p-3 font-bold transition-all hover:bg-muted hover:shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]"
-            >
-              <Home className="h-5 w-5" />
-              Dashboard
-            </Link>
-            <Link
-              href="/dashboard/agent/properties"
-              className="flex items-center gap-3 border-3 border-foreground bg-primary p-3 font-bold shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]"
-            >
-              <Building2 className="h-5 w-5" />
-              My Properties
-            </Link>
-            <Link
-              href="/dashboard/agent/applications"
-              className="flex items-center gap-3 border-3 border-foreground bg-card p-3 font-bold transition-all hover:bg-muted hover:shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]"
-            >
-              <Briefcase className="h-5 w-5" />
-              Applications
-            </Link>
-            <Link
-              href="/messages"
-              className="flex items-center gap-3 border-3 border-foreground bg-card p-3 font-bold transition-all hover:bg-muted hover:shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]"
-            >
-              <MessageSquare className="h-5 w-5" />
-              Messages
-              <span className="ml-auto flex h-6 w-6 items-center justify-center border-2 border-foreground bg-destructive text-xs font-bold text-destructive-foreground">
-                5
-              </span>
-            </Link>
-            <Link
-              href="/dashboard/agent/settings"
-              className="flex items-center gap-3 border-3 border-foreground bg-card p-3 font-bold transition-all hover:bg-muted hover:shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]"
-            >
-              <Settings className="h-5 w-5" />
-              Settings
-            </Link>
-          </nav>
-        </div>
-      </aside>
-
-      {/* Main Content */}
       <main className="ml-64 min-h-screen pt-20">
-        <div className="p-8">
-          {/* Header */}
-          <div className="mb-8 flex items-center justify-between">
-            <div>
-              <h1 className="text-3xl font-bold text-foreground">My Properties</h1>
-              <p className="mt-1 text-muted-foreground">Manage properties you represent</p>
-            </div>
-            <Link href="/dashboard/agent">
-              <Button className="border-3 border-foreground bg-primary font-bold shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
-                <Plus className="mr-2 h-4 w-4" />
-                Find Properties
-              </Button>
-            </Link>
-          </div>
-
-          {/* Stats */}
-          <div className="mb-8 grid grid-cols-4 gap-4">
-            <Card className="border-3 border-foreground p-4 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
-              <div className="flex items-center gap-3">
-                <div className="flex h-10 w-10 items-center justify-center border-2 border-foreground bg-primary">
-                  <Building2 className="h-5 w-5" />
-                </div>
-                <div>
-                  <p className="text-sm text-muted-foreground">Total Properties</p>
-                  <p className="text-xl font-bold">{managedProperties.length}</p>
-                </div>
+        <div className="container mx-auto px-4 py-8">
+          <Card className="border-3 border-foreground p-8 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] max-w-2xl mx-auto">
+            <div className="flex flex-col items-center text-center space-y-6">
+              <div className="flex h-16 w-16 items-center justify-center border-3 border-foreground bg-destructive/10 rounded-full">
+                <AlertCircle className="h-8 w-8 text-destructive" />
               </div>
-            </Card>
-            <Card className="border-3 border-foreground p-4 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
-              <div className="flex items-center gap-3">
-                <div className="flex h-10 w-10 items-center justify-center border-2 border-foreground bg-secondary">
-                  <Eye className="h-5 w-5" />
-                </div>
-                <div>
-                  <p className="text-sm text-muted-foreground">Total Views</p>
-                  <p className="text-xl font-bold">{managedProperties.reduce((sum, p) => sum + p.views, 0)}</p>
-                </div>
-              </div>
-            </Card>
-            <Card className="border-3 border-foreground p-4 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
-              <div className="flex items-center gap-3">
-                <div className="flex h-10 w-10 items-center justify-center border-2 border-foreground bg-accent">
-                  <MessageSquare className="h-5 w-5" />
-                </div>
-                <div>
-                  <p className="text-sm text-muted-foreground">Total Inquiries</p>
-                  <p className="text-xl font-bold">{managedProperties.reduce((sum, p) => sum + p.inquiries, 0)}</p>
-                </div>
-              </div>
-            </Card>
-            <Card className="border-3 border-foreground p-4 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
-              <div className="flex items-center gap-3">
-                <div className="flex h-10 w-10 items-center justify-center border-2 border-foreground bg-muted">
-                  <TrendingUp className="h-5 w-5" />
-                </div>
-                <div>
-                  <p className="text-sm text-muted-foreground">Active Listings</p>
-                  <p className="text-xl font-bold">{managedProperties.filter((p) => p.status === "active").length}</p>
-                </div>
-              </div>
-            </Card>
-          </div>
-
-          {/* Search and Filter */}
-          <div className="mb-6 flex gap-4">
-            <div className="relative flex-1">
-              <Search className="absolute left-4 top-1/2 h-5 w-5 -translate-y-1/2 text-muted-foreground" />
-              <Input
-                placeholder="Search properties..."
-                value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
-                className="border-3 border-foreground py-6 pl-12 text-lg shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]"
-              />
-            </div>
-            <Select value={statusFilter} onValueChange={setStatusFilter}>
-              <SelectTrigger className="w-48 border-3 border-foreground py-6 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
-                <Filter className="mr-2 h-4 w-4" />
-                <SelectValue placeholder="Status" />
-              </SelectTrigger>
-              <SelectContent className="border-3 border-foreground">
-                <SelectItem value="all">All Status</SelectItem>
-                <SelectItem value="active">Active</SelectItem>
-                <SelectItem value="rented">Rented</SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
-
-          {/* Properties List */}
-          <div className="grid gap-6">
-            {filteredProperties.length === 0 ? (
-              <Card className="border-3 border-foreground p-12 text-center shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
-                <Building2 className="mx-auto h-16 w-16 text-muted-foreground" />
-                <h3 className="mt-4 text-xl font-bold">No Properties Found</h3>
-                <p className="mt-2 text-muted-foreground">
-                  No properties match your search criteria.
+              
+              <div>
+                <h1 className="text-3xl font-bold mb-2">Agent Role Deprecated</h1>
+                <p className="text-muted-foreground text-lg">
+                  Agent property management is no longer available.
                 </p>
-              </Card>
-            ) : (
-              filteredProperties.map((property) => (
-                <Card
-                  key={property.id}
-                  className="border-3 border-foreground p-0 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]"
-                >
-                  <div className="flex">
-                    <div className="relative h-48 w-72 shrink-0 border-r-3 border-foreground bg-muted">
-                      <div className="flex h-full items-center justify-center">
-                        <Building2 className="h-16 w-16 text-muted-foreground" />
-                      </div>
-                      <div
-                        className={`absolute left-3 top-3 border-2 border-foreground px-3 py-1 text-sm font-bold ${
-                          property.status === "active" ? "bg-secondary" : "bg-muted"
-                        }`}
-                      >
-                        {property.status === "active" ? "Active" : "Rented"}
-                      </div>
-                    </div>
+              </div>
 
-                    <div className="flex flex-1 flex-col p-6">
-                      <div className="mb-4 flex items-start justify-between">
-                        <div>
-                          <h3 className="text-xl font-bold text-foreground">{property.title}</h3>
-                          <p className="mt-1 flex items-center gap-1 text-muted-foreground">
-                            <MapPin className="h-4 w-4" />
-                            {property.location}
-                          </p>
-                        </div>
-                        <div className="flex items-center gap-3 border-3 border-foreground bg-muted/50 px-4 py-2">
-                          <div className="flex h-10 w-10 items-center justify-center border-2 border-foreground bg-accent font-bold">
-                            {property.landlord.avatar}
-                          </div>
-                          <div>
-                            <p className="text-sm font-bold">{property.landlord.name}</p>
-                            <p className="text-xs text-muted-foreground">Landlord</p>
-                          </div>
-                        </div>
-                      </div>
+              <div className="w-full border-t-2 border-foreground pt-6 space-y-4">
+                <p className="text-sm text-muted-foreground">
+                  We have transitioned to a whistleblower model. If you're a current tenant, you can become a whistleblower to help verify properties.
+                </p>
+              </div>
 
-                      <div className="mb-4 flex gap-6">
-                        <span className="flex items-center gap-1 text-sm font-medium">
-                          <Bed className="h-4 w-4" /> {property.beds} Beds
-                        </span>
-                        <span className="flex items-center gap-1 text-sm font-medium">
-                          <Bath className="h-4 w-4" /> {property.baths} Baths
-                        </span>
-                        <span className="flex items-center gap-1 text-sm font-medium">
-                          <Square className="h-4 w-4" /> {property.sqm} sqm
-                        </span>
-                        <span className="flex items-center gap-1 text-sm text-muted-foreground">
-                          <Clock className="h-4 w-4" /> Listed {property.listedDate}
-                        </span>
-                      </div>
-
-                      <div className="mt-auto flex items-center justify-between">
-                        <div className="flex items-center gap-6">
-                          <p className="text-2xl font-bold text-primary">
-                            {formatCurrency(property.price)}
-                            <span className="text-sm font-normal text-muted-foreground">/year</span>
-                          </p>
-                          <span className="flex items-center gap-1 text-sm text-muted-foreground">
-                            <Eye className="h-4 w-4" /> {property.views} views
-                          </span>
-                          <span className="flex items-center gap-1 text-sm text-muted-foreground">
-                            <MessageSquare className="h-4 w-4" /> {property.inquiries} inquiries
-                          </span>
-                        </div>
-                        <Link href={`/properties/${property.id}`}>
-                          <Button className="border-3 border-foreground bg-secondary font-bold shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] transition-all hover:translate-x-0.5 hover:translate-y-0.5 hover:shadow-[2px_2px_0px_0px_rgba(26,26,26,1)]">
-                            <Eye className="mr-2 h-4 w-4" />
-                            View Listing
-                          </Button>
-                        </Link>
-                      </div>
-                    </div>
-                  </div>
-                </Card>
-              ))
-            )}
-          </div>
+              <div className="flex gap-4 pt-4">
+                <Link href="/">
+                  <Button className="border-3 border-foreground bg-primary font-bold shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
+                    <Home className="mr-2 h-4 w-4" />
+                    Go to Homepage
+                  </Button>
+                </Link>
+                <Link href="/whistleblower/signup">
+                  <Button variant="outline" className="border-3 border-foreground font-bold shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
+                    <Users className="mr-2 h-4 w-4" />
+                    Become a Whistleblower
+                  </Button>
+                </Link>
+              </div>
+            </div>
+          </Card>
         </div>
       </main>
     </div>
-  )
+  );
 }

--- a/frontend/app/dashboard/agent/settings/page.tsx
+++ b/frontend/app/dashboard/agent/settings/page.tsx
@@ -1,424 +1,55 @@
-"use client"
+"use client";
 
-import { useState } from "react"
-import Link from "next/link"
-import {
-  Home,
-  Building2,
-  MessageSquare,
-  Settings,
-  User,
-  Bell,
-  Shield,
-  CreditCard,
-  Mail,
-  Phone,
-  MapPin,
-  Save,
-  Eye,
-  EyeOff,
-  Star,
-  Briefcase,
-  Award,
-} from "lucide-react"
-import { Button } from "@/components/ui/button"
-import { Card } from "@/components/ui/card"
-import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
-import { Switch } from "@/components/ui/switch"
-import { Textarea } from "@/components/ui/textarea"
-import { DashboardHeader } from "@/components/dashboard-header"
-import { agentRecentPayouts } from "@/lib/mockData"
+import Link from "next/link";
+import { AlertCircle, Home, Users } from "lucide-react";
+import { Card } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { DashboardHeader } from "@/components/dashboard-header";
 
-export default function AgentSettingsPage() {
-  const [activeTab, setActiveTab] = useState<"profile" | "notifications" | "security" | "payment">("profile")
-  const [showPassword, setShowPassword] = useState(false)
-
-  const tabs = [
-    { id: "profile", label: "Profile", icon: User },
-    { id: "notifications", label: "Notifications", icon: Bell },
-    { id: "security", label: "Security", icon: Shield },
-    { id: "payment", label: "Earnings", icon: CreditCard },
-  ]
-
+export default function AgentSettingsPageDeprecated() {
   return (
     <div className="min-h-screen bg-background">
       <DashboardHeader />
 
-      {/* Sidebar */}
-      <aside className="fixed left-0 top-0 z-40 h-screen w-64 border-r-3 border-foreground bg-card pt-20">
-        <div className="flex h-full flex-col px-4 py-6">
-          <div className="mb-8 border-3 border-foreground bg-secondary p-4 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
-            <p className="text-sm font-medium text-foreground">Logged in as</p>
-            <p className="text-lg font-bold text-foreground">Adebayo Johnson</p>
-            <p className="text-sm text-muted-foreground">Property Agent</p>
-            <div className="mt-2 flex items-center gap-1">
-              <Star className="h-4 w-4 fill-accent text-accent" />
-              <span className="text-sm font-bold">4.8</span>
-              <span className="text-xs text-muted-foreground">(127 reviews)</span>
-            </div>
-          </div>
-
-          <nav className="flex-1 space-y-2">
-            <Link
-              href="/dashboard/agent"
-              className="flex items-center gap-3 border-3 border-foreground bg-card p-3 font-bold transition-all hover:bg-muted hover:shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]"
-            >
-              <Home className="h-5 w-5" />
-              Dashboard
-            </Link>
-            <Link
-              href="/dashboard/agent/properties"
-              className="flex items-center gap-3 border-3 border-foreground bg-card p-3 font-bold transition-all hover:bg-muted hover:shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]"
-            >
-              <Building2 className="h-5 w-5" />
-              My Properties
-            </Link>
-            <Link
-              href="/dashboard/agent/applications"
-              className="flex items-center gap-3 border-3 border-foreground bg-card p-3 font-bold transition-all hover:bg-muted hover:shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]"
-            >
-              <Briefcase className="h-5 w-5" />
-              Applications
-            </Link>
-            <Link
-              href="/messages"
-              className="flex items-center gap-3 border-3 border-foreground bg-card p-3 font-bold transition-all hover:bg-muted hover:shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]"
-            >
-              <MessageSquare className="h-5 w-5" />
-              Messages
-              <span className="ml-auto flex h-6 w-6 items-center justify-center border-2 border-foreground bg-destructive text-xs font-bold text-destructive-foreground">
-                5
-              </span>
-            </Link>
-            <Link
-              href="/dashboard/agent/settings"
-              className="flex items-center gap-3 border-3 border-foreground bg-primary p-3 font-bold shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]"
-            >
-              <Settings className="h-5 w-5" />
-              Settings
-            </Link>
-          </nav>
-        </div>
-      </aside>
-
-      {/* Main Content */}
       <main className="ml-64 min-h-screen pt-20">
-        <div className="p-8">
-          {/* Header */}
-          <div className="mb-8">
-            <h1 className="text-3xl font-bold text-foreground">Settings</h1>
-            <p className="mt-1 text-muted-foreground">Manage your account and agent profile</p>
-          </div>
-
-          {/* Tabs */}
-          <div className="mb-6 flex gap-2">
-            {tabs.map((tab) => (
-              <button
-                key={tab.id}
-                onClick={() => setActiveTab(tab.id as typeof activeTab)}
-                className={`flex items-center gap-2 border-3 border-foreground px-4 py-3 font-bold transition-all ${
-                  activeTab === tab.id
-                    ? "bg-foreground text-background shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]"
-                    : "bg-card hover:bg-muted"
-                }`}
-              >
-                <tab.icon className="h-4 w-4" />
-                {tab.label}
-              </button>
-            ))}
-          </div>
-
-          {/* Profile Tab */}
-          {activeTab === "profile" && (
-            <div className="grid gap-6 lg:grid-cols-3">
-              <div className="lg:col-span-2">
-                <Card className="border-3 border-foreground p-6 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
-                  <h2 className="mb-6 text-xl font-bold">Profile Information</h2>
-                  
-                  <div className="mb-8 flex items-center gap-6">
-                    <div className="flex h-24 w-24 items-center justify-center border-3 border-foreground bg-secondary text-3xl font-bold">
-                      AJ
-                    </div>
-                    <div>
-                      <Button variant="outline" className="border-3 border-foreground bg-transparent font-bold">
-                        Change Photo
-                      </Button>
-                      <p className="mt-2 text-sm text-muted-foreground">JPG, PNG or GIF. Max 2MB</p>
-                    </div>
-                  </div>
-
-                  <div className="grid gap-6 md:grid-cols-2">
-                    <div className="space-y-2">
-                      <Label htmlFor="full-name" className="font-bold">Full Name</Label>
-                      <Input
-                        id="full-name"
-                        defaultValue="Adebayo Johnson"
-                        className="border-3 border-foreground bg-background py-5 shadow-[3px_3px_0px_0px_rgba(26,26,26,1)]"
-                      />
-                    </div>
-                    <div className="space-y-2">
-                      <Label htmlFor="license-number" className="font-bold">License Number</Label>
-                      <Input
-                        id="license-number"
-                        defaultValue="NIESV-2024-12345"
-                        className="border-3 border-foreground bg-background py-5 shadow-[3px_3px_0px_0px_rgba(26,26,26,1)]"
-                      />
-                    </div>
-                    <div className="space-y-2">
-                      <Label htmlFor="email" className="font-bold">Email Address</Label>
-                      <div className="relative">
-                        <Mail className="absolute left-4 top-1/2 h-5 w-5 -translate-y-1/2 text-muted-foreground" />
-                        <Input
-                          id="email"
-                          type="email"
-                          defaultValue="adebayo.j@sheltaflex.com"
-                          className="border-3 border-foreground bg-background py-5 pl-12 shadow-[3px_3px_0px_0px_rgba(26,26,26,1)]"
-                        />
-                      </div>
-                    </div>
-                    <div className="space-y-2">
-                      <Label htmlFor="phone" className="font-bold">Phone Number</Label>
-                      <div className="relative">
-                        <Phone className="absolute left-4 top-1/2 h-5 w-5 -translate-y-1/2 text-muted-foreground" />
-                        <Input
-                          id="phone"
-                          defaultValue="+234 802 345 6789"
-                          className="border-3 border-foreground bg-background py-5 pl-12 shadow-[3px_3px_0px_0px_rgba(26,26,26,1)]"
-                        />
-                      </div>
-                    </div>
-                    <div className="space-y-2 md:col-span-2">
-                      <Label htmlFor="office-address" className="font-bold">Office Address</Label>
-                      <div className="relative">
-                        <MapPin className="absolute left-4 top-4 h-5 w-5 text-muted-foreground" />
-                        <Input
-                          id="office-address"
-                          defaultValue="25 Marina Street, Lagos Island, Lagos"
-                          className="border-3 border-foreground bg-background py-5 pl-12 shadow-[3px_3px_0px_0px_rgba(26,26,26,1)]"
-                        />
-                      </div>
-                    </div>
-                    <div className="space-y-2 md:col-span-2">
-                      <Label htmlFor="bio" className="font-bold">Bio</Label>
-                      <Textarea
-                        id="bio"
-                        defaultValue="Experienced property agent with 5+ years in the Lagos real estate market. Specializing in luxury apartments and commercial properties in Victoria Island, Lekki, and Ikoyi areas."
-                        className="min-h-30 border-3 border-foreground bg-background shadow-[3px_3px_0px_0px_rgba(26,26,26,1)]"
-                      />
-                    </div>
-                  </div>
-
-                  <div className="mt-6 flex justify-end">
-                    <Button className="border-3 border-foreground bg-primary px-6 py-5 font-bold shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] transition-all hover:translate-x-0.5 hover:translate-y-0.5 hover:shadow-[2px_2px_0px_0px_rgba(26,26,26,1)]">
-                      <Save className="mr-2 h-4 w-4" />
-                      Save Changes
-                    </Button>
-                  </div>
-                </Card>
+        <div className="container mx-auto px-4 py-8">
+          <Card className="border-3 border-foreground p-8 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] max-w-2xl mx-auto">
+            <div className="flex flex-col items-center text-center space-y-6">
+              <div className="flex h-16 w-16 items-center justify-center border-3 border-foreground bg-destructive/10 rounded-full">
+                <AlertCircle className="h-8 w-8 text-destructive" />
+              </div>
+              
+              <div>
+                <h1 className="text-3xl font-bold mb-2">Agent Role Deprecated</h1>
+                <p className="text-muted-foreground text-lg">
+                  Agent settings are no longer available.
+                </p>
               </div>
 
-              {/* Agent Stats */}
-              <Card className="border-3 border-foreground p-6 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
-                <h3 className="mb-4 text-lg font-bold">Agent Stats</h3>
-                <div className="space-y-4">
-                  <div className="flex items-center justify-between border-b-2 border-foreground/10 pb-4">
-                    <div className="flex items-center gap-3">
-                      <Star className="h-5 w-5 fill-accent text-accent" />
-                      <span>Rating</span>
-                    </div>
-                    <span className="font-bold">4.8/5</span>
-                  </div>
-                  <div className="flex items-center justify-between border-b-2 border-foreground/10 pb-4">
-                    <div className="flex items-center gap-3">
-                      <Building2 className="h-5 w-5" />
-                      <span>Properties Managed</span>
-                    </div>
-                    <span className="font-bold">12</span>
-                  </div>
-                  <div className="flex items-center justify-between border-b-2 border-foreground/10 pb-4">
-                    <div className="flex items-center gap-3">
-                      <Award className="h-5 w-5" />
-                      <span>Successful Rentals</span>
-                    </div>
-                    <span className="font-bold">47</span>
-                  </div>
-                  <div className="flex items-center justify-between">
-                    <div className="flex items-center gap-3">
-                      <User className="h-5 w-5" />
-                      <span>Reviews</span>
-                    </div>
-                    <span className="font-bold">127</span>
-                  </div>
-                </div>
+              <div className="w-full border-t-2 border-foreground pt-6 space-y-4">
+                <p className="text-sm text-muted-foreground">
+                  We have transitioned to a whistleblower model. If you're a current tenant, you can become a whistleblower to help verify properties.
+                </p>
+              </div>
 
-                <div className="mt-6 border-3 border-foreground bg-secondary/30 p-4">
-                  <p className="text-sm font-bold">Verified Agent</p>
-                  <p className="text-xs text-muted-foreground">Your credentials have been verified</p>
-                </div>
-              </Card>
+              <div className="flex gap-4 pt-4">
+                <Link href="/">
+                  <Button className="border-3 border-foreground bg-primary font-bold shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
+                    <Home className="mr-2 h-4 w-4" />
+                    Go to Homepage
+                  </Button>
+                </Link>
+                <Link href="/whistleblower/signup">
+                  <Button variant="outline" className="border-3 border-foreground font-bold shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
+                    <Users className="mr-2 h-4 w-4" />
+                    Become a Whistleblower
+                  </Button>
+                </Link>
+              </div>
             </div>
-          )}
-
-          {/* Notifications Tab */}
-          {activeTab === "notifications" && (
-            <Card className="border-3 border-foreground p-6 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
-              <h2 className="mb-6 text-xl font-bold">Notification Preferences</h2>
-              
-              <div className="space-y-6">
-                {[
-                  { title: "New Property Listings", description: "Get notified when landlords post new properties", defaultChecked: true },
-                  { title: "Application Updates", description: "Get notified about your application status changes", defaultChecked: true },
-                  { title: "Tenant Inquiries", description: "Get notified when tenants inquire about your listings", defaultChecked: true },
-                  { title: "Messages", description: "Get notified when you receive new messages", defaultChecked: true },
-                  { title: "Payment Notifications", description: "Get notified about commission payments", defaultChecked: true },
-                  { title: "Market Updates", description: "Weekly market insights and trends", defaultChecked: false },
-                ].map((item) => (
-                  <div key={item.title} className="flex items-center justify-between border-b-2 border-foreground/10 pb-4 last:border-0">
-                    <div>
-                      <p className="font-bold">{item.title}</p>
-                      <p className="text-sm text-muted-foreground">{item.description}</p>
-                    </div>
-                    <Switch defaultChecked={item.defaultChecked} />
-                  </div>
-                ))}
-              </div>
-            </Card>
-          )}
-
-          {/* Security Tab */}
-          {activeTab === "security" && (
-            <Card className="border-3 border-foreground p-6 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
-              <h2 className="mb-6 text-xl font-bold">Security Settings</h2>
-              
-              <div className="space-y-6">
-                <div className="space-y-4">
-                  <h3 className="font-bold">Change Password</h3>
-                  <div className="grid gap-4 md:grid-cols-2">
-                    <div className="space-y-2">
-                      <Label htmlFor="current-password">Current Password</Label>
-                      <div className="relative">
-                        <Input
-                          id="current-password"
-                          type={showPassword ? "text" : "password"}
-                          className="border-3 border-foreground bg-background py-5 pr-12 shadow-[3px_3px_0px_0px_rgba(26,26,26,1)]"
-                        />
-                        <button
-                          type="button"
-                          onClick={() => setShowPassword(!showPassword)}
-                          className="absolute right-4 top-1/2 -translate-y-1/2"
-                        >
-                          {showPassword ? <EyeOff className="h-5 w-5" /> : <Eye className="h-5 w-5" />}
-                        </button>
-                      </div>
-                    </div>
-                    <div />
-                    <div className="space-y-2">
-                      <Label htmlFor="new-password">New Password</Label>
-                      <Input
-                        id="new-password"
-                        type="password"
-                        className="border-3 border-foreground bg-background py-5 shadow-[3px_3px_0px_0px_rgba(26,26,26,1)]"
-                      />
-                    </div>
-                    <div className="space-y-2">
-                      <Label htmlFor="confirm-new-password">Confirm New Password</Label>
-                      <Input
-                        id="confirm-new-password"
-                        type="password"
-                        className="border-3 border-foreground bg-background py-5 shadow-[3px_3px_0px_0px_rgba(26,26,26,1)]"
-                      />
-                    </div>
-                  </div>
-                  <Button className="border-3 border-foreground bg-secondary font-bold shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
-                    Update Password
-                  </Button>
-                </div>
-
-                <div className="border-t-2 border-foreground pt-6">
-                  <h3 className="font-bold mb-4">Two-Factor Authentication</h3>
-                  <div className="flex items-center justify-between">
-                    <div>
-                      <p className="text-muted-foreground">Add an extra layer of security to your account</p>
-                    </div>
-                    <Switch />
-                  </div>
-                </div>
-              </div>
-            </Card>
-          )}
-
-          {/* Earnings Tab */}
-          {activeTab === "payment" && (
-            <Card className="border-3 border-foreground p-6 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
-              <h2 className="mb-6 text-xl font-bold">Earnings & Payout</h2>
-              
-              <div className="space-y-6">
-                {/* Earnings Summary */}
-                <div className="grid gap-4 md:grid-cols-3">
-                  <div className="border-3 border-foreground bg-primary/10 p-4">
-                    <p className="text-sm text-muted-foreground">This Month</p>
-                    <p className="text-2xl font-bold">₦450,000</p>
-                  </div>
-                  <div className="border-3 border-foreground bg-secondary/10 p-4">
-                    <p className="text-sm text-muted-foreground">Last Month</p>
-                    <p className="text-2xl font-bold">₦380,000</p>
-                  </div>
-                  <div className="border-3 border-foreground bg-accent/10 p-4">
-                    <p className="text-sm text-muted-foreground">Total Earnings</p>
-                    <p className="text-2xl font-bold">₦4,250,000</p>
-                  </div>
-                </div>
-
-                {/* Bank Account */}
-                <div>
-                  <h3 className="font-bold mb-4">Payout Account</h3>
-                  <div className="border-3 border-foreground bg-muted p-4">
-                    <div className="grid gap-4 md:grid-cols-3">
-                      <div>
-                        <p className="text-sm text-muted-foreground">Bank Name</p>
-                        <p className="font-bold">Access Bank</p>
-                      </div>
-                      <div>
-                        <p className="text-sm text-muted-foreground">Account Number</p>
-                        <p className="font-bold">••••••7890</p>
-                      </div>
-                      <div>
-                        <p className="text-sm text-muted-foreground">Account Name</p>
-                        <p className="font-bold">Adebayo Johnson</p>
-                      </div>
-                    </div>
-                  </div>
-                  <Button variant="outline" className="mt-4 border-3 border-foreground bg-transparent font-bold">
-                    Update Bank Details
-                  </Button>
-                </div>
-
-                {/* Recent Payouts */}
-                <div className="border-t-2 border-foreground pt-6">
-                  <h3 className="font-bold mb-4">Recent Payouts</h3>
-                  <div className="space-y-3">
-                    {agentRecentPayouts.map((payout) => (
-                      <div key={payout.date} className="flex items-center justify-between border-b border-foreground/10 pb-3">
-                        <div>
-                          <p className="font-bold">{payout.property}</p>
-                          <p className="text-sm text-muted-foreground">{payout.date}</p>
-                        </div>
-                        <div className="text-right">
-                          <p className="font-bold">{payout.amount}</p>
-                          <span className="border-2 border-foreground bg-secondary px-2 py-0.5 text-xs font-bold">
-                            {payout.status}
-                          </span>
-                        </div>
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              </div>
-            </Card>
-          )}
+          </Card>
         </div>
       </main>
     </div>
-  )
+  );
 }

--- a/frontend/app/dashboard/landlord/agents/page.tsx
+++ b/frontend/app/dashboard/landlord/agents/page.tsx
@@ -1,36 +1,16 @@
-"use client"
+"use client";
 
-import Link from "next/link"
-import {
-  Home,
-  Building2,
-  Users,
-  MessageSquare,
-  Settings,
-  Star,
-  Phone,
-  Mail,
-  MoreVertical,
-  UserMinus,
-  CheckCircle,
-} from "lucide-react"
-import { Button } from "@/components/ui/button"
-import { Card } from "@/components/ui/card"
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu"
-import {
-  landlordAgentsStats as stats,
-  landlordMyAgents as myAgents,
-} from "@/lib/mockData"
+import Link from "next/link";
+import { AlertCircle, Home, Building2, MessageSquare, Settings } from "lucide-react";
+import { Card } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { DashboardHeader } from "@/components/dashboard-header";
 
-export default function LandlordAgentsPage() {
+export default function LandlordAgentsPageDeprecated() {
   return (
     <div className="min-h-screen bg-background">
-      {/* Sidebar */}
+      <DashboardHeader />
+
       <aside className="fixed left-0 top-0 z-40 h-screen w-64 border-r-3 border-foreground bg-card pt-20">
         <div className="flex h-full flex-col px-4 py-6">
           <div className="mb-8 border-3 border-foreground bg-accent p-4 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
@@ -55,13 +35,6 @@ export default function LandlordAgentsPage() {
               My Properties
             </Link>
             <Link
-              href="/dashboard/landlord/agents"
-              className="flex items-center gap-3 border-3 border-foreground bg-primary p-3 font-bold shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]"
-            >
-              <Users className="h-5 w-5" />
-              My Agents
-            </Link>
-            <Link
               href="/messages"
               className="flex items-center gap-3 border-3 border-foreground bg-card p-3 font-bold transition-all hover:bg-muted hover:shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]"
             >
@@ -79,117 +52,54 @@ export default function LandlordAgentsPage() {
         </div>
       </aside>
 
-      {/* Main Content */}
       <main className="ml-64 min-h-screen pt-20">
-        <div className="p-8">
-          {/* Header */}
-          <div className="mb-8">
-            <h1 className="text-3xl font-bold text-foreground">My Agents</h1>
-            <p className="mt-1 text-muted-foreground">Manage agents working on your properties</p>
-          </div>
+        <div className="container mx-auto px-4 py-8">
+          <Card className="border-3 border-foreground p-8 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] max-w-2xl mx-auto">
+            <div className="flex flex-col items-center text-center space-y-6">
+              <div className="flex h-16 w-16 items-center justify-center border-3 border-foreground bg-destructive/10 rounded-full">
+                <AlertCircle className="h-8 w-8 text-destructive" />
+              </div>
+              
+              <div>
+                <h1 className="text-3xl font-bold mb-2">Agent Management Deprecated</h1>
+                <p className="text-muted-foreground text-lg">
+                  Agent management has been removed from Sheltaflex.
+                </p>
+              </div>
 
-          {/* Stats Grid */}
-          <div className="mb-8 grid grid-cols-4 gap-4">
-            {stats.map((stat) => (
-              <Card key={stat.label} className="border-3 border-foreground p-4 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
-                <div className="flex items-center gap-3">
-                  <div className="flex h-12 w-12 items-center justify-center border-3 border-foreground bg-secondary">
-                    <stat.icon className="h-6 w-6" />
-                  </div>
-                  <div>
-                    <p className="text-sm text-muted-foreground">{stat.label}</p>
-                    <p className="text-2xl font-bold">{stat.value}</p>
-                  </div>
+              <div className="w-full border-t-2 border-foreground pt-6 space-y-4">
+                <p className="text-sm text-muted-foreground">
+                  We have transitioned to a whistleblower model where current tenants in buildings help with property discovery and verification. Landlords now manage properties directly.
+                </p>
+                
+                <div className="bg-muted/50 border-2 border-foreground p-4 space-y-2">
+                  <p className="font-bold">What changed?</p>
+                  <ul className="text-sm text-left space-y-1 list-disc list-inside text-muted-foreground">
+                    <li>Property verification is now done by resident whistleblowers</li>
+                    <li>Tenants can message residents (whistleblowers) for property questions</li>
+                    <li>Landlords manage properties directly without agents</li>
+                  </ul>
                 </div>
-              </Card>
-            ))}
-          </div>
+              </div>
 
-          {/* Agents List */}
-          <div className="grid gap-6">
-            {myAgents.map((agent) => (
-              <Card key={agent.id} className="border-3 border-foreground p-6 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
-                <div className="flex items-start justify-between">
-                  <div className="flex gap-6">
-                    {/* Avatar */}
-                    <div className="relative">
-                      <div className="flex h-20 w-20 items-center justify-center border-3 border-foreground bg-accent text-2xl font-bold">
-                        {agent.avatar}
-                      </div>
-                      {agent.verified && (
-                        <div className="absolute -bottom-1 -right-1 flex h-6 w-6 items-center justify-center border-2 border-foreground bg-secondary">
-                          <CheckCircle className="h-4 w-4" />
-                        </div>
-                      )}
-                    </div>
-
-                    {/* Info */}
-                    <div>
-                      <div className="flex items-center gap-3">
-                        <h3 className="text-xl font-bold">{agent.name}</h3>
-                        <div className="flex items-center gap-1 border-2 border-foreground bg-accent px-2 py-0.5">
-                          <Star className="h-4 w-4 fill-foreground" />
-                          <span className="font-bold">{agent.rating}</span>
-                          <span className="text-xs text-muted-foreground">({agent.reviews})</span>
-                        </div>
-                      </div>
-                      <p className="mt-1 text-sm text-muted-foreground">Agent since {agent.joinedDate}</p>
-
-                      <div className="mt-4 flex gap-6 text-sm">
-                        <div>
-                          <p className="text-muted-foreground">Properties</p>
-                          <p className="font-bold">{agent.properties}</p>
-                        </div>
-                        <div>
-                          <p className="text-muted-foreground">Inquiries</p>
-                          <p className="font-bold">{agent.totalInquiries}</p>
-                        </div>
-                        <div>
-                          <p className="text-muted-foreground">Response Time</p>
-                          <p className="font-bold">{agent.responseTime}</p>
-                        </div>
-                      </div>
-
-                      <div className="mt-4">
-                        <p className="text-sm text-muted-foreground mb-2">Managing:</p>
-                        <div className="flex flex-wrap gap-2">
-                          {agent.propertyNames.map((name) => (
-                            <span key={name} className="border-2 border-foreground bg-muted px-3 py-1 text-sm font-medium">
-                              {name}
-                            </span>
-                          ))}
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-
-                  {/* Actions */}
-                  <div className="flex items-start gap-2">
-                    <Link href="/messages">
-                      <Button className="border-3 border-foreground bg-secondary font-bold shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] transition-all hover:translate-x-0.5 hover:translate-y-0.5 hover:shadow-[2px_2px_0px_0px_rgba(26,26,26,1)]">
-                        <MessageSquare className="mr-2 h-4 w-4" />
-                        Message
-                      </Button>
-                    </Link>
-                    <DropdownMenu>
-                      <DropdownMenuTrigger asChild>
-                        <Button variant="outline" size="icon" className="border-3 border-foreground bg-transparent">
-                          <MoreVertical className="h-4 w-4" />
-                        </Button>
-                      </DropdownMenuTrigger>
-                      <DropdownMenuContent className="border-3 border-foreground">
-                        <DropdownMenuItem><Phone className="mr-2 h-4 w-4" /> Request Call</DropdownMenuItem>
-                        <DropdownMenuItem><Mail className="mr-2 h-4 w-4" /> Send Email</DropdownMenuItem>
-                        <DropdownMenuItem className="text-destructive"><UserMinus className="mr-2 h-4 w-4" /> Remove Agent</DropdownMenuItem>
-                      </DropdownMenuContent>
-                    </DropdownMenu>
-                  </div>
-                </div>
-              </Card>
-            ))}
-          </div>
+              <div className="flex gap-4 pt-4">
+                <Link href="/dashboard/landlord">
+                  <Button className="border-3 border-foreground bg-primary font-bold shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
+                    <Home className="mr-2 h-4 w-4" />
+                    Back to Dashboard
+                  </Button>
+                </Link>
+                <Link href="/dashboard/landlord/properties">
+                  <Button variant="outline" className="border-3 border-foreground font-bold shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
+                    <Building2 className="mr-2 h-4 w-4" />
+                    Manage Properties
+                  </Button>
+                </Link>
+              </div>
+            </div>
+          </Card>
         </div>
       </main>
     </div>
-  )
+  );
 }

--- a/frontend/app/dashboard/landlord/properties/page.tsx
+++ b/frontend/app/dashboard/landlord/properties/page.tsx
@@ -160,7 +160,7 @@ export default function LandlordPropertiesPage() {
                     break
                   case "pending":
                     statusBadgeClass = "bg-accent"
-                    statusLabel = "Pending Agent"
+                    statusLabel = "Pending"
                     break
                   default:
                     break

--- a/frontend/app/dashboard/tenant/lease/page.tsx
+++ b/frontend/app/dashboard/tenant/lease/page.tsx
@@ -384,44 +384,6 @@ export default function TenantLeasePage() {
 
             {/* Contact Cards */}
             <div className="space-y-6">
-              {/* Agent */}
-              <Card className="border-3 border-foreground p-6 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
-                <h3 className="mb-4 text-lg font-bold">Your Agent</h3>
-                <div className="mb-4 flex items-center gap-4">
-                  <div className="flex h-16 w-16 items-center justify-center border-3 border-foreground bg-accent text-xl font-bold">
-                    AJ
-                  </div>
-                  <div>
-                    <p className="font-bold">{leaseDetails.agent.name}</p>
-                    <p className="text-sm text-muted-foreground">
-                      Property Agent
-                    </p>
-                    <div className="mt-1 flex items-center gap-1">
-                      <span className="text-sm font-bold">
-                        {leaseDetails.agent.rating}
-                      </span>
-                      <span className="text-accent">★</span>
-                    </div>
-                  </div>
-                </div>
-                <div className="space-y-2 border-t-2 border-foreground pt-4">
-                  <div className="flex items-center gap-2 text-sm">
-                    <Phone className="h-4 w-4 text-muted-foreground" />
-                    <span>{leaseDetails.agent.phone}</span>
-                  </div>
-                  <div className="flex items-center gap-2 text-sm">
-                    <Mail className="h-4 w-4 text-muted-foreground" />
-                    <span>{leaseDetails.agent.email}</span>
-                  </div>
-                </div>
-                <Link href="/messages">
-                  <Button className="mt-4 w-full border-3 border-foreground bg-secondary font-bold shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
-                    <MessageSquare className="mr-2 h-4 w-4" />
-                    Message Agent
-                  </Button>
-                </Link>
-              </Card>
-
               {/* Landlord */}
               <Card className="border-3 border-foreground p-6 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
                 <h3 className="mb-4 text-lg font-bold">Landlord</h3>

--- a/frontend/app/dashboard/tenant/page.tsx
+++ b/frontend/app/dashboard/tenant/page.tsx
@@ -314,12 +314,12 @@ export default function TenantDashboard() {
                 </p>
 
                 <div className="mt-4 flex items-center gap-3 border-t-2 border-foreground pt-4">
-                  <div className="flex h-10 w-10 items-center justify-center border-2 border-foreground bg-accent font-bold">
-                    {currentLease.agent.avatar}
+                  <div className="flex h-10 w-10 items-center justify-center border-2 border-foreground bg-primary font-bold">
+                    {currentLease.landlord?.name?.charAt(0) || "L"}
                   </div>
                   <div>
-                    <p className="font-bold">{currentLease.agent.name}</p>
-                    <p className="text-sm text-muted-foreground">Your Agent</p>
+                    <p className="font-bold">{currentLease.landlord?.name || "Landlord"}</p>
+                    <p className="text-sm text-muted-foreground">Your Landlord</p>
                   </div>
                   <Link href="/messages" className="ml-auto">
                     <Button

--- a/frontend/lib/mockData/index.ts
+++ b/frontend/lib/mockData/index.ts
@@ -40,23 +40,10 @@ export {
   tenantWhistleblowersToRate,
 } from "./tenant";
 
-// Agent dashboard & applications
-export {
-  agentManagedProperties,
-  agentManagedPropertiesWithMetrics,
-  agentAvailableProperties,
-  agentMyApplications,
-  agentDashboardStats,
-  agentApplications,
-  agentRecentPayouts,
-} from "./agent";
-
-// Landlord dashboard & agents
+// Landlord dashboard
 export {
   landlordMyProperties,
   landlordDashboardStats,
-  landlordMyAgents,
-  landlordAgentsStats,
   landlordProperties,
   landlordTenants,
   landlordPaymentHistory,

--- a/frontend/lib/mockData/leaseData.ts
+++ b/frontend/lib/mockData/leaseData.ts
@@ -7,12 +7,6 @@ export const leaseDetails = {
     baths: 2,
     sqm: 120,
   },
-  agent: {
-    name: "Amina Johnson",
-    rating: 4.8,
-    phone: "+234 801 234 5678",
-    email: "amina.johnson@shelterflex.com",
-  },
   lease: {
     startDate: "Jan 1, 2025",
     endDate: "Dec 31, 2025",

--- a/frontend/lib/mockData/tenant.ts
+++ b/frontend/lib/mockData/tenant.ts
@@ -102,7 +102,7 @@ export const tenantCurrentLease = {
   totalPaid: 1290000,
   totalOwed: 2580000,
   progress: 33,
-  agent: { name: "Adebayo Johnson", avatar: "AJ" },
+  landlord: { name: "Chief Emeka Okonkwo" },
 }
 
 export const tenantDashboardPaymentSchedule: TenantDashboardPaymentItem[] = [

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
- Replace all /dashboard/agent/* routes with deprecation pages
- Remove agent references from tenant pages (lease, dashboard)
- Update tenant contact UI to show landlord instead of agent
- Deprecate landlord agents page with informative message
- Update 'Pending Agent' status to 'Pending' in landlord properties
- Remove agent mock data exports from index.ts
- Remove agent fields from leaseData and tenant mock data
- All agent routes now show deprecation message with links to whistleblower signup

Acceptance Criteria:
✓ No /dashboard/agent/* routes remain functional (all show deprecation) ✓ No agent mock data exports in production UI
✓ Tenant contact UI updated to whistleblower/landlord ✓ Property detail pages use whistleblower and landlord sections ✓ No dead links in navigation
✓ Frontend lint and build pass

<img width="1366" height="736" alt="Screenshot from 2026-02-28 20-43-06" src="https://github.com/user-attachments/assets/62d89624-64e3-4851-929c-57d1efb40b83" />
<img width="1366" height="736" alt="Screenshot from 2026-02-28 20-42-46" src="https://github.com/user-attachments/assets/ab4bcada-8960-4801-84db-d8b6518469ea" />


closes #55 