### PR TITLE
feat: implement reward payout receipt system (closes #51)

### DIFF
--- a/backend/openapi.yml
+++ b/backend/openapi.yml
@@ -583,6 +583,142 @@ paths:
         default:
           $ref: '#/components/responses/Error'
 
+  /api/admin/rewards/{rewardId}/mark-paid:
+    post:
+      summary: Mark reward as paid
+      description: |
+        Mark a whistleblower reward as paid and record receipt on-chain.
+        
+        Rules:
+        - Reward must be in 'payable' status
+        - Creates on-chain receipt with WHISTLEBLOWER_REWARD type
+        - Idempotent by external reference (duplicate refs return same txId)
+        - Receipt contains dealId and listingId
+      operationId: markRewardPaid
+      tags:
+        - Admin
+      parameters:
+        - name: rewardId
+          in: path
+          description: Reward ID
+          required: true
+          schema:
+            type: string
+            format: uuid
+            example: 550e8400-e29b-41d4-a716-446655440000
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MarkRewardPaidRequest'
+      responses:
+        '200':
+          description: Reward marked as paid and receipt written to chain
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - success
+                  - reward
+                  - receipt
+                  - message
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  reward:
+                    type: object
+                    required:
+                      - rewardId
+                      - status
+                    properties:
+                      rewardId:
+                        type: string
+                        format: uuid
+                      status:
+                        type: string
+                        enum: [paid]
+                      paidAt:
+                        type: string
+                        format: date-time
+                      paymentTxId:
+                        type: string
+                        description: Transaction ID on blockchain
+                  receipt:
+                    type: object
+                    required:
+                      - outboxId
+                      - txId
+                      - status
+                    properties:
+                      outboxId:
+                        type: string
+                        format: uuid
+                      txId:
+                        type: string
+                        description: 32-byte transaction ID as hex
+                      status:
+                        type: string
+                        enum: [pending, sent, failed]
+                  message:
+                    type: string
+                    example: Reward marked as paid and receipt written to chain
+        '202':
+          description: Reward marked as paid, receipt queued for retry
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - success
+                  - reward
+                  - receipt
+                  - message
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  reward:
+                    type: object
+                  receipt:
+                    type: object
+                  message:
+                    type: string
+                    example: Reward marked as paid, receipt queued for retry
+        '400':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Reward not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              example:
+                error:
+                  code: NOT_FOUND
+                  message: Reward with ID '550e8400-e29b-41d4-a716-446655440000' not found
+        '409':
+          description: Reward not in payable status
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              example:
+                error:
+                  code: CONFLICT
+                  message: Reward cannot be marked as paid. Current status pending
+                  details:
+                    currentStatus: pending
+                    requiredStatus: payable
+        default:
+          $ref: '#/components/responses/Error'
+
 components:
   schemas:
     PaymentTxType:
@@ -1069,6 +1205,44 @@ components:
           description: Total number of pages
           example: 3
 
+    MarkRewardPaidRequest:
+      type: object
+      required:
+        - amountUsdc
+        - tokenAddress
+        - externalRefSource
+        - externalRef
+      properties:
+        amountUsdc:
+          type: number
+          description: Payment amount in USDC
+          minimum: 0.01
+          example: 100
+        tokenAddress:
+          type: string
+          description: USDC token contract address
+          example: USDC_CONTRACT_ADDRESS
+        externalRefSource:
+          type: string
+          description: Source of external reference (e.g., "stripe", "manual")
+          example: stripe
+        externalRef:
+          type: string
+          description: External payment reference ID
+          example: pi_abc123
+        amountNgn:
+          type: number
+          description: Optional payment amount in Nigerian Naira
+          example: 150000
+        fxRateNgnPerUsdc:
+          type: number
+          description: Optional FX rate (NGN per USDC)
+          example: 1500
+        fxProvider:
+          type: string
+          description: Optional FX rate provider
+          example: coinbase
+
     Error:
       type: object
       required:
@@ -1131,3 +1305,5 @@ tags:
     description: Whistleblower listing operations
   - name: Deals
     description: Deal management and repayment schedule operations
+  - name: Admin
+    description: Administrative operations including reward payouts

--- a/backend/src/models/reward.ts
+++ b/backend/src/models/reward.ts
@@ -1,0 +1,47 @@
+/**
+ * Reward model and types
+ */
+
+export enum RewardStatus {
+  PENDING = 'pending',
+  PAYABLE = 'payable',
+  PAID = 'paid',
+  CANCELLED = 'cancelled',
+}
+
+export interface Reward {
+  rewardId: string
+  whistleblowerId: string
+  dealId: string
+  listingId: string
+  amountUsdc: number
+  status: RewardStatus
+  createdAt: Date
+  updatedAt: Date
+  paidAt?: Date
+  paymentTxId?: string
+  externalRefSource?: string
+  externalRef?: string
+  metadata?: {
+    amountNgn?: number
+    fxRateNgnPerUsdc?: number
+    fxProvider?: string
+  }
+}
+
+export interface CreateRewardInput {
+  whistleblowerId: string
+  dealId: string
+  listingId: string
+  amountUsdc: number
+}
+
+export interface MarkRewardPaidInput {
+  amountUsdc: number
+  tokenAddress: string
+  externalRefSource: string
+  externalRef: string
+  amountNgn?: number
+  fxRateNgnPerUsdc?: number
+  fxProvider?: string
+}

--- a/backend/src/models/rewardStore.ts
+++ b/backend/src/models/rewardStore.ts
@@ -1,0 +1,102 @@
+import { randomUUID } from 'node:crypto'
+import { Reward, RewardStatus, CreateRewardInput } from './reward.js'
+
+/**
+ * In-memory reward store
+ * MVP implementation - designed for easy database migration
+ */
+class RewardStore {
+  private rewards = new Map<string, Reward>()
+
+  /**
+   * Create a new reward
+   */
+  async create(input: CreateRewardInput): Promise<Reward> {
+    const now = new Date()
+    const reward: Reward = {
+      rewardId: randomUUID(),
+      whistleblowerId: input.whistleblowerId,
+      dealId: input.dealId,
+      listingId: input.listingId,
+      amountUsdc: input.amountUsdc,
+      status: RewardStatus.PENDING,
+      createdAt: now,
+      updatedAt: now,
+    }
+
+    this.rewards.set(reward.rewardId, reward)
+    return reward
+  }
+
+  /**
+   * Get reward by ID
+   */
+  async getById(rewardId: string): Promise<Reward | null> {
+    return this.rewards.get(rewardId) ?? null
+  }
+
+  /**
+   * Update reward status to paid
+   */
+  async markAsPaid(
+    rewardId: string,
+    paymentTxId: string,
+    externalRefSource: string,
+    externalRef: string,
+    metadata?: {
+      amountNgn?: number
+      fxRateNgnPerUsdc?: number
+      fxProvider?: string
+    },
+  ): Promise<Reward | null> {
+    const reward = this.rewards.get(rewardId)
+    if (!reward) return null
+
+    reward.status = RewardStatus.PAID
+    reward.paidAt = new Date()
+    reward.updatedAt = new Date()
+    reward.paymentTxId = paymentTxId
+    reward.externalRefSource = externalRefSource
+    reward.externalRef = externalRef
+    
+    if (metadata) {
+      reward.metadata = metadata
+    }
+
+    this.rewards.set(rewardId, reward)
+    return reward
+  }
+
+  /**
+   * Update reward status
+   */
+  async updateStatus(rewardId: string, status: RewardStatus): Promise<Reward | null> {
+    const reward = this.rewards.get(rewardId)
+    if (!reward) return null
+
+    reward.status = status
+    reward.updatedAt = new Date()
+
+    this.rewards.set(rewardId, reward)
+    return reward
+  }
+
+  /**
+   * List all rewards
+   */
+  async listAll(): Promise<Reward[]> {
+    return Array.from(this.rewards.values()).sort(
+      (a, b) => b.createdAt.getTime() - a.createdAt.getTime(),
+    )
+  }
+
+  /**
+   * Clear all data (for testing)
+   */
+  async clear(): Promise<void> {
+    this.rewards.clear()
+  }
+}
+
+// Singleton instance
+export const rewardStore = new RewardStore()

--- a/backend/src/routes/rewards.test.ts
+++ b/backend/src/routes/rewards.test.ts
@@ -1,0 +1,271 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import request from 'supertest'
+import { createApp } from '../app.js'
+import { rewardStore } from '../models/rewardStore.js'
+import { outboxStore } from '../outbox/store.js'
+import { RewardStatus } from '../models/reward.js'
+import { OutboxStatus, TxType } from '../outbox/types.js'
+
+describe('POST /api/admin/rewards/:rewardId/mark-paid', () => {
+  const app = createApp()
+
+  beforeEach(async () => {
+    await rewardStore.clear()
+    await outboxStore.clear()
+  })
+
+  const validMarkPaidRequest = {
+    amountUsdc: 100,
+    tokenAddress: 'USDC_CONTRACT_ADDRESS',
+    externalRefSource: 'stripe',
+    externalRef: 'pi_test123',
+    amountNgn: 150000,
+    fxRateNgnPerUsdc: 1500,
+    fxProvider: 'coinbase',
+  }
+
+  it('should mark a payable reward as paid and create on-chain receipt', async () => {
+    // Create a payable reward
+    const reward = await rewardStore.create({
+      whistleblowerId: 'wb-001',
+      dealId: 'deal-001',
+      listingId: 'listing-001',
+      amountUsdc: 100,
+    })
+    await rewardStore.updateStatus(reward.rewardId, RewardStatus.PAYABLE)
+
+    const response = await request(app)
+      .post(`/api/admin/rewards/${reward.rewardId}/mark-paid`)
+      .send(validMarkPaidRequest)
+
+    expect(response.status).toBeGreaterThanOrEqual(200)
+    expect(response.status).toBeLessThan(300)
+    expect(response.body.success).toBe(true)
+    expect(response.body.reward).toBeDefined()
+    expect(response.body.reward.status).toBe(RewardStatus.PAID)
+    expect(response.body.reward.paidAt).toBeDefined()
+    expect(response.body.reward.paymentTxId).toBeDefined()
+    expect(response.body.receipt).toBeDefined()
+    expect(response.body.receipt.txId).toBeDefined()
+    expect(['pending', 'sent', 'failed']).toContain(response.body.receipt.status)
+  })
+
+  it('should be idempotent when marking paid twice with same external ref', async () => {
+    // Create two payable rewards
+    const reward1 = await rewardStore.create({
+      whistleblowerId: 'wb-001',
+      dealId: 'deal-001',
+      listingId: 'listing-001',
+      amountUsdc: 100,
+    })
+    await rewardStore.updateStatus(reward1.rewardId, RewardStatus.PAYABLE)
+
+    const reward2 = await rewardStore.create({
+      whistleblowerId: 'wb-002',
+      dealId: 'deal-002',
+      listingId: 'listing-002',
+      amountUsdc: 150,
+    })
+    await rewardStore.updateStatus(reward2.rewardId, RewardStatus.PAYABLE)
+
+    // Mark first reward as paid
+    const response1 = await request(app)
+      .post(`/api/admin/rewards/${reward1.rewardId}/mark-paid`)
+      .send(validMarkPaidRequest)
+
+    expect(response1.status).toBeGreaterThanOrEqual(200)
+    expect(response1.status).toBeLessThan(300)
+
+    // Try to mark second reward with same external ref
+    const response2 = await request(app)
+      .post(`/api/admin/rewards/${reward2.rewardId}/mark-paid`)
+      .send(validMarkPaidRequest)
+
+    expect(response2.status).toBeGreaterThanOrEqual(200)
+    expect(response2.status).toBeLessThan(300)
+
+    // Both should have the same txId (idempotent)
+    expect(response1.body.receipt.txId).toBe(response2.body.receipt.txId)
+    expect(response1.body.receipt.outboxId).toBe(response2.body.receipt.outboxId)
+  })
+
+  it('should reject marking non-payable reward as paid', async () => {
+    // Create a pending reward (not payable)
+    const reward = await rewardStore.create({
+      whistleblowerId: 'wb-001',
+      dealId: 'deal-001',
+      listingId: 'listing-001',
+      amountUsdc: 100,
+    })
+
+    const response = await request(app)
+      .post(`/api/admin/rewards/${reward.rewardId}/mark-paid`)
+      .send(validMarkPaidRequest)
+      .expect(409)
+
+    expect(response.body.error).toBeDefined()
+    expect(response.body.error.code).toBe('CONFLICT')
+    expect(response.body.error.message).toContain('cannot be marked as paid')
+    expect(response.body.error.details).toBeDefined()
+    expect(response.body.error.details.currentStatus).toBe(RewardStatus.PENDING)
+    expect(response.body.error.details.requiredStatus).toBe(RewardStatus.PAYABLE)
+  })
+
+  it('should reject marking already paid reward', async () => {
+    // Create and mark reward as paid
+    const reward = await rewardStore.create({
+      whistleblowerId: 'wb-001',
+      dealId: 'deal-001',
+      listingId: 'listing-001',
+      amountUsdc: 100,
+    })
+    await rewardStore.updateStatus(reward.rewardId, RewardStatus.PAYABLE)
+    await rewardStore.markAsPaid(
+      reward.rewardId,
+      'existing-tx-id',
+      'stripe',
+      'pi_existing',
+    )
+
+    const response = await request(app)
+      .post(`/api/admin/rewards/${reward.rewardId}/mark-paid`)
+      .send(validMarkPaidRequest)
+      .expect(409)
+
+    expect(response.body.error).toBeDefined()
+    expect(response.body.error.code).toBe('CONFLICT')
+    expect(response.body.error.details.currentStatus).toBe(RewardStatus.PAID)
+  })
+
+  it('should return 404 for non-existent reward', async () => {
+    const response = await request(app)
+      .post('/api/admin/rewards/non-existent-id/mark-paid')
+      .send(validMarkPaidRequest)
+      .expect(404)
+
+    expect(response.body.error).toBeDefined()
+    expect(response.body.error.code).toBe('NOT_FOUND')
+    expect(response.body.error.message).toContain('not found')
+  })
+
+  it('should reject invalid amount (zero)', async () => {
+    const reward = await rewardStore.create({
+      whistleblowerId: 'wb-001',
+      dealId: 'deal-001',
+      listingId: 'listing-001',
+      amountUsdc: 100,
+    })
+    await rewardStore.updateStatus(reward.rewardId, RewardStatus.PAYABLE)
+
+    const response = await request(app)
+      .post(`/api/admin/rewards/${reward.rewardId}/mark-paid`)
+      .send({
+        ...validMarkPaidRequest,
+        amountUsdc: 0,
+      })
+      .expect(400)
+
+    expect(response.body.error).toBeDefined()
+    expect(response.body.error.code).toBe('VALIDATION_ERROR')
+  })
+
+  it('should reject invalid amount (negative)', async () => {
+    const reward = await rewardStore.create({
+      whistleblowerId: 'wb-001',
+      dealId: 'deal-001',
+      listingId: 'listing-001',
+      amountUsdc: 100,
+    })
+    await rewardStore.updateStatus(reward.rewardId, RewardStatus.PAYABLE)
+
+    const response = await request(app)
+      .post(`/api/admin/rewards/${reward.rewardId}/mark-paid`)
+      .send({
+        ...validMarkPaidRequest,
+        amountUsdc: -100,
+      })
+      .expect(400)
+
+    expect(response.body.error).toBeDefined()
+    expect(response.body.error.code).toBe('VALIDATION_ERROR')
+  })
+
+  it('should reject missing required fields', async () => {
+    const reward = await rewardStore.create({
+      whistleblowerId: 'wb-001',
+      dealId: 'deal-001',
+      listingId: 'listing-001',
+      amountUsdc: 100,
+    })
+    await rewardStore.updateStatus(reward.rewardId, RewardStatus.PAYABLE)
+
+    const response = await request(app)
+      .post(`/api/admin/rewards/${reward.rewardId}/mark-paid`)
+      .send({
+        amountUsdc: 100,
+        // missing tokenAddress, externalRefSource, externalRef
+      })
+      .expect(400)
+
+    expect(response.body.error).toBeDefined()
+    expect(response.body.error.code).toBe('VALIDATION_ERROR')
+  })
+
+  it('should create outbox item with correct payload structure', async () => {
+    const reward = await rewardStore.create({
+      whistleblowerId: 'wb-001',
+      dealId: 'deal-001',
+      listingId: 'listing-001',
+      amountUsdc: 100,
+    })
+    await rewardStore.updateStatus(reward.rewardId, RewardStatus.PAYABLE)
+
+    const response = await request(app)
+      .post(`/api/admin/rewards/${reward.rewardId}/mark-paid`)
+      .send(validMarkPaidRequest)
+
+    expect(response.status).toBeGreaterThanOrEqual(200)
+    expect(response.status).toBeLessThan(300)
+
+    // Verify outbox item was created
+    const outboxItem = await outboxStore.getById(response.body.receipt.outboxId)
+    expect(outboxItem).toBeDefined()
+    expect(outboxItem?.txType).toBe(TxType.WHISTLEBLOWER_REWARD)
+    expect(outboxItem?.payload.dealId).toBe('deal-001')
+    expect(outboxItem?.payload.listingId).toBe('listing-001')
+    expect(outboxItem?.payload.whistleblowerId).toBe('wb-001')
+    expect(outboxItem?.payload.amountUsdc).toBe(100)
+    expect(outboxItem?.payload.tokenAddress).toBe('USDC_CONTRACT_ADDRESS')
+    expect(outboxItem?.payload.amountNgn).toBe(150000)
+    expect(outboxItem?.payload.fxRateNgnPerUsdc).toBe(1500)
+    expect(outboxItem?.payload.fxProvider).toBe('coinbase')
+  })
+
+  it('should handle optional metadata fields', async () => {
+    const reward = await rewardStore.create({
+      whistleblowerId: 'wb-001',
+      dealId: 'deal-001',
+      listingId: 'listing-001',
+      amountUsdc: 100,
+    })
+    await rewardStore.updateStatus(reward.rewardId, RewardStatus.PAYABLE)
+
+    const response = await request(app)
+      .post(`/api/admin/rewards/${reward.rewardId}/mark-paid`)
+      .send({
+        amountUsdc: 100,
+        tokenAddress: 'USDC_CONTRACT_ADDRESS',
+        externalRefSource: 'manual',
+        externalRef: 'manual-payment-001',
+        // No optional metadata
+      })
+
+    expect(response.status).toBeGreaterThanOrEqual(200)
+    expect(response.status).toBeLessThan(300)
+
+    const outboxItem = await outboxStore.getById(response.body.receipt.outboxId)
+    expect(outboxItem?.payload.amountNgn).toBeUndefined()
+    expect(outboxItem?.payload.fxRateNgnPerUsdc).toBeUndefined()
+    expect(outboxItem?.payload.fxProvider).toBeUndefined()
+  })
+})

--- a/backend/src/schemas/reward.ts
+++ b/backend/src/schemas/reward.ts
@@ -1,0 +1,39 @@
+import { z } from 'zod'
+
+/**
+ * Schema for marking a reward as paid
+ */
+export const markRewardPaidSchema = z.object({
+  amountUsdc: z
+    .number()
+    .positive('Amount must be greater than 0')
+    .describe('Payment amount in USDC'),
+  tokenAddress: z
+    .string()
+    .min(1, 'Token address is required')
+    .describe('USDC token contract address'),
+  externalRefSource: z
+    .string()
+    .min(1, 'External reference source is required')
+    .describe('Source of external reference (e.g., "stripe", "manual")'),
+  externalRef: z
+    .string()
+    .min(1, 'External reference is required')
+    .describe('External payment reference ID'),
+  amountNgn: z
+    .number()
+    .positive()
+    .optional()
+    .describe('Optional payment amount in Nigerian Naira'),
+  fxRateNgnPerUsdc: z
+    .number()
+    .positive()
+    .optional()
+    .describe('Optional FX rate (NGN per USDC)'),
+  fxProvider: z
+    .string()
+    .optional()
+    .describe('Optional FX rate provider'),
+})
+
+export type MarkRewardPaidRequest = z.infer<typeof markRewardPaidSchema>


### PR DESCRIPTION
- Add reward model and store with status tracking (pending, payable, paid, cancelled)
- Implement POST /api/admin/rewards/:rewardId/mark-paid endpoint
- Integrate with outbox pattern for on-chain receipt recording
- Add WHISTLEBLOWER_REWARD tx type support
- Implement idempotency by external reference
- Add comprehensive test coverage (10 tests passing)
- Update OpenAPI spec with reward payout endpoint documentation

The endpoint marks rewards as paid and records receipts on-chain with:
- Validation that reward must be in 'payable' status
- Idempotent behavior using canonical external references
- Automatic outbox creation for reliable chain writes
- Support for optional NGN metadata (amount, FX rate, provider)

- closes #51
