### PR TITLE
Feat:Implemented transaction receipt contract

### DIFF
--- a/.kiro/specs/transaction-receipt-contract/design.md
+++ b/.kiro/specs/transaction-receipt-contract/design.md
@@ -1,0 +1,457 @@
+# Design Document: Transaction Receipt Contract
+
+## Overview
+
+The Transaction Receipt Contract is a Soroban smart contract that provides immutable, append-only storage for transaction receipts. The contract enforces strict authorization (admin/operator model), duplicate prevention through deterministic transaction ID generation, and supports audit queries with pagination.
+
+The design prioritizes:
+- **Immutability**: Receipts cannot be modified or deleted once recorded
+- **Idempotency**: Deterministic tx_id generation from external references enables safe retries
+- **Auditability**: Query functions support compliance and financial reconciliation
+- **Authorization**: Role-based access control (admin manages operator, operator records receipts)
+- **Pause capability**: Emergency stop mechanism for operational safety
+
+## Architecture
+
+### Contract Structure
+
+The contract follows a standard Soroban contract pattern with:
+- Storage-based state management using Soroban's persistent storage
+- Function-based interface with clear authorization boundaries
+- Event emission for off-chain indexing and monitoring
+
+### Authorization Model
+
+Two-tier authorization:
+1. **Admin**: Can set operator, pause/unpause contract (set during initialization, immutable)
+2. **Operator**: Can record receipts (can be changed by admin)
+
+This separation allows operational flexibility (rotating operator credentials) while maintaining admin control.
+
+### Storage Strategy
+
+The contract uses three primary storage patterns:
+1. **Singleton values**: admin, operator, paused state
+2. **Key-value mapping**: tx_id → Receipt (for get_receipt)
+3. **Secondary index**: deal_id → list of tx_ids (for list_receipts_by_deal)
+
+## Components and Interfaces
+
+### Core Functions
+
+#### Initialization
+```rust
+fn init(env: Env, admin: Address, operator: Address)
+```
+- Sets admin and operator addresses
+- Initializes paused state to false
+- Can only be called once
+
+#### Authorization Management
+```rust
+fn set_operator(env: Env, new_operator: Address)
+```
+- Requires: caller is admin
+- Updates operator address in storage
+
+#### Pause Control
+```rust
+fn pause(env: Env)
+fn unpause(env: Env)
+```
+- Requires: caller is admin
+- Updates paused state in storage
+
+#### Receipt Recording
+```rust
+fn record_receipt(
+    env: Env,
+    external_ref_source: Symbol,
+    external_ref: String,
+    tx_type: Symbol,
+    amount_usdc: i128,
+    token: Address,
+    deal_id: String,
+    listing_id: Option<String>,
+    from: Option<Address>,
+    to: Option<Address>,
+    amount_ngn: Option<i128>,
+    fx_rate_ngn_per_usdc: Option<i128>,
+    fx_provider: Option<String>,
+    metadata_hash: Option<BytesN<32>>,
+) -> BytesN<32>
+```
+- Requires: caller is operator, contract not paused
+- Validates inputs (positive amount, valid addresses, valid tx_type)
+- Generates tx_id from canonical external reference
+- Checks for duplicate tx_id
+- Stores receipt
+- Emits event
+- Returns tx_id
+
+#### Query Functions
+```rust
+fn get_receipt(env: Env, tx_id: BytesN<32>) -> Option<Receipt>
+```
+- Returns receipt if exists, None otherwise
+- No authorization required (public read)
+
+```rust
+fn list_receipts_by_deal(
+    env: Env,
+    deal_id: String,
+    limit: u32,
+    cursor: Option<u32>,
+) -> Vec<Receipt>
+```
+- Returns receipts for specified deal_id
+- Supports pagination via limit and cursor
+- Returns receipts in deterministic order (by storage order)
+- No authorization required (public read)
+
+### Helper Functions
+
+#### Transaction ID Generation
+```rust
+fn generate_tx_id(
+    external_ref_source: &Symbol,
+    external_ref: &String,
+) -> Result<BytesN<32>, ContractError>
+```
+- Validates external_ref_source against allowed values
+- Validates external_ref (non-empty, no pipes, max 256 chars)
+- Constructs canonical string: "v1|source=<source>|ref=<ref>"
+- Returns SHA-256 hash as tx_id
+
+#### Authorization Checks
+```rust
+fn require_admin(env: &Env, caller: &Address) -> Result<(), ContractError>
+fn require_operator(env: &Env, caller: &Address) -> Result<(), ContractError>
+fn require_not_paused(env: &Env) -> Result<(), ContractError>
+```
+
+## Data Models
+
+### Receipt Structure
+```rust
+#[contracttype]
+pub struct Receipt {
+    pub tx_id: BytesN<32>,
+    pub tx_type: Symbol,
+    pub amount_usdc: i128,
+    pub token: Address,
+    pub deal_id: String,
+    pub listing_id: Option<String>,
+    pub from: Option<Address>,
+    pub to: Option<Address>,
+    pub external_ref: BytesN<32>,  // Same as tx_id
+    pub amount_ngn: Option<i128>,
+    pub fx_rate_ngn_per_usdc: Option<i128>,
+    pub fx_provider: Option<String>,
+    pub metadata_hash: Option<BytesN<32>>,
+    pub timestamp: u64,
+}
+```
+
+### Storage Keys
+```rust
+#[contracttype]
+pub enum StorageKey {
+    Admin,
+    Operator,
+    Paused,
+    Receipt(BytesN<32>),           // tx_id → Receipt
+    DealIndex(String, u32),        // (deal_id, index) → tx_id
+    DealCount(String),             // deal_id → count
+}
+```
+
+### Error Types
+```rust
+#[contracterror]
+pub enum ContractError {
+    AlreadyInitialized = 1,
+    NotAuthorized = 2,
+    ContractPaused = 3,
+    DuplicateTransaction = 4,
+    InvalidAmount = 5,
+    InvalidExternalRefSource = 6,
+    InvalidExternalRef = 7,
+    InvalidTimestamp = 8,
+}
+```
+
+### Allowed External Reference Sources
+```rust
+const ALLOWED_SOURCES: [&str; 7] = [
+    "paystack",
+    "flutterwave",
+    "bank_transfer",
+    "stellar",
+    "onramp",
+    "offramp",
+    "manual_admin",
+];
+```
+
+### Canonical External Reference Format
+```
+v1|source=<external_ref_source>|ref=<external_ref>
+```
+
+Where:
+- `external_ref_source` is lowercased and trimmed
+- `external_ref` is trimmed but case-preserved
+- The entire string is hashed with SHA-256 to produce tx_id
+
+
+## Correctness Properties
+
+A property is a characteristic or behavior that should hold true across all valid executions of a system—essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.
+
+### Property 1: Initialization stores addresses correctly
+*For any* valid admin and operator addresses, after initialization, querying storage should return those exact addresses.
+**Validates: Requirements 1.2**
+
+### Property 2: Single initialization only
+*For any* initialized contract, attempting to call init again should fail with AlreadyInitialized error.
+**Validates: Requirements 1.3**
+
+### Property 3: Receipt storage round-trip
+*For any* valid receipt with all required and optional fields, after recording it, calling get_receipt with its tx_id should return a receipt with identical field values.
+**Validates: Requirements 2.1, 8.1**
+
+### Property 4: Mandatory field validation
+*For any* receipt missing one or more mandatory fields (tx_type, amount_usdc, token, deal_id), the contract should reject it with an appropriate error.
+**Validates: Requirements 2.2**
+
+### Property 5: Optional fields are preserved
+*For any* valid receipt with various combinations of optional fields (listing_id, from, to, amount_ngn, fx_rate_ngn_per_usdc, fx_provider, metadata_hash), after recording and retrieving, all provided optional fields should be preserved exactly.
+**Validates: Requirements 2.3**
+
+### Property 6: Positive amount validation
+*For any* amount_usdc value that is zero or negative, the contract should reject the receipt with InvalidAmount error.
+**Validates: Requirements 2.4**
+
+### Property 7: Duplicate transaction rejection
+*For any* receipt that has been successfully recorded, attempting to record another receipt with the same tx_id should fail with DuplicateTransaction error.
+**Validates: Requirements 3.1**
+
+### Property 8: Transaction ID canonicalization
+*For any* valid external_ref_source and external_ref, the tx_id should be the SHA-256 hash of the canonical string "v1|source=<lowercased_trimmed_source>|ref=<trimmed_ref>".
+**Validates: Requirements 4.1, 4.2**
+
+### Property 9: External reference normalization
+*For any* external_ref_source with different casing or surrounding whitespace, the resulting tx_id should be identical (case-insensitive, whitespace-trimmed). For any external_ref with surrounding whitespace, the tx_id should be the same as the trimmed version, but different casing in external_ref should produce different tx_ids.
+**Validates: Requirements 4.3, 4.4**
+
+### Property 10: External reference source validation
+*For any* external_ref_source value not in the allowed list (paystack, flutterwave, bank_transfer, stellar, onramp, offramp, manual_admin), the contract should reject it with InvalidExternalRefSource error.
+**Validates: Requirements 4.5**
+
+### Property 11: Empty external reference rejection
+*For any* external_ref that is empty or contains only whitespace characters, the contract should reject it with InvalidExternalRef error.
+**Validates: Requirements 4.7**
+
+### Property 12: Pipe character rejection
+*For any* external_ref containing the pipe character (|), the contract should reject it with InvalidExternalRef error.
+**Validates: Requirements 4.8**
+
+### Property 13: External reference length validation
+*For any* external_ref exceeding 256 characters, the contract should reject it with InvalidExternalRef error.
+**Validates: Requirements 4.9**
+
+### Property 14: External ref field equals tx_id
+*For any* successfully recorded receipt, the external_ref field should be equal to the tx_id field (both are the same 32-byte value).
+**Validates: Requirements 4.10**
+
+### Property 15: Operator authorization for recording
+*For any* address that is not the current operator, calling record_receipt should fail with NotAuthorized error. For the operator address (when contract is not paused and inputs are valid), record_receipt should succeed.
+**Validates: Requirements 5.1**
+
+### Property 16: Admin authorization for set_operator
+*For any* address that is not the admin, calling set_operator should fail with NotAuthorized error. For the admin address, set_operator should succeed.
+**Validates: Requirements 5.2**
+
+### Property 17: Admin authorization for pause
+*For any* address that is not the admin, calling pause should fail with NotAuthorized error. For the admin address, pause should succeed.
+**Validates: Requirements 5.3**
+
+### Property 18: Admin authorization for unpause
+*For any* address that is not the admin, calling unpause should fail with NotAuthorized error. For the admin address, unpause should succeed.
+**Validates: Requirements 5.4**
+
+### Property 19: Paused state blocks recording
+*For any* valid receipt and authorized operator, when the contract is paused, calling record_receipt should fail with ContractPaused error.
+**Validates: Requirements 6.2**
+
+### Property 20: Unpause restores recording capability
+*For any* contract that is paused then unpaused, record_receipt should work normally for the operator (assuming valid inputs).
+**Validates: Requirements 6.3**
+
+### Property 21: Pause idempotence
+*For any* contract state, calling pause multiple times should succeed without error, and the contract should remain paused.
+**Validates: Requirements 6.4**
+
+### Property 22: Unpause idempotence
+*For any* contract state, calling unpause multiple times should succeed without error, and the contract should remain unpaused.
+**Validates: Requirements 6.5**
+
+### Property 23: Operator update round-trip
+*For any* valid address, after the admin calls set_operator with that address, subsequent record_receipt calls should only succeed when called by that new address.
+**Validates: Requirements 7.1**
+
+### Property 24: Operator flexibility
+*For any* valid Soroban Address, the admin should be able to set it as the operator successfully.
+**Validates: Requirements 7.3**
+
+### Property 25: Non-existent receipt returns None
+*For any* tx_id that has never been recorded, calling get_receipt should return None.
+**Validates: Requirements 8.2**
+
+### Property 26: Deal-based query returns matching receipts
+*For any* deal_id, all receipts returned by list_receipts_by_deal should have that exact deal_id value.
+**Validates: Requirements 9.1**
+
+### Property 27: Pagination limits results
+*For any* deal_id and limit value, calling list_receipts_by_deal should return at most limit receipts.
+**Validates: Requirements 9.2, 9.4**
+
+### Property 28: Deterministic ordering
+*For any* deal_id, calling list_receipts_by_deal multiple times with the same parameters should return receipts in the same order.
+**Validates: Requirements 9.3**
+
+### Property 29: Cursor-based pagination
+*For any* deal_id and cursor value, receipts returned with the cursor should be a subset of all receipts for that deal, starting after the cursor position.
+**Validates: Requirements 9.5**
+
+### Property 30: Event emission on successful recording
+*For any* successfully recorded receipt, the contract should emit an event with topic ("receipt", tx_id) and payload containing all receipt fields.
+**Validates: Requirements 10.1, 10.2, 10.3**
+
+## Error Handling
+
+### Error Categories
+
+1. **Authorization Errors** (NotAuthorized)
+   - Caller is not admin when admin is required
+   - Caller is not operator when operator is required
+
+2. **State Errors** (ContractPaused, AlreadyInitialized)
+   - Contract is paused when recording receipt
+   - Contract is already initialized when calling init
+
+3. **Validation Errors** (InvalidAmount, InvalidExternalRefSource, InvalidExternalRef, InvalidTimestamp)
+   - Amount is zero or negative
+   - External ref source not in allowed list
+   - External ref is empty, contains pipes, or exceeds 256 chars
+   - Timestamp is invalid (though u64 type provides basic validation)
+
+4. **Business Logic Errors** (DuplicateTransaction)
+   - Attempting to record a receipt with an existing tx_id
+
+### Error Handling Strategy
+
+- All errors should be returned as Result types with descriptive ContractError variants
+- Errors should be checked early (fail fast) before any state modifications
+- Authorization checks should occur before validation checks
+- State checks (paused) should occur before business logic
+- All errors should be propagated to the caller with clear error codes
+
+### Transaction Atomicity
+
+Soroban provides transaction atomicity at the contract call level:
+- If any error occurs during record_receipt, no state changes are persisted
+- This ensures receipts are never partially recorded
+- Duplicate detection is atomic (check and insert are in the same transaction)
+
+## Testing Strategy
+
+### Dual Testing Approach
+
+The contract will use both unit tests and property-based tests for comprehensive coverage:
+
+- **Unit tests**: Verify specific examples, edge cases, and error conditions
+- **Property tests**: Verify universal properties across all inputs using randomized testing
+
+Both approaches are complementary and necessary. Unit tests catch concrete bugs and validate specific scenarios, while property tests verify general correctness across a wide input space.
+
+### Property-Based Testing
+
+We will use **proptest** (Rust property-based testing library) for property tests.
+
+**Configuration**:
+- Each property test should run a minimum of 100 iterations
+- Each test must be tagged with a comment referencing the design property
+- Tag format: `// Feature: transaction-receipt-contract, Property N: <property text>`
+- Each correctness property must be implemented by a single property-based test
+
+**Property Test Coverage**:
+- Canonicalization properties (Properties 8, 9)
+- Validation properties (Properties 4, 6, 10-13)
+- Authorization properties (Properties 15-18)
+- Round-trip properties (Properties 1, 3, 23)
+- Duplicate prevention (Property 7)
+- Pause mechanism (Properties 19-22)
+- Query properties (Properties 25-29)
+- Event emission (Property 30)
+
+### Unit Testing
+
+Unit tests should focus on:
+- Specific examples demonstrating correct behavior
+- Edge cases (empty strings, boundary values, maximum lengths)
+- Error conditions (unauthorized access, invalid inputs)
+- Integration between components (storage, events, authorization)
+
+**Unit Test Coverage**:
+- Initialization scenarios
+- Authorization boundary cases
+- Pause/unpause state transitions
+- Receipt recording with various field combinations
+- Query functions with different data sets
+- Error handling for all error types
+
+### Test Organization
+
+```
+tests/
+├── unit/
+│   ├── initialization.rs
+│   ├── authorization.rs
+│   ├── pause.rs
+│   ├── receipt_recording.rs
+│   ├── queries.rs
+│   └── errors.rs
+└── property/
+    ├── canonicalization.rs
+    ├── validation.rs
+    ├── authorization.rs
+    ├── round_trip.rs
+    ├── duplicate_prevention.rs
+    └── queries.rs
+```
+
+### Testing Tools
+
+- **Soroban SDK test utilities**: For contract testing environment
+- **proptest**: For property-based testing with random input generation
+- **Rust standard test framework**: For unit tests
+
+### Test Data Generation
+
+For property tests, we need generators for:
+- Random addresses (admin, operator, from, to)
+- Random external references (valid and invalid)
+- Random external reference sources (valid and invalid)
+- Random amounts (positive, zero, negative)
+- Random strings (deal_id, listing_id, fx_provider)
+- Random optional fields (Some/None combinations)
+- Random timestamps
+
+### Continuous Integration
+
+All tests (unit and property) should run on every commit:
+- Cargo test should execute all tests
+- Property tests should use a fixed seed for reproducibility in CI
+- Test coverage should be measured and tracked

--- a/.kiro/specs/transaction-receipt-contract/requirements.md
+++ b/.kiro/specs/transaction-receipt-contract/requirements.md
@@ -1,0 +1,159 @@
+# Requirements Document: Transaction Receipt Contract
+
+## Introduction
+
+The Transaction Receipt Contract is a Soroban smart contract that provides immutable, auditable storage for all money movements in the Sheltaflex hybrid system. Every transaction must be recorded on-chain with standardized USDC amounts, while NGN values serve as metadata only. The contract enforces strict duplicate prevention through deterministic transaction ID generation and provides query capabilities for audit purposes.
+
+## Glossary
+
+- **Contract**: The Soroban smart contract that stores transaction receipts
+- **Receipt**: An immutable record of a single money movement transaction
+- **Operator**: The authorized address that can record new receipts
+- **Admin**: The address with authority to manage the operator and pause state
+- **tx_id**: A unique 32-byte identifier derived from external payment references
+- **USDC**: The canonical token for all transaction amounts (referenced by Soroban Address)
+- **NGN**: Nigerian Naira, stored as metadata only for reference
+- **Canonical_External_Ref**: A deterministic string format for external payment references
+- **Deal**: A business entity in Sheltaflex (e.g., rental agreement)
+- **Listing**: A property listing in Sheltaflex
+
+## Requirements
+
+### Requirement 1: Initialize Contract
+
+**User Story:** As a system deployer, I want to initialize the contract with admin and operator addresses, so that the contract is ready for authorized use.
+
+#### Acceptance Criteria
+
+1. THE Contract SHALL accept an admin address and operator address during initialization
+2. WHEN initialization is complete, THE Contract SHALL store both addresses in contract storage
+3. THE Contract SHALL only allow initialization once (prevent re-initialization)
+
+### Requirement 2: Receipt Storage
+
+**User Story:** As an operator, I want to record transaction receipts with complete transaction details, so that all money movements are permanently tracked on-chain.
+
+#### Acceptance Criteria
+
+1. WHEN a valid receipt is submitted, THE Contract SHALL store all receipt fields in contract storage
+2. THE Contract SHALL require the following mandatory fields: tx_id, tx_type, amount_usdc, token, deal_id, timestamp
+3. THE Contract SHALL accept the following optional fields: listing_id, from, to, amount_ngn, fx_rate_ngn_per_usdc, fx_provider, metadata_hash
+4. THE Contract SHALL validate that amount_usdc is positive (greater than zero)
+5. THE Contract SHALL validate that token is a valid Soroban Address
+6. THE Contract SHALL validate that tx_type is a valid Symbol
+7. THE Contract SHALL validate that timestamp is a valid u64 value
+
+### Requirement 3: Duplicate Prevention
+
+**User Story:** As a system architect, I want the contract to reject duplicate transaction IDs, so that the same payment cannot be recorded twice.
+
+#### Acceptance Criteria
+
+1. WHEN a receipt with an existing tx_id is submitted, THE Contract SHALL reject the submission with a clear error
+2. THE Contract SHALL maintain a mapping of tx_id to receipt for duplicate detection
+3. THE Contract SHALL never overwrite an existing receipt
+
+### Requirement 4: Transaction ID Canonicalization
+
+**User Story:** As a backend developer, I want deterministic transaction ID generation from external payment references, so that retries are safe and idempotent.
+
+#### Acceptance Criteria
+
+1. THE Contract SHALL derive tx_id as SHA-256 hash of the canonical external reference string
+2. THE Contract SHALL use the format "v1|source=<external_ref_source>|ref=<external_ref>" for canonical strings
+3. THE Contract SHALL lowercase and trim the external_ref_source value
+4. THE Contract SHALL trim the external_ref value while preserving case
+5. THE Contract SHALL accept only these external_ref_source values: paystack, flutterwave, bank_transfer, stellar, onramp, offramp, manual_admin
+6. WHEN external_ref_source is missing or invalid, THE Contract SHALL reject the input
+7. WHEN external_ref is missing or empty after trimming, THE Contract SHALL reject the input
+8. WHEN external_ref contains the pipe character (|), THE Contract SHALL reject the input
+9. WHEN external_ref exceeds 256 characters, THE Contract SHALL reject the input
+10. THE Contract SHALL set external_ref field equal to tx_id (same 32 bytes)
+
+### Requirement 5: Authorization and Access Control
+
+**User Story:** As an admin, I want to control who can record receipts and manage contract state, so that only authorized parties can modify the ledger.
+
+#### Acceptance Criteria
+
+1. WHEN record_receipt is called, THE Contract SHALL verify the caller is the current operator
+2. WHEN set_operator is called, THE Contract SHALL verify the caller is the admin
+3. WHEN pause is called, THE Contract SHALL verify the caller is the admin
+4. WHEN unpause is called, THE Contract SHALL verify the caller is the admin
+5. WHEN an unauthorized address attempts a restricted operation, THE Contract SHALL reject with an authorization error
+
+### Requirement 6: Pause Mechanism
+
+**User Story:** As an admin, I want to pause and unpause receipt recording, so that I can halt operations during emergencies or maintenance.
+
+#### Acceptance Criteria
+
+1. THE Contract SHALL maintain a boolean pause state in storage
+2. WHEN the contract is paused, THE Contract SHALL reject all record_receipt calls
+3. WHEN the contract is unpaused, THE Contract SHALL accept record_receipt calls from the operator
+4. WHEN pause is called while already paused, THE Contract SHALL succeed without error
+5. WHEN unpause is called while already unpaused, THE Contract SHALL succeed without error
+
+### Requirement 7: Operator Management
+
+**User Story:** As an admin, I want to update the operator address, so that I can rotate credentials or change authorized parties.
+
+#### Acceptance Criteria
+
+1. WHEN set_operator is called with a valid address, THE Contract SHALL update the operator in storage
+2. WHEN set_operator is called, THE Contract SHALL verify the caller is the admin
+3. THE Contract SHALL allow setting the operator to any valid Soroban Address
+
+### Requirement 8: Receipt Retrieval
+
+**User Story:** As an auditor, I want to retrieve a specific receipt by transaction ID, so that I can verify individual transactions.
+
+#### Acceptance Criteria
+
+1. WHEN get_receipt is called with a valid tx_id, THE Contract SHALL return the complete receipt if it exists
+2. WHEN get_receipt is called with a non-existent tx_id, THE Contract SHALL return None
+3. THE Contract SHALL return all stored fields for the receipt
+
+### Requirement 9: Deal-Based Query
+
+**User Story:** As an auditor, I want to list all receipts for a specific deal with pagination, so that I can review all transactions related to a business entity.
+
+#### Acceptance Criteria
+
+1. WHEN list_receipts_by_deal is called, THE Contract SHALL return receipts matching the specified deal_id
+2. THE Contract SHALL support pagination through limit and cursor parameters
+3. THE Contract SHALL return receipts in a deterministic order
+4. WHEN limit is specified, THE Contract SHALL return at most that many receipts
+5. WHEN cursor is provided, THE Contract SHALL return receipts starting after that cursor position
+
+### Requirement 10: Event Emission
+
+**User Story:** As a backend system, I want the contract to emit events when receipts are recorded, so that I can monitor and index transactions off-chain.
+
+#### Acceptance Criteria
+
+1. WHEN a receipt is successfully recorded, THE Contract SHALL emit an event
+2. THE Contract SHALL include the topic ("receipt", tx_id) in the emitted event
+3. THE Contract SHALL include the complete receipt data in the event payload
+
+### Requirement 11: USDC Canonicalization
+
+**User Story:** As a system architect, I want USDC to be the canonical amount representation, so that all financial calculations use a consistent standard.
+
+#### Acceptance Criteria
+
+1. THE Contract SHALL store amount_usdc as the primary transaction amount
+2. THE Contract SHALL store the USDC token contract Address in the token field
+3. THE Contract SHALL treat amount_ngn as optional metadata only
+4. THE Contract SHALL treat fx_rate_ngn_per_usdc as optional metadata only
+5. THE Contract SHALL treat fx_provider as optional metadata only
+
+### Requirement 12: Metadata Integrity
+
+**User Story:** As a compliance officer, I want optional cryptographic verification of receipt payloads, so that I can detect tampering or corruption.
+
+#### Acceptance Criteria
+
+1. THE Contract SHALL accept an optional metadata_hash field
+2. WHEN metadata_hash is provided, THE Contract SHALL store it as a BytesN<32>
+3. THE Contract SHALL document that metadata_hash represents SHA-256 of canonical receipt payload v1

--- a/.kiro/specs/transaction-receipt-contract/tasks.md
+++ b/.kiro/specs/transaction-receipt-contract/tasks.md
@@ -1,0 +1,274 @@
+# Implementation Plan: Transaction Receipt Contract
+
+## Overview
+
+This implementation plan breaks down the Transaction Receipt Contract into discrete coding tasks. The contract will be implemented as a Soroban smart contract in Rust, with comprehensive property-based testing using proptest and unit tests for specific scenarios.
+
+The implementation follows an incremental approach:
+1. Set up project structure and core types
+2. Implement transaction ID generation and validation
+3. Implement core contract functions (init, authorization, pause)
+4. Implement receipt recording with validation
+5. Implement query functions
+6. Add comprehensive testing
+7. Final integration and documentation
+
+## Tasks
+
+- [-] 1. Set up project structure and core types
+  - Create Soroban contract project structure in contracts/transaction-receipt-contract
+  - Define Receipt struct with all required and optional fields
+  - Define StorageKey enum for all storage patterns
+  - Define ContractError enum with all error variants
+  - Define constants (ALLOWED_SOURCES array)
+  - Set up test dependencies (proptest, soroban-sdk test utilities)
+  - _Requirements: 2.1, 2.2, 2.3, 4.5_
+
+- [x] 2. Implement transaction ID generation and canonicalization
+  - [x] 2.1 Implement generate_tx_id helper function
+    - Validate external_ref_source against ALLOWED_SOURCES
+    - Validate external_ref (non-empty after trim, no pipes, max 256 chars)
+    - Construct canonical string: "v1|source=<lowercased_trimmed_source>|ref=<trimmed_ref>"
+    - Compute SHA-256 hash and return as BytesN<32>
+    - _Requirements: 4.1, 4.2, 4.3, 4.4, 4.5, 4.7, 4.8, 4.9_
+  
+  - [ ]* 2.2 Write property test for canonicalization
+    - **Property 8: Transaction ID canonicalization**
+    - **Validates: Requirements 4.1, 4.2**
+  
+  - [ ]* 2.3 Write property test for normalization
+    - **Property 9: External reference normalization**
+    - **Validates: Requirements 4.3, 4.4**
+  
+  - [ ]* 2.4 Write property tests for validation
+    - **Property 10: External reference source validation**
+    - **Property 11: Empty external reference rejection**
+    - **Property 12: Pipe character rejection**
+    - **Property 13: External reference length validation**
+    - **Validates: Requirements 4.5, 4.7, 4.8, 4.9**
+  
+  - [ ]* 2.5 Write unit tests for edge cases
+    - Test boundary conditions (exactly 256 chars, 257 chars)
+    - Test each allowed source value
+    - Test various invalid source values
+    - Test whitespace handling (leading, trailing, internal)
+    - _Requirements: 4.1-4.9_
+
+- [x] 3. Checkpoint - Ensure canonicalization tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [x] 4. Implement authorization helper functions
+  - [x] 4.1 Implement require_admin function
+    - Load admin from storage
+    - Compare caller with admin
+    - Return NotAuthorized error if mismatch
+    - _Requirements: 5.2, 5.3, 5.4_
+  
+  - [x] 4.2 Implement require_operator function
+    - Load operator from storage
+    - Compare caller with operator
+    - Return NotAuthorized error if mismatch
+    - _Requirements: 5.1_
+  
+  - [x] 4.3 Implement require_not_paused function
+    - Load paused state from storage
+    - Return ContractPaused error if paused
+    - _Requirements: 6.2_
+  
+  - [ ]* 4.4 Write property tests for authorization
+    - **Property 15: Operator authorization for recording**
+    - **Property 16: Admin authorization for set_operator**
+    - **Property 17: Admin authorization for pause**
+    - **Property 18: Admin authorization for unpause**
+    - **Validates: Requirements 5.1, 5.2, 5.3, 5.4**
+  
+  - [ ]* 4.5 Write unit tests for authorization edge cases
+    - Test with uninitialized contract
+    - Test with various unauthorized addresses
+    - _Requirements: 5.1-5.4_
+
+- [x] 5. Implement initialization function
+  - [x] 5.1 Implement init function
+    - Check if already initialized (AlreadyInitialized error)
+    - Store admin address
+    - Store operator address
+    - Initialize paused state to false
+    - _Requirements: 1.1, 1.2, 1.3_
+  
+  - [ ]* 5.2 Write property test for initialization
+    - **Property 1: Initialization stores addresses correctly**
+    - **Property 2: Single initialization only**
+    - **Validates: Requirements 1.2, 1.3**
+  
+  - [ ]* 5.3 Write unit tests for initialization
+    - Test successful initialization
+    - Test double initialization attempt
+    - Test storage verification
+    - _Requirements: 1.1, 1.2, 1.3_
+
+- [~] 6. Implement pause mechanism
+  - [x] 6.1 Implement pause and unpause functions
+    - Add require_admin check
+    - Update paused state in storage
+    - Handle idempotent behavior (pause when paused, unpause when unpaused)
+    - _Requirements: 6.1, 6.2, 6.3, 6.4, 6.5_
+  
+  - [ ]* 6.2 Write property tests for pause mechanism
+    - **Property 19: Paused state blocks recording**
+    - **Property 20: Unpause restores recording capability**
+    - **Property 21: Pause idempotence**
+    - **Property 22: Unpause idempotence**
+    - **Validates: Requirements 6.2, 6.3, 6.4, 6.5**
+  
+  - [ ]* 6.3 Write unit tests for pause transitions
+    - Test pause → unpause → pause sequences
+    - Test recording attempts while paused
+    - _Requirements: 6.2, 6.3, 6.4, 6.5_
+
+- [~] 7. Implement operator management
+  - [x] 7.1 Implement set_operator function
+    - Add require_admin check
+    - Update operator address in storage
+    - _Requirements: 7.1, 7.2, 7.3_
+  
+  - [ ]* 7.2 Write property tests for operator management
+    - **Property 23: Operator update round-trip**
+    - **Property 24: Operator flexibility**
+    - **Validates: Requirements 7.1, 7.3**
+  
+  - [ ]* 7.3 Write unit tests for operator changes
+    - Test operator rotation scenarios
+    - Test authorization after operator change
+    - _Requirements: 7.1, 7.3_
+
+- [~] 8. Checkpoint - Ensure core functions pass tests
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [~] 9. Implement receipt recording function
+  - [x] 9.1 Implement record_receipt function
+    - Add require_operator check
+    - Add require_not_paused check
+    - Validate amount_usdc is positive (InvalidAmount error)
+    - Call generate_tx_id to get tx_id
+    - Check for duplicate tx_id (DuplicateTransaction error)
+    - Create Receipt struct with all fields (set external_ref = tx_id, timestamp = current ledger timestamp)
+    - Store receipt in storage (Receipt key)
+    - Update deal index (DealIndex and DealCount keys)
+    - Emit event with topic ("receipt", tx_id) and receipt payload
+    - Return tx_id
+    - _Requirements: 2.1, 2.2, 2.3, 2.4, 3.1, 4.10, 5.1, 6.2, 10.1, 10.2, 10.3_
+  
+  - [ ]* 9.2 Write property test for receipt round-trip
+    - **Property 3: Receipt storage round-trip**
+    - **Property 5: Optional fields are preserved**
+    - **Property 14: External ref field equals tx_id**
+    - **Validates: Requirements 2.1, 2.3, 4.10**
+  
+  - [ ]* 9.3 Write property test for validation
+    - **Property 4: Mandatory field validation**
+    - **Property 6: Positive amount validation**
+    - **Validates: Requirements 2.2, 2.4**
+  
+  - [ ]* 9.4 Write property test for duplicate prevention
+    - **Property 7: Duplicate transaction rejection**
+    - **Validates: Requirements 3.1**
+  
+  - [ ]* 9.5 Write property test for event emission
+    - **Property 30: Event emission on successful recording**
+    - **Validates: Requirements 10.1, 10.2, 10.3**
+  
+  - [ ]* 9.6 Write unit tests for receipt recording
+    - Test with various tx_type values
+    - Test with all optional fields present
+    - Test with no optional fields
+    - Test with various combinations of optional fields
+    - Test error cases (zero amount, negative amount, duplicate)
+    - _Requirements: 2.1-2.7, 3.1, 4.10, 10.1-10.3_
+
+- [~] 10. Implement query functions
+  - [x] 10.1 Implement get_receipt function
+    - Load receipt from storage using tx_id
+    - Return Some(receipt) if exists, None otherwise
+    - _Requirements: 8.1, 8.2, 8.3_
+  
+  - [x] 10.2 Implement list_receipts_by_deal function
+    - Load deal count from storage
+    - Calculate start index from cursor (default 0)
+    - Calculate end index from start + limit (capped at deal count)
+    - Iterate through DealIndex keys to load tx_ids
+    - Load receipts for each tx_id
+    - Return vector of receipts
+    - _Requirements: 9.1, 9.2, 9.3, 9.4, 9.5_
+  
+  - [ ]* 10.3 Write property tests for queries
+    - **Property 25: Non-existent receipt returns None**
+    - **Property 26: Deal-based query returns matching receipts**
+    - **Property 27: Pagination limits results**
+    - **Property 28: Deterministic ordering**
+    - **Property 29: Cursor-based pagination**
+    - **Validates: Requirements 8.2, 9.1, 9.2, 9.3, 9.4, 9.5**
+  
+  - [ ]* 10.4 Write unit tests for query edge cases
+    - Test get_receipt with non-existent tx_id
+    - Test list_receipts_by_deal with no receipts
+    - Test list_receipts_by_deal with limit > total receipts
+    - Test list_receipts_by_deal with cursor at end
+    - Test list_receipts_by_deal with multiple deals
+    - _Requirements: 8.1, 8.2, 9.1-9.5_
+
+- [-] 11. Checkpoint - Ensure all core functionality tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [~] 12. Integration and final testing
+  - [-] 12.1 Write integration tests
+    - Test complete workflow: init → record multiple receipts → query
+    - Test authorization flow: init → set_operator → record with new operator
+    - Test pause flow: init → record → pause → attempt record → unpause → record
+    - Test deal queries with multiple receipts per deal
+    - Test pagination across multiple pages
+    - _Requirements: All requirements_
+  
+  - [ ]* 12.2 Write property test for complex scenarios
+    - Generate random sequences of operations (record, query, pause, unpause, set_operator)
+    - Verify contract invariants hold after each operation
+    - _Requirements: All requirements_
+  
+  - [~] 12.3 Review test coverage
+    - Ensure all 30 correctness properties have corresponding tests
+    - Ensure all error conditions are tested
+    - Ensure all acceptance criteria are covered
+    - _Requirements: All requirements_
+
+- [ ]* 13. Documentation and README
+  - [ ]* 13.1 Write comprehensive README
+    - Document contract purpose and features
+    - Document initialization process
+    - Document all functions with parameters and return values
+    - Document error codes and meanings
+    - Document canonical external reference format
+    - Document metadata_hash format (SHA-256 of canonical receipt payload v1)
+    - Provide usage examples
+    - Document testing approach
+    - _Requirements: 12.3_
+  
+  - [ ]* 13.2 Add inline code documentation
+    - Add rustdoc comments to all public functions
+    - Add rustdoc comments to all types (Receipt, StorageKey, ContractError)
+    - Add examples in documentation
+    - _Requirements: All requirements_
+
+- [~] 14. Final checkpoint - Ensure all tests pass
+  - Run cargo test to verify all unit and property tests pass
+  - Verify test coverage meets requirements
+  - Ask the user if questions arise or if ready for deployment
+
+## Notes
+
+- Tasks marked with `*` are optional and can be skipped for faster MVP
+- Each task references specific requirements for traceability
+- Property tests should run minimum 100 iterations each
+- All property tests must be tagged with comments referencing design properties
+- Checkpoints ensure incremental validation and provide opportunities for user feedback
+- The contract uses Soroban SDK storage patterns and event emission
+- Testing uses proptest for property-based tests and standard Rust test framework for unit tests
+ 

--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -24,6 +24,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "arbitrary"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -147,7 +153,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -179,6 +185,27 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitflags"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "block-buffer"
@@ -274,7 +301,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -499,7 +526,7 @@ checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
  "sha2",
  "subtle",
@@ -524,7 +551,7 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
@@ -535,6 +562,16 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
 
 [[package]]
 name = "escape-bytes"
@@ -549,12 +586,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
 
 [[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "ff"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -575,6 +618,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "generic-array"
@@ -601,13 +650,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -628,9 +702,24 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hex"
@@ -679,6 +768,12 @@ checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "ident_case"
@@ -762,6 +857,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -772,6 +873,12 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
@@ -908,6 +1015,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -917,14 +1049,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -934,7 +1082,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -943,7 +1101,25 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -965,6 +1141,12 @@ dependencies = [
  "quote",
  "syn 2.0.116",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rent_payments"
@@ -1000,10 +1182,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "schemars"
@@ -1156,7 +1363,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1193,7 +1400,7 @@ dependencies = [
  "soroban-wasmi",
  "static_assertions",
  "stellar-xdr",
- "wasmparser",
+ "wasmparser 0.116.1",
 ]
 
 [[package]]
@@ -1221,7 +1428,7 @@ dependencies = [
  "ed25519-dalek",
  "elliptic-curve",
  "generic-array",
- "getrandom",
+ "getrandom 0.2.17",
  "hex-literal",
  "hmac",
  "k256",
@@ -1229,8 +1436,8 @@ dependencies = [
  "num-integer",
  "num-traits",
  "p256",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "sec1",
  "sha2",
  "sha3",
@@ -1239,7 +1446,7 @@ dependencies = [
  "soroban-wasmi",
  "static_assertions",
  "stellar-strkey",
- "wasmparser",
+ "wasmparser 0.116.1",
 ]
 
 [[package]]
@@ -1282,7 +1489,7 @@ dependencies = [
  "ctor",
  "derive_arbitrary",
  "ed25519-dalek",
- "rand",
+ "rand 0.8.5",
  "rustc_version",
  "serde",
  "serde_json",
@@ -1322,7 +1529,7 @@ dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
  "thiserror",
- "wasmparser",
+ "wasmparser 0.116.1",
 ]
 
 [[package]]
@@ -1438,6 +1645,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.1",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1489,10 +1709,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "transaction-receipt-contract"
+version = "0.1.0"
+dependencies = [
+ "proptest",
+ "soroban-sdk",
+]
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
@@ -1501,16 +1735,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -1558,6 +1825,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.244.0",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.13.0",
+ "wasm-encoder",
+ "wasmparser 0.244.0",
+]
+
+[[package]]
 name = "wasmi_arena"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1581,6 +1870,18 @@ version = "0.116.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a58e28b80dd8340cb07b8242ae654756161f6fc8d0038123d679b7b99964fa50"
 dependencies = [
+ "indexmap 2.13.0",
+ "semver",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
  "indexmap 2.13.0",
  "semver",
 ]
@@ -1651,6 +1952,103 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap 2.13.0",
+ "prettyplease",
+ "syn 2.0.116",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.116",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap 2.13.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser 0.244.0",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.13.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.244.0",
 ]
 
 [[package]]

--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -3,4 +3,5 @@ resolver = "2"
 members = [
   "rent_wallet",
   "rent_payments",
+  "transaction-receipt-contract",
 ]

--- a/contracts/transaction-receipt-contract/Cargo.toml
+++ b/contracts/transaction-receipt-contract/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "transaction-receipt-contract"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.7"
+
+[dev-dependencies]
+soroban-sdk = { version = "22.0.7", features = ["testutils"] }
+proptest = "1.4"

--- a/contracts/transaction-receipt-contract/README.md
+++ b/contracts/transaction-receipt-contract/README.md
@@ -1,0 +1,84 @@
+# Transaction Receipt Contract
+
+This Soroban smart contract records immutable transaction receipts keyed by a deterministic transaction ID derived from an external payment reference.
+
+## Purpose
+
+- Record canonical transaction receipts for on-chain indexing and audit.
+- Prevent duplicate receipts using a deterministic tx_id derived from external payment references.
+- Provide query APIs to fetch receipts and list receipts by deal with pagination.
+
+## Initialization
+
+Call `init(admin: Address, operator: Address)` once to initialize the contract. This stores the `admin` (manages operator and pause) and `operator` (records receipts) addresses and sets the paused state to `false`.
+
+Attempting to `init` a second time returns `AlreadyInitialized`.
+
+## Public API
+
+- `init(env, admin, operator) -> Result<(), ContractError>`: initialize contract.
+- `pause(env, admin) -> Result<(), ContractError>`: pause recording (admin only).
+- `unpause(env, admin) -> Result<(), ContractError>`: unpause (admin only).
+- `set_operator(env, admin, new_operator) -> Result<(), ContractError>`: update operator (admin only).
+- `record_receipt(env, operator, input: ReceiptInput) -> Result<BytesN<32>, ContractError>`: record a transaction receipt (operator only, rejects duplicates or invalid input).
+- `get_receipt(env, tx_id: BytesN<32>) -> Option<Receipt>`: fetch a receipt by tx_id.
+- `list_receipts_by_deal(env, deal_id: String, limit: u32, cursor: Option<u32>) -> Vec<Receipt>`: list receipts for a deal with pagination.
+
+## ReceiptInput and Receipt
+
+`ReceiptInput` contains all fields required to record a receipt, including `external_ref_source`, `external_ref`, `tx_type`, `amount_usdc`, `token`, `deal_id`, and optional metadata fields.
+
+`Receipt` is the stored, immutable representation returned by queries and emitted in events. The `external_ref` field in `Receipt` equals the `tx_id` (SHA-256 of canonicalized external ref) per contract design.
+
+## Transaction ID canonicalization
+
+Canonical format: `v1|source=<lowercased_trimmed_source>|ref=<trimmed_ref>`
+
+Validation rules:
+- `external_ref_source` must be one of the allowed sources: `paystack`, `flutterwave`, `bank_transfer`, `stellar`, `onramp`, `offramp`, `manual_admin` (case-insensitive).
+- `external_ref` is trimmed of whitespace and must be non-empty, must not contain the pipe character `|`, and must be at most 256 characters.
+
+The canonical string is SHA-256 hashed to produce a 32-byte `tx_id` (type `BytesN<32>`).
+
+## Metadata hash
+
+`metadata_hash` is optional and expected to be the SHA-256 hash of the canonical receipt payload (v1). The contract stores it as `BytesN<32>` if provided; generation of this hash is the caller's responsibility.
+
+## Error codes
+
+The contract exposes the following `ContractError` variants (numeric values shown in tests):
+
+- `AlreadyInitialized` (1)
+- `NotAuthorized` (2)
+- `ContractPaused` (3)
+- `DuplicateTransaction` (4)
+- `InvalidAmount` (5)
+- `InvalidExternalRefSource` (6)
+- `InvalidExternalRef` (7)
+- `InvalidTimestamp` (8)
+
+## Events
+
+On successful `record_receipt`, the contract emits an event with topic `("receipt", tx_id)` and the `Receipt` payload.
+
+## Usage examples (testing harness)
+
+The `src/test.rs` and `src/integration_tests.rs` files contain examples of how to call the contract from the Soroban test environment (`Env`). Examples include initialization, recording receipts, and querying.
+
+## Testing
+
+Run the contract tests with:
+
+```bash
+cargo test --manifest-path monorepo/contracts/transaction-receipt-contract/Cargo.toml
+```
+
+The project includes unit tests and integration-style tests that cover canonicalization, authorization, pause/unpause, duplicate prevention, and pagination.
+
+Property-based tests are described in the design spec and can be added using `proptest` where necessary. Current tests validate the core behaviors and invariants.
+
+## Notes
+
+- The contract uses Soroban SDK storage patterns and event emission.
+- The caller is responsible for generating `metadata_hash` if desired.
+- The contract enforces deterministic tx_id generation to prevent duplicates originating from the same external reference.

--- a/contracts/transaction-receipt-contract/src/integration_tests.rs
+++ b/contracts/transaction-receipt-contract/src/integration_tests.rs
@@ -1,0 +1,254 @@
+#![cfg(test)]
+
+extern crate alloc;
+use alloc::format;
+use crate::{
+	ReceiptInput, TransactionReceiptContract, TransactionReceiptContractClient, ContractError,
+};
+use soroban_sdk::{testutils::Address as _, Address, Env, String, Symbol};
+
+// Integration: init -> record multiple receipts -> query
+#[test]
+fn test_integration_init_record_query() {
+	let env = Env::default();
+	let contract_id = env.register(TransactionReceiptContract, ());
+	let client = TransactionReceiptContractClient::new(&env, &contract_id);
+
+	let admin = Address::generate(&env);
+	let operator = Address::generate(&env);
+
+	client.try_init(&admin, &operator).unwrap();
+
+	// Allow require_auth to succeed for our mock calls
+	env.mock_all_auths();
+
+	let token = Address::generate(&env);
+
+	// Record two receipts for deal "dealA" and one for "dealB"
+	let deal_a = String::from_str(&env, "dealA");
+	let deal_b = String::from_str(&env, "dealB");
+
+	let input_a1 = ReceiptInput {
+		external_ref_source: Symbol::new(&env, "manual_admin"),
+		external_ref: String::from_str(&env, "a_ref_1"),
+		tx_type: Symbol::new(&env, "rent_payment"),
+		amount_usdc: 1_000_0000000i128,
+		token: token.clone(),
+		deal_id: deal_a.clone(),
+		listing_id: None,
+		from: None,
+		to: None,
+		amount_ngn: None,
+		fx_rate_ngn_per_usdc: None,
+		fx_provider: None,
+		metadata_hash: None,
+	};
+
+	let input_a2 = ReceiptInput {
+		external_ref_source: Symbol::new(&env, "manual_admin"),
+		external_ref: String::from_str(&env, "a_ref_2"),
+		tx_type: Symbol::new(&env, "rent_payment"),
+		amount_usdc: 2_000_0000000i128,
+		token: token.clone(),
+		deal_id: deal_a.clone(),
+		listing_id: None,
+		from: None,
+		to: None,
+		amount_ngn: None,
+		fx_rate_ngn_per_usdc: None,
+		fx_provider: None,
+		metadata_hash: None,
+	};
+
+	let input_b1 = ReceiptInput {
+		external_ref_source: Symbol::new(&env, "manual_admin"),
+		external_ref: String::from_str(&env, "b_ref_1"),
+		tx_type: Symbol::new(&env, "rent_payment"),
+		amount_usdc: 3_000_0000000i128,
+		token: token.clone(),
+		deal_id: deal_b.clone(),
+		listing_id: None,
+		from: None,
+		to: None,
+		amount_ngn: None,
+		fx_rate_ngn_per_usdc: None,
+		fx_provider: None,
+		metadata_hash: None,
+	};
+
+	let tx_a1 = client.try_record_receipt(&operator, &input_a1).unwrap().unwrap();
+	let tx_a2 = client.try_record_receipt(&operator, &input_a2).unwrap().unwrap();
+	let tx_b1 = client.try_record_receipt(&operator, &input_b1).unwrap().unwrap();
+
+	// Query by tx id
+	let got_a1 = client.get_receipt(&tx_a1);
+	assert!(got_a1.is_some());
+	let got = got_a1.unwrap();
+	assert_eq!(got.tx_id, tx_a1);
+	assert_eq!(got.deal_id, deal_a);
+
+	// List receipts by deal A
+	let list_a = client.list_receipts_by_deal(&deal_a, &10u32, &Option::<u32>::None);
+	assert_eq!(list_a.len(), 2);
+
+	// List receipts by deal B
+	let list_b = client.list_receipts_by_deal(&deal_b, &10u32, &Option::<u32>::None);
+	assert_eq!(list_b.len(), 1);
+
+	// Pagination: limit 1 should return first element only
+	let page1 = client.list_receipts_by_deal(&deal_a, &1u32, &Option::<u32>::None);
+	assert_eq!(page1.len(), 1);
+
+	let page2 = client.list_receipts_by_deal(&deal_a, &1u32, &Some(1u32));
+	assert_eq!(page2.len(), 1);
+}
+
+// Integration: authorization flow (init -> set_operator -> record with new operator)
+#[test]
+fn test_integration_authorization_flow() {
+	let env = Env::default();
+	let contract_id = env.register(TransactionReceiptContract, ());
+	let client = TransactionReceiptContractClient::new(&env, &contract_id);
+
+	let admin = Address::generate(&env);
+	let operator1 = Address::generate(&env);
+	let operator2 = Address::generate(&env);
+
+	client.try_init(&admin, &operator1).unwrap();
+
+	env.mock_all_auths();
+
+	// Admin rotates operator to operator2
+	client.try_set_operator(&admin, &operator2).unwrap();
+
+	let token = Address::generate(&env);
+	let deal = String::from_str(&env, "auth_deal");
+
+	let input = ReceiptInput {
+		external_ref_source: Symbol::new(&env, "manual_admin"),
+		external_ref: String::from_str(&env, "auth_ref"),
+		tx_type: Symbol::new(&env, "rent_payment"),
+		amount_usdc: 5_000_0000000i128,
+		token: token.clone(),
+		deal_id: deal.clone(),
+		listing_id: None,
+		from: None,
+		to: None,
+		amount_ngn: None,
+		fx_rate_ngn_per_usdc: None,
+		fx_provider: None,
+		metadata_hash: None,
+	};
+
+	// Recording with new operator should succeed
+	let _tx = client.try_record_receipt(&operator2, &input).unwrap().unwrap();
+
+	// Recording with old operator should fail
+	let input2 = ReceiptInput { external_ref: String::from_str(&env, "auth_ref2"), ..input };
+	let res_err = client.try_record_receipt(&operator1, &input2);
+	assert!(res_err.is_err());
+	assert_eq!(res_err.unwrap_err().unwrap(), ContractError::NotAuthorized);
+}
+
+// Integration: pause flow (init -> record -> pause -> fail record -> unpause -> record)
+#[test]
+fn test_integration_pause_flow() {
+	let env = Env::default();
+	let contract_id = env.register(TransactionReceiptContract, ());
+	let client = TransactionReceiptContractClient::new(&env, &contract_id);
+
+	let admin = Address::generate(&env);
+	let operator = Address::generate(&env);
+
+	client.try_init(&admin, &operator).unwrap();
+
+	env.mock_all_auths();
+
+	let token = Address::generate(&env);
+	let deal = String::from_str(&env, "pause_deal");
+
+	let input = ReceiptInput {
+		external_ref_source: Symbol::new(&env, "manual_admin"),
+		external_ref: String::from_str(&env, "pause_ref"),
+		tx_type: Symbol::new(&env, "rent_payment"),
+		amount_usdc: 10_000_0000000i128,
+		token: token.clone(),
+		deal_id: deal.clone(),
+		listing_id: None,
+		from: None,
+		to: None,
+		amount_ngn: None,
+		fx_rate_ngn_per_usdc: None,
+		fx_provider: None,
+		metadata_hash: None,
+	};
+
+	// Record should succeed before pause
+	client.try_record_receipt(&operator, &input).unwrap().unwrap();
+
+	// Pause contract
+	client.try_pause(&admin).unwrap();
+
+	// Recording while paused should fail
+	let input2 = ReceiptInput { external_ref: String::from_str(&env, "pause_ref2"), ..input };
+	let res = client.try_record_receipt(&operator, &input2);
+	assert!(res.is_err());
+	assert_eq!(res.unwrap_err().unwrap(), ContractError::ContractPaused);
+
+	// Unpause
+	client.try_unpause(&admin).unwrap();
+
+	// Now recording should succeed again
+	let _tx2 = client.try_record_receipt(&operator, &input2).unwrap().unwrap();
+}
+
+// Integration: deal queries with multiple receipts and pagination across pages
+#[test]
+fn test_integration_deal_queries_and_pagination() {
+	let env = Env::default();
+	let contract_id = env.register(TransactionReceiptContract, ());
+	let client = TransactionReceiptContractClient::new(&env, &contract_id);
+
+	let admin = Address::generate(&env);
+	let operator = Address::generate(&env);
+
+	client.try_init(&admin, &operator).unwrap();
+	env.mock_all_auths();
+
+	let token = Address::generate(&env);
+	let deal = String::from_str(&env, "paging_deal");
+
+	// Create 5 receipts for the same deal
+	for i in 0..5u8 {
+		let ext = format!("p_ref_{}", i);
+		let input = ReceiptInput {
+			external_ref_source: Symbol::new(&env, "manual_admin"),
+			external_ref: String::from_str(&env, &ext),
+			tx_type: Symbol::new(&env, "rent_payment"),
+			amount_usdc: 1_000_0000000i128 + (i as i128),
+			token: token.clone(),
+			deal_id: deal.clone(),
+			listing_id: None,
+			from: None,
+			to: None,
+			amount_ngn: None,
+			fx_rate_ngn_per_usdc: None,
+			fx_provider: None,
+			metadata_hash: None,
+		};
+		client.try_record_receipt(&operator, &input).unwrap().unwrap();
+	}
+
+	// Page 0, limit 2
+	let p0 = client.list_receipts_by_deal(&deal, &2u32, &Option::<u32>::None);
+	assert_eq!(p0.len(), 2);
+
+	// Page 1 (cursor 2), limit 2
+	let p1 = client.list_receipts_by_deal(&deal, &2u32, &Some(2u32));
+	assert_eq!(p1.len(), 2);
+
+	// Page 2 (cursor 4), limit 2 -> should have 1
+	let p2 = client.list_receipts_by_deal(&deal, &2u32, &Some(4u32));
+	assert_eq!(p2.len(), 1);
+}
+

--- a/contracts/transaction-receipt-contract/src/lib.rs
+++ b/contracts/transaction-receipt-contract/src/lib.rs
@@ -1,0 +1,558 @@
+//! Transaction Receipt Contract
+//!
+//! This contract provides deterministic transaction receipt recording and
+//! retrieval for on-chain indexing. Receipts are keyed by a SHA-256 hash of a
+//! canonicalized external payment reference (the `tx_id`). The contract enforces
+//! validation rules on external references, prevents duplicates, and supports
+//! admin/operator authorization and pause control.
+#![no_std]
+
+extern crate alloc;
+
+use soroban_sdk::{contract, contractimpl, contracttype, contracterror, Address, BytesN, String, Symbol};
+
+/// Allowed external reference sources for transaction ID generation
+pub const ALLOWED_SOURCES: [&str; 7] = [
+    "paystack",
+    "flutterwave",
+    "bank_transfer",
+    "stellar",
+    "onramp",
+    "offramp",
+    "manual_admin",
+];
+
+/// Input parameters for recording a receipt (to avoid 10-parameter limit)
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ReceiptInput {
+    /// The payment source (e.g., "paystack", "stellar")
+    pub external_ref_source: Symbol,
+    /// The external payment reference string
+    pub external_ref: String,
+    /// Transaction type (e.g., "rent_payment", "deposit", "refund")
+    pub tx_type: Symbol,
+    /// Transaction amount in USDC (canonical amount, must be positive)
+    pub amount_usdc: i128,
+    /// USDC token contract address
+    pub token: Address,
+    /// Deal identifier this transaction belongs to
+    pub deal_id: String,
+    /// Optional listing identifier
+    pub listing_id: Option<String>,
+    /// Optional sender address
+    pub from: Option<Address>,
+    /// Optional recipient address
+    pub to: Option<Address>,
+    /// Optional amount in NGN (metadata only)
+    pub amount_ngn: Option<i128>,
+    /// Optional FX rate (NGN per USDC, metadata only)
+    pub fx_rate_ngn_per_usdc: Option<i128>,
+    /// Optional FX provider name (metadata only)
+    pub fx_provider: Option<String>,
+    /// Optional metadata hash (SHA-256 of canonical receipt payload v1)
+    pub metadata_hash: Option<BytesN<32>>,
+}
+
+/// Receipt data structure representing an immutable transaction record
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Receipt {
+    /// Unique transaction identifier (SHA-256 hash of canonical external reference)
+    pub tx_id: BytesN<32>,
+    /// Transaction type (e.g., "rent_payment", "deposit", "refund")
+    pub tx_type: Symbol,
+    /// Transaction amount in USDC (canonical amount, must be positive)
+    pub amount_usdc: i128,
+    /// USDC token contract address
+    pub token: Address,
+    /// Deal identifier this transaction belongs to
+    pub deal_id: String,
+    /// Optional listing identifier
+    pub listing_id: Option<String>,
+    /// Optional sender address
+    pub from: Option<Address>,
+    /// Optional recipient address
+    pub to: Option<Address>,
+    /// External reference (same as tx_id)
+    pub external_ref: BytesN<32>,
+    /// Optional amount in NGN (metadata only)
+    pub amount_ngn: Option<i128>,
+    /// Optional FX rate (NGN per USDC, metadata only)
+    pub fx_rate_ngn_per_usdc: Option<i128>,
+    /// Optional FX provider name (metadata only)
+    pub fx_provider: Option<String>,
+    /// Optional metadata hash (SHA-256 of canonical receipt payload v1)
+    pub metadata_hash: Option<BytesN<32>>,
+    /// Timestamp when receipt was recorded (ledger timestamp)
+    pub timestamp: u64,
+}
+
+/// Storage keys for contract state
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum StorageKey {
+    /// Admin address (set during initialization, immutable)
+    Admin,
+    /// Operator address (can be changed by admin)
+    Operator,
+    /// Paused state (boolean)
+    Paused,
+    /// Receipt storage: tx_id → Receipt
+    Receipt(BytesN<32>),
+    /// Deal index: (deal_id, index) → tx_id
+    DealIndex(String, u32),
+    /// Deal count: deal_id → count
+    DealCount(String),
+}
+
+/// Contract error types
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum ContractError {
+    /// Contract has already been initialized
+    AlreadyInitialized = 1,
+    /// Caller is not authorized for this operation
+    NotAuthorized = 2,
+    /// Contract is currently paused
+    ContractPaused = 3,
+    /// Transaction ID already exists (duplicate)
+    DuplicateTransaction = 4,
+    /// Amount is invalid (zero or negative)
+    InvalidAmount = 5,
+    /// External reference source is not in allowed list
+    InvalidExternalRefSource = 6,
+    /// External reference is invalid (empty, contains pipes, or too long)
+    InvalidExternalRef = 7,
+    /// Timestamp is invalid
+    InvalidTimestamp = 8,
+}
+
+#[contract]
+/// Primary contract type. All public contract methods are implemented on this
+/// struct via the `#[contractimpl]` impl block.
+pub struct TransactionReceiptContract;
+
+#[contractimpl]
+impl TransactionReceiptContract {
+    /// Initialize the contract with admin and operator addresses
+    /// 
+    /// # Arguments
+    /// * `env` - The Soroban environment
+    /// * `admin` - The admin address (can manage operator and pause state)
+    /// * `operator` - The operator address (can record receipts)
+    /// 
+    /// # Returns
+    /// * `Ok(())` - If initialization succeeds
+    /// * `Err(ContractError::AlreadyInitialized)` - If contract is already initialized
+    /// 
+    /// # Requirements
+    /// * Can only be called once (Requirements 1.3)
+    /// * Stores admin and operator addresses (Requirements 1.1, 1.2)
+    /// * Initializes paused state to false
+    pub fn init(env: soroban_sdk::Env, admin: Address, operator: Address) -> Result<(), ContractError> {
+        // Check if already initialized by checking if Admin key exists
+        if env.storage().instance().has(&StorageKey::Admin) {
+            return Err(ContractError::AlreadyInitialized);
+        }
+        
+        // Store admin address
+        env.storage().instance().set(&StorageKey::Admin, &admin);
+        
+        // Store operator address
+        env.storage().instance().set(&StorageKey::Operator, &operator);
+        
+        // Initialize paused state to false
+        env.storage().instance().set(&StorageKey::Paused, &false);
+        
+        Ok(())
+    }
+
+    /// Pause the contract to prevent receipt recording
+    /// 
+    /// # Arguments
+    /// * `env` - The Soroban environment
+    /// * `admin` - The admin address attempting to pause
+    /// 
+    /// # Returns
+    /// * `Ok(())` - If pause succeeds
+    /// * `Err(ContractError::NotAuthorized)` - If caller is not admin
+    /// 
+    /// # Requirements
+    /// * Only admin can pause (Requirement 5.3)
+    /// * Updates paused state to true (Requirement 6.1)
+    /// * Idempotent - succeeds even if already paused (Requirement 6.4)
+    pub fn pause(env: soroban_sdk::Env, admin: Address) -> Result<(), ContractError> {
+        // Require authentication from the admin
+        admin.require_auth();
+        
+        // Verify caller is admin
+        require_admin(&env, &admin)?;
+        
+        // Set paused state to true (idempotent - no error if already paused)
+        env.storage().instance().set(&StorageKey::Paused, &true);
+        
+        Ok(())
+    }
+
+    /// Unpause the contract to allow receipt recording
+    /// 
+    /// # Arguments
+    /// * `env` - The Soroban environment
+    /// * `admin` - The admin address attempting to unpause
+    /// 
+    /// # Returns
+    /// * `Ok(())` - If unpause succeeds
+    /// * `Err(ContractError::NotAuthorized)` - If caller is not admin
+    /// 
+    /// # Requirements
+    /// * Only admin can unpause (Requirement 5.4)
+    /// * Updates paused state to false (Requirement 6.1)
+    /// * Idempotent - succeeds even if already unpaused (Requirement 6.5)
+    pub fn unpause(env: soroban_sdk::Env, admin: Address) -> Result<(), ContractError> {
+        // Require authentication from the admin
+        admin.require_auth();
+        
+        // Verify caller is admin
+        require_admin(&env, &admin)?;
+        
+        // Set paused state to false (idempotent - no error if already unpaused)
+        env.storage().instance().set(&StorageKey::Paused, &false);
+        
+        Ok(())
+    }
+
+    /// Set a new operator address
+    /// 
+    /// # Arguments
+    /// * `env` - The Soroban environment
+    /// * `admin` - The admin address attempting to set operator
+    /// * `new_operator` - The new operator address
+    /// 
+    /// # Returns
+    /// * `Ok(())` - If operator update succeeds
+    /// * `Err(ContractError::NotAuthorized)` - If caller is not admin
+    /// 
+    /// # Requirements
+    /// * Only admin can set operator (Requirement 5.2, 7.2)
+    /// * Updates operator address in storage (Requirement 7.1)
+    /// * Accepts any valid Soroban Address (Requirement 7.3)
+    pub fn set_operator(env: soroban_sdk::Env, admin: Address, new_operator: Address) -> Result<(), ContractError> {
+        // Require authentication from the admin
+        admin.require_auth();
+        
+        // Verify caller is admin
+        require_admin(&env, &admin)?;
+        
+        // Update operator address in storage
+        env.storage().instance().set(&StorageKey::Operator, &new_operator);
+        
+        Ok(())
+    }
+
+    /// Record a new transaction receipt
+    /// 
+    /// # Arguments
+    /// * `env` - The Soroban environment
+    /// * `operator` - The operator address attempting to record
+    /// * `input` - Receipt input parameters (ReceiptInput struct)
+    /// 
+    /// # Returns
+    /// * `Ok(BytesN<32>)` - The generated tx_id
+    /// * `Err(ContractError)` - If validation fails or duplicate detected
+    /// 
+    /// # Requirements
+    /// * Only operator can record (Requirement 5.1)
+    /// * Contract must not be paused (Requirement 6.2)
+    /// * Amount must be positive (Requirement 2.4)
+    /// * Rejects duplicate tx_id (Requirement 3.1)
+    /// * Emits event on success (Requirements 10.1, 10.2, 10.3)
+    pub fn record_receipt(
+        env: soroban_sdk::Env,
+        operator: Address,
+        input: ReceiptInput,
+    ) -> Result<BytesN<32>, ContractError> {
+        // Require authentication from the operator
+        operator.require_auth();
+        
+        // Verify caller is operator
+        require_operator(&env, &operator)?;
+        
+        // Verify contract is not paused
+        require_not_paused(&env)?;
+        
+        // Validate amount_usdc is positive
+        if input.amount_usdc <= 0 {
+            return Err(ContractError::InvalidAmount);
+        }
+        
+        // Generate tx_id from canonical external reference
+        let tx_id = generate_tx_id(&env, &input.external_ref_source, &input.external_ref)?;
+        
+        // Check for duplicate tx_id
+        if env.storage().persistent().has(&StorageKey::Receipt(tx_id.clone())) {
+            return Err(ContractError::DuplicateTransaction);
+        }
+        
+        // Get current ledger timestamp
+        let timestamp = env.ledger().timestamp();
+        
+        // Create Receipt struct
+        let receipt = Receipt {
+            tx_id: tx_id.clone(),
+            tx_type: input.tx_type,
+            amount_usdc: input.amount_usdc,
+            token: input.token,
+            deal_id: input.deal_id.clone(),
+            listing_id: input.listing_id,
+            from: input.from,
+            to: input.to,
+            external_ref: tx_id.clone(), // Same as tx_id per Requirement 4.10
+            amount_ngn: input.amount_ngn,
+            fx_rate_ngn_per_usdc: input.fx_rate_ngn_per_usdc,
+            fx_provider: input.fx_provider,
+            metadata_hash: input.metadata_hash,
+            timestamp,
+        };
+        
+        // Store receipt in persistent storage
+        env.storage().persistent().set(&StorageKey::Receipt(tx_id.clone()), &receipt);
+        
+        // Update deal index
+        let deal_count_key = StorageKey::DealCount(input.deal_id.clone());
+        let current_count: u32 = env.storage().persistent().get(&deal_count_key).unwrap_or(0);
+        
+        // Store tx_id in deal index
+        let deal_index_key = StorageKey::DealIndex(input.deal_id.clone(), current_count);
+        env.storage().persistent().set(&deal_index_key, &tx_id);
+        
+        // Increment deal count
+        env.storage().persistent().set(&deal_count_key, &(current_count + 1));
+        
+        // Emit event with topic ("receipt", tx_id) and receipt payload
+        env.events().publish(("receipt", tx_id.clone()), receipt);
+        
+        Ok(tx_id)
+    }
+
+    /// Retrieve a receipt by transaction ID
+    /// 
+    /// # Arguments
+    /// * `env` - The Soroban environment
+    /// * `tx_id` - The transaction ID to look up
+    /// 
+    /// # Returns
+    /// * `Some(Receipt)` - If the receipt exists
+    /// * `None` - If the receipt does not exist
+    /// 
+    /// # Requirements
+    /// * Returns complete receipt if exists (Requirement 8.1, 8.3)
+    /// * Returns None for non-existent tx_id (Requirement 8.2)
+    /// * No authorization required (public read)
+    pub fn get_receipt(env: soroban_sdk::Env, tx_id: BytesN<32>) -> Option<Receipt> {
+        env.storage().persistent().get(&StorageKey::Receipt(tx_id))
+    }
+
+    /// List all receipts for a specific deal with pagination
+    /// 
+    /// # Arguments
+    /// * `env` - The Soroban environment
+    /// * `deal_id` - The deal identifier to query
+    /// * `limit` - Maximum number of receipts to return
+    /// * `cursor` - Optional starting index for pagination (default: 0)
+    /// 
+    /// # Returns
+    /// * `Vec<Receipt>` - Vector of receipts matching the deal_id
+    /// 
+    /// # Requirements
+    /// * Returns receipts matching deal_id (Requirement 9.1)
+    /// * Supports pagination (Requirements 9.2, 9.4, 9.5)
+    /// * Returns receipts in deterministic order (Requirement 9.3)
+    /// * No authorization required (public read)
+    pub fn list_receipts_by_deal(
+        env: soroban_sdk::Env,
+        deal_id: String,
+        limit: u32,
+        cursor: Option<u32>,
+    ) -> soroban_sdk::Vec<Receipt> {
+        use soroban_sdk::Vec;
+        
+        let mut results = Vec::new(&env);
+        
+        // Get total count of receipts for this deal
+        let deal_count_key = StorageKey::DealCount(deal_id.clone());
+        let total_count: u32 = env.storage().persistent().get(&deal_count_key).unwrap_or(0);
+        
+        // Calculate start index from cursor (default 0)
+        let start_index = cursor.unwrap_or(0);
+        
+        // Calculate end index (start + limit, capped at total_count)
+        let end_index = core::cmp::min(start_index + limit, total_count);
+        
+        // Iterate through deal index to load receipts
+        for index in start_index..end_index {
+            let deal_index_key = StorageKey::DealIndex(deal_id.clone(), index);
+            
+            // Load tx_id from deal index
+            if let Some(tx_id) = env.storage().persistent().get::<StorageKey, BytesN<32>>(&deal_index_key) {
+                // Load receipt for this tx_id
+                if let Some(receipt) = env.storage().persistent().get::<StorageKey, Receipt>(&StorageKey::Receipt(tx_id)) {
+                    results.push_back(receipt);
+                }
+            }
+        }
+        
+        results
+    }
+}
+
+/// Helper function to verify that the caller is the admin
+/// 
+/// # Arguments
+/// * `env` - The Soroban environment
+/// * `caller` - The address attempting the operation
+/// 
+/// # Returns
+/// * `Ok(())` - If the caller is the admin
+/// * `Err(ContractError::NotAuthorized)` - If the caller is not the admin
+fn require_admin(env: &soroban_sdk::Env, caller: &Address) -> Result<(), ContractError> {
+    // Load admin address from storage
+    let admin: Address = env
+        .storage()
+        .instance()
+        .get(&StorageKey::Admin)
+        .unwrap_or_else(|| panic!("Admin not initialized"));
+    
+    // Verify caller is admin
+    if caller != &admin {
+        return Err(ContractError::NotAuthorized);
+    }
+    
+    Ok(())
+}
+
+/// Helper function to verify that the caller is the operator
+/// 
+/// # Arguments
+/// * `env` - The Soroban environment
+/// * `caller` - The address attempting the operation
+/// 
+/// # Returns
+/// * `Ok(())` - If the caller is the operator
+/// * `Err(ContractError::NotAuthorized)` - If the caller is not the operator
+fn require_operator(env: &soroban_sdk::Env, caller: &Address) -> Result<(), ContractError> {
+    // Load operator address from storage
+    let operator: Address = env
+        .storage()
+        .instance()
+        .get(&StorageKey::Operator)
+        .unwrap_or_else(|| panic!("Operator not initialized"));
+    
+    // Verify caller is operator
+    if caller != &operator {
+        return Err(ContractError::NotAuthorized);
+    }
+    
+    Ok(())
+}
+
+/// Helper function to verify that the contract is not paused
+/// 
+/// # Arguments
+/// * `env` - The Soroban environment
+/// 
+/// # Returns
+/// * `Ok(())` - If the contract is not paused
+/// * `Err(ContractError::ContractPaused)` - If the contract is paused
+fn require_not_paused(env: &soroban_sdk::Env) -> Result<(), ContractError> {
+    // Load paused state from storage (defaults to false if not set)
+    let paused: bool = env
+        .storage()
+        .instance()
+        .get(&StorageKey::Paused)
+        .unwrap_or(false);
+    
+    // Return error if contract is paused
+    if paused {
+        return Err(ContractError::ContractPaused);
+    }
+    
+    Ok(())
+}
+
+/// Helper function to generate a deterministic transaction ID from external payment references
+/// 
+/// # Arguments
+/// * `env` - The Soroban environment
+/// * `external_ref_source` - The payment source (must be in ALLOWED_SOURCES)
+/// * `external_ref` - The external payment reference string
+/// 
+/// # Returns
+/// * `Ok(BytesN<32>)` - SHA-256 hash of the canonical external reference string
+/// * `Err(ContractError)` - If validation fails
+/// 
+/// # Validation Rules
+/// * external_ref_source must be in ALLOWED_SOURCES (case-insensitive)
+/// * external_ref must not be empty after trimming
+/// * external_ref must not contain pipe character (|)
+/// * external_ref must not exceed 256 characters
+/// 
+/// # Canonical Format
+/// The canonical string format is: "v1|source=<lowercased_trimmed_source>|ref=<trimmed_ref>"
+fn generate_tx_id(
+    env: &soroban_sdk::Env,
+    external_ref_source: &Symbol,
+    external_ref: &String,
+) -> Result<BytesN<32>, ContractError> {
+    use soroban_sdk::Bytes;
+    
+    // Convert Symbol to string for validation
+    // We need to use the alloc feature for string manipulation
+    extern crate alloc;
+    use alloc::string::ToString;
+    use alloc::string::String as StdString;
+    
+    let source_str: StdString = external_ref_source.to_string();
+    let source_trimmed = source_str.trim();
+    let source_lower = source_trimmed.to_lowercase();
+    
+    // Validate external_ref_source against ALLOWED_SOURCES
+    if !ALLOWED_SOURCES.contains(&source_lower.as_str()) {
+        return Err(ContractError::InvalidExternalRefSource);
+    }
+    
+    // Get the external_ref as a string and trim it
+    let ref_str: StdString = external_ref.to_string();
+    let ref_trimmed = ref_str.trim();
+    
+    // Validate external_ref is not empty after trimming
+    if ref_trimmed.is_empty() {
+        return Err(ContractError::InvalidExternalRef);
+    }
+    
+    // Validate external_ref does not contain pipe character
+    if ref_trimmed.contains('|') {
+        return Err(ContractError::InvalidExternalRef);
+    }
+    
+    // Validate external_ref does not exceed 256 characters
+    if ref_trimmed.len() > 256 {
+        return Err(ContractError::InvalidExternalRef);
+    }
+    
+    // Construct canonical string: "v1|source=<lowercased_trimmed_source>|ref=<trimmed_ref>"
+    use alloc::format;
+    let canonical = format!("v1|source={}|ref={}", source_lower, ref_trimmed);
+    
+    // Convert to Bytes for hashing
+    let canonical_bytes = Bytes::from_slice(env, canonical.as_bytes());
+    
+    // Compute SHA-256 hash using Soroban's crypto module
+    let hash = env.crypto().sha256(&canonical_bytes);
+    
+    Ok(hash.into())
+}
+
+mod test;
+mod integration_tests;

--- a/contracts/transaction-receipt-contract/src/test.rs
+++ b/contracts/transaction-receipt-contract/src/test.rs
@@ -1,0 +1,675 @@
+#![cfg(test)]
+
+use crate::{generate_tx_id, ContractError, Receipt, StorageKey, ALLOWED_SOURCES};
+use soroban_sdk::{testutils::Address as _, Address, BytesN, Env, String, Symbol};
+
+#[test]
+fn test_allowed_sources_constant() {
+    // Verify ALLOWED_SOURCES contains expected values
+    assert_eq!(ALLOWED_SOURCES.len(), 7);
+    assert!(ALLOWED_SOURCES.contains(&"paystack"));
+    assert!(ALLOWED_SOURCES.contains(&"flutterwave"));
+    assert!(ALLOWED_SOURCES.contains(&"bank_transfer"));
+    assert!(ALLOWED_SOURCES.contains(&"stellar"));
+    assert!(ALLOWED_SOURCES.contains(&"onramp"));
+    assert!(ALLOWED_SOURCES.contains(&"offramp"));
+    assert!(ALLOWED_SOURCES.contains(&"manual_admin"));
+}
+
+#[test]
+fn test_contract_error_codes() {
+    // Verify error codes match specification
+    assert_eq!(ContractError::AlreadyInitialized as u32, 1);
+    assert_eq!(ContractError::NotAuthorized as u32, 2);
+    assert_eq!(ContractError::ContractPaused as u32, 3);
+    assert_eq!(ContractError::DuplicateTransaction as u32, 4);
+    assert_eq!(ContractError::InvalidAmount as u32, 5);
+    assert_eq!(ContractError::InvalidExternalRefSource as u32, 6);
+    assert_eq!(ContractError::InvalidExternalRef as u32, 7);
+    assert_eq!(ContractError::InvalidTimestamp as u32, 8);
+}
+
+#[test]
+fn test_receipt_struct_creation() {
+    let env = Env::default();
+    
+    let tx_id = BytesN::from_array(&env, &[0u8; 32]);
+    let token = Address::generate(&env);
+    let deal_id = String::from_str(&env, "deal_123");
+    
+    let receipt = Receipt {
+        tx_id: tx_id.clone(),
+        tx_type: Symbol::new(&env, "rent_payment"),
+        amount_usdc: 1000_0000000, // 1000 USDC (7 decimals)
+        token: token.clone(),
+        deal_id: deal_id.clone(),
+        listing_id: None,
+        from: None,
+        to: None,
+        external_ref: tx_id.clone(),
+        amount_ngn: None,
+        fx_rate_ngn_per_usdc: None,
+        fx_provider: None,
+        metadata_hash: None,
+        timestamp: 1234567890,
+    };
+    
+    // Verify receipt fields
+    assert_eq!(receipt.tx_id, tx_id);
+    assert_eq!(receipt.external_ref, tx_id);
+    assert_eq!(receipt.amount_usdc, 1000_0000000);
+    assert_eq!(receipt.timestamp, 1234567890);
+}
+
+#[test]
+fn test_storage_key_variants() {
+    let env = Env::default();
+    
+    // Test that all StorageKey variants can be created
+    let _admin_key = StorageKey::Admin;
+    let _operator_key = StorageKey::Operator;
+    let _paused_key = StorageKey::Paused;
+    
+    let tx_id = BytesN::from_array(&env, &[1u8; 32]);
+    let _receipt_key = StorageKey::Receipt(tx_id);
+    
+    let deal_id = String::from_str(&env, "deal_456");
+    let _deal_index_key = StorageKey::DealIndex(deal_id.clone(), 0);
+    let _deal_count_key = StorageKey::DealCount(deal_id);
+}
+
+// Tests for generate_tx_id function
+
+#[test]
+fn test_generate_tx_id_valid_input() {
+    let env = Env::default();
+    let source = Symbol::new(&env, "paystack");
+    let reference = String::from_str(&env, "ref_12345");
+    
+    let result = generate_tx_id(&env, &source, &reference);
+    assert!(result.is_ok());
+    
+    let tx_id = result.unwrap();
+    // Verify it's a 32-byte hash
+    assert_eq!(tx_id.len(), 32);
+}
+
+#[test]
+fn test_generate_tx_id_all_allowed_sources() {
+    let env = Env::default();
+    let reference = String::from_str(&env, "test_ref");
+    
+    for source_str in ALLOWED_SOURCES.iter() {
+        let source = Symbol::new(&env, source_str);
+        let result = generate_tx_id(&env, &source, &reference);
+        assert!(result.is_ok(), "Failed for source: {}", source_str);
+    }
+}
+
+#[test]
+fn test_generate_tx_id_invalid_source() {
+    let env = Env::default();
+    let source = Symbol::new(&env, "invalid_source");
+    let reference = String::from_str(&env, "ref_12345");
+    
+    let result = generate_tx_id(&env, &source, &reference);
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err(), ContractError::InvalidExternalRefSource);
+}
+
+#[test]
+fn test_generate_tx_id_empty_reference() {
+    let env = Env::default();
+    let source = Symbol::new(&env, "paystack");
+    let reference = String::from_str(&env, "");
+    
+    let result = generate_tx_id(&env, &source, &reference);
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err(), ContractError::InvalidExternalRef);
+}
+
+#[test]
+fn test_generate_tx_id_whitespace_only_reference() {
+    let env = Env::default();
+    let source = Symbol::new(&env, "paystack");
+    let reference = String::from_str(&env, "   ");
+    
+    let result = generate_tx_id(&env, &source, &reference);
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err(), ContractError::InvalidExternalRef);
+}
+
+#[test]
+fn test_generate_tx_id_reference_with_pipe() {
+    let env = Env::default();
+    let source = Symbol::new(&env, "paystack");
+    let reference = String::from_str(&env, "ref|12345");
+    
+    let result = generate_tx_id(&env, &source, &reference);
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err(), ContractError::InvalidExternalRef);
+}
+
+#[test]
+fn test_generate_tx_id_reference_too_long() {
+    let env = Env::default();
+    let source = Symbol::new(&env, "paystack");
+    // Create a string with 257 characters
+    let long_ref = "a".repeat(257);
+    let reference = String::from_str(&env, &long_ref);
+    
+    let result = generate_tx_id(&env, &source, &reference);
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err(), ContractError::InvalidExternalRef);
+}
+
+#[test]
+fn test_generate_tx_id_reference_exactly_256_chars() {
+    let env = Env::default();
+    let source = Symbol::new(&env, "paystack");
+    // Create a string with exactly 256 characters
+    let max_ref = "a".repeat(256);
+    let reference = String::from_str(&env, &max_ref);
+    
+    let result = generate_tx_id(&env, &source, &reference);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_generate_tx_id_source_case_insensitive() {
+    let env = Env::default();
+    let reference = String::from_str(&env, "ref_12345");
+    
+    let source_lower = Symbol::new(&env, "paystack");
+    let source_upper = Symbol::new(&env, "PAYSTACK");
+    let source_mixed = Symbol::new(&env, "PayStack");
+    
+    let result_lower = generate_tx_id(&env, &source_lower, &reference).unwrap();
+    let result_upper = generate_tx_id(&env, &source_upper, &reference).unwrap();
+    let result_mixed = generate_tx_id(&env, &source_mixed, &reference).unwrap();
+    
+    // All should produce the same tx_id
+    assert_eq!(result_lower, result_upper);
+    assert_eq!(result_lower, result_mixed);
+}
+
+#[test]
+fn test_generate_tx_id_reference_case_sensitive() {
+    let env = Env::default();
+    let source = Symbol::new(&env, "paystack");
+    
+    let ref_lower = String::from_str(&env, "ref_12345");
+    let ref_upper = String::from_str(&env, "REF_12345");
+    
+    let result_lower = generate_tx_id(&env, &source, &ref_lower).unwrap();
+    let result_upper = generate_tx_id(&env, &source, &ref_upper).unwrap();
+    
+    // Should produce different tx_ids (case-sensitive)
+    assert_ne!(result_lower, result_upper);
+}
+
+#[test]
+fn test_generate_tx_id_trimming() {
+    let env = Env::default();
+    // Note: Symbols cannot contain spaces, so we test reference trimming only
+    let source = Symbol::new(&env, "paystack");
+    let reference = String::from_str(&env, "  ref_12345  ");
+    
+    let reference_clean = String::from_str(&env, "ref_12345");
+    
+    let result_trimmed = generate_tx_id(&env, &source, &reference).unwrap();
+    let result_clean = generate_tx_id(&env, &source, &reference_clean).unwrap();
+    
+    // Should produce the same tx_id after trimming
+    assert_eq!(result_trimmed, result_clean);
+}
+
+#[test]
+fn test_generate_tx_id_deterministic() {
+    let env = Env::default();
+    let source = Symbol::new(&env, "paystack");
+    let reference = String::from_str(&env, "ref_12345");
+    
+    let result1 = generate_tx_id(&env, &source, &reference).unwrap();
+    let result2 = generate_tx_id(&env, &source, &reference).unwrap();
+    
+    // Should produce the same tx_id for the same inputs
+    assert_eq!(result1, result2);
+}
+
+#[test]
+fn test_generate_tx_id_different_sources_different_hashes() {
+    let env = Env::default();
+    let reference = String::from_str(&env, "ref_12345");
+    
+    let source1 = Symbol::new(&env, "paystack");
+    let source2 = Symbol::new(&env, "flutterwave");
+    
+    let result1 = generate_tx_id(&env, &source1, &reference).unwrap();
+    let result2 = generate_tx_id(&env, &source2, &reference).unwrap();
+    
+    // Different sources should produce different tx_ids
+    assert_ne!(result1, result2);
+}
+
+#[test]
+fn test_generate_tx_id_different_references_different_hashes() {
+    let env = Env::default();
+    let source = Symbol::new(&env, "paystack");
+    
+    let ref1 = String::from_str(&env, "ref_12345");
+    let ref2 = String::from_str(&env, "ref_67890");
+    
+    let result1 = generate_tx_id(&env, &source, &ref1).unwrap();
+    let result2 = generate_tx_id(&env, &source, &ref2).unwrap();
+    
+    // Different references should produce different tx_ids
+    assert_ne!(result1, result2);
+}
+
+// Tests for init function
+
+use crate::TransactionReceiptContract;
+use crate::TransactionReceiptContractClient;
+
+#[test]
+fn test_init_success() {
+    let env = Env::default();
+    let contract_id = env.register(TransactionReceiptContract, ());
+    let client = TransactionReceiptContractClient::new(&env, &contract_id);
+    
+    let admin = Address::generate(&env);
+    let operator = Address::generate(&env);
+    
+    // Initialize the contract
+    client.try_init(&admin, &operator).unwrap();
+    
+    // Verify admin is stored by checking storage directly
+    let stored_admin: Address = env
+        .as_contract(&contract_id, || {
+            env.storage()
+                .instance()
+                .get(&StorageKey::Admin)
+                .unwrap()
+        });
+    assert_eq!(stored_admin, admin);
+    
+    // Verify operator is stored
+    let stored_operator: Address = env
+        .as_contract(&contract_id, || {
+            env.storage()
+                .instance()
+                .get(&StorageKey::Operator)
+                .unwrap()
+        });
+    assert_eq!(stored_operator, operator);
+    
+    // Verify paused state is false
+    let paused: bool = env
+        .as_contract(&contract_id, || {
+            env.storage()
+                .instance()
+                .get(&StorageKey::Paused)
+                .unwrap()
+        });
+    assert_eq!(paused, false);
+}
+
+#[test]
+fn test_init_already_initialized() {
+    let env = Env::default();
+    let contract_id = env.register(TransactionReceiptContract, ());
+    let client = TransactionReceiptContractClient::new(&env, &contract_id);
+    
+    let admin = Address::generate(&env);
+    let operator = Address::generate(&env);
+    
+    // Initialize the contract first time
+    client.try_init(&admin, &operator).unwrap();
+    
+    // Try to initialize again
+    let admin2 = Address::generate(&env);
+    let operator2 = Address::generate(&env);
+    let result2 = client.try_init(&admin2, &operator2);
+    
+    // Should fail with AlreadyInitialized error
+    assert!(result2.is_err());
+    assert_eq!(result2.unwrap_err().unwrap(), ContractError::AlreadyInitialized);
+    
+    // Verify original admin and operator are still stored
+    let stored_admin: Address = env
+        .as_contract(&contract_id, || {
+            env.storage()
+                .instance()
+                .get(&StorageKey::Admin)
+                .unwrap()
+        });
+    assert_eq!(stored_admin, admin);
+    
+    let stored_operator: Address = env
+        .as_contract(&contract_id, || {
+            env.storage()
+                .instance()
+                .get(&StorageKey::Operator)
+                .unwrap()
+        });
+    assert_eq!(stored_operator, operator);
+}
+
+#[test]
+fn test_init_with_same_admin_and_operator() {
+    let env = Env::default();
+    let contract_id = env.register(TransactionReceiptContract, ());
+    let client = TransactionReceiptContractClient::new(&env, &contract_id);
+    
+    let address = Address::generate(&env);
+    
+    // Initialize with same address for both admin and operator
+    client.try_init(&address, &address).unwrap();
+    
+    // Verify both are stored correctly
+    let stored_admin: Address = env
+        .as_contract(&contract_id, || {
+            env.storage()
+                .instance()
+                .get(&StorageKey::Admin)
+                .unwrap()
+        });
+    assert_eq!(stored_admin, address);
+    
+    let stored_operator: Address = env
+        .as_contract(&contract_id, || {
+            env.storage()
+                .instance()
+                .get(&StorageKey::Operator)
+                .unwrap()
+        });
+    assert_eq!(stored_operator, address);
+}
+
+// Tests for pause and unpause functions
+
+#[test]
+fn test_pause_success() {
+    let env = Env::default();
+    let contract_id = env.register(TransactionReceiptContract, ());
+    let client = TransactionReceiptContractClient::new(&env, &contract_id);
+    
+    let admin = Address::generate(&env);
+    let operator = Address::generate(&env);
+    
+    // Initialize the contract
+    client.try_init(&admin, &operator).unwrap();
+    
+    // Mock admin authentication
+    env.mock_all_auths();
+    
+    // Pause the contract
+    client.try_pause(&admin).unwrap();
+    
+    // Verify paused state is true
+    let paused: bool = env
+        .as_contract(&contract_id, || {
+            env.storage()
+                .instance()
+                .get(&StorageKey::Paused)
+                .unwrap()
+        });
+    assert_eq!(paused, true);
+}
+
+#[test]
+fn test_pause_not_authorized() {
+    let env = Env::default();
+    let contract_id = env.register(TransactionReceiptContract, ());
+    let client = TransactionReceiptContractClient::new(&env, &contract_id);
+    
+    let admin = Address::generate(&env);
+    let operator = Address::generate(&env);
+    let unauthorized = Address::generate(&env);
+    
+    // Initialize the contract
+    client.try_init(&admin, &operator).unwrap();
+    
+    // Mock authentication for unauthorized address
+    env.mock_all_auths();
+    
+    // Try to pause with unauthorized address
+    let result = client.try_pause(&unauthorized);
+    
+    // Should fail with NotAuthorized error
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err().unwrap(), ContractError::NotAuthorized);
+    
+    // Verify paused state is still false
+    let paused: bool = env
+        .as_contract(&contract_id, || {
+            env.storage()
+                .instance()
+                .get(&StorageKey::Paused)
+                .unwrap()
+        });
+    assert_eq!(paused, false);
+}
+
+#[test]
+fn test_pause_idempotent() {
+    let env = Env::default();
+    let contract_id = env.register(TransactionReceiptContract, ());
+    let client = TransactionReceiptContractClient::new(&env, &contract_id);
+    
+    let admin = Address::generate(&env);
+    let operator = Address::generate(&env);
+    
+    // Initialize the contract
+    client.try_init(&admin, &operator).unwrap();
+    
+    // Mock admin authentication
+    env.mock_all_auths();
+    
+    // Pause the contract first time
+    client.try_pause(&admin).unwrap();
+    
+    // Verify paused state is true
+    let paused: bool = env
+        .as_contract(&contract_id, || {
+            env.storage()
+                .instance()
+                .get(&StorageKey::Paused)
+                .unwrap()
+        });
+    assert_eq!(paused, true);
+    
+    // Pause again (should succeed without error)
+    client.try_pause(&admin).unwrap();
+    
+    // Verify paused state is still true
+    let paused: bool = env
+        .as_contract(&contract_id, || {
+            env.storage()
+                .instance()
+                .get(&StorageKey::Paused)
+                .unwrap()
+        });
+    assert_eq!(paused, true);
+}
+
+#[test]
+fn test_unpause_success() {
+    let env = Env::default();
+    let contract_id = env.register(TransactionReceiptContract, ());
+    let client = TransactionReceiptContractClient::new(&env, &contract_id);
+    
+    let admin = Address::generate(&env);
+    let operator = Address::generate(&env);
+    
+    // Initialize the contract
+    client.try_init(&admin, &operator).unwrap();
+    
+    // Mock admin authentication
+    env.mock_all_auths();
+    
+    // Pause the contract first
+    client.try_pause(&admin).unwrap();
+    
+    // Verify paused state is true
+    let paused: bool = env
+        .as_contract(&contract_id, || {
+            env.storage()
+                .instance()
+                .get(&StorageKey::Paused)
+                .unwrap()
+        });
+    assert_eq!(paused, true);
+    
+    // Unpause the contract
+    client.try_unpause(&admin).unwrap();
+    
+    // Verify paused state is false
+    let paused: bool = env
+        .as_contract(&contract_id, || {
+            env.storage()
+                .instance()
+                .get(&StorageKey::Paused)
+                .unwrap()
+        });
+    assert_eq!(paused, false);
+}
+
+#[test]
+fn test_unpause_not_authorized() {
+    let env = Env::default();
+    let contract_id = env.register(TransactionReceiptContract, ());
+    let client = TransactionReceiptContractClient::new(&env, &contract_id);
+    
+    let admin = Address::generate(&env);
+    let operator = Address::generate(&env);
+    let unauthorized = Address::generate(&env);
+    
+    // Initialize the contract
+    client.try_init(&admin, &operator).unwrap();
+    
+    // Mock authentication
+    env.mock_all_auths();
+    
+    // Pause the contract first
+    client.try_pause(&admin).unwrap();
+    
+    // Try to unpause with unauthorized address
+    let result = client.try_unpause(&unauthorized);
+    
+    // Should fail with NotAuthorized error
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err().unwrap(), ContractError::NotAuthorized);
+    
+    // Verify paused state is still true
+    let paused: bool = env
+        .as_contract(&contract_id, || {
+            env.storage()
+                .instance()
+                .get(&StorageKey::Paused)
+                .unwrap()
+        });
+    assert_eq!(paused, true);
+}
+
+#[test]
+fn test_unpause_idempotent() {
+    let env = Env::default();
+    let contract_id = env.register(TransactionReceiptContract, ());
+    let client = TransactionReceiptContractClient::new(&env, &contract_id);
+    
+    let admin = Address::generate(&env);
+    let operator = Address::generate(&env);
+    
+    // Initialize the contract
+    client.try_init(&admin, &operator).unwrap();
+    
+    // Mock admin authentication
+    env.mock_all_auths();
+    
+    // Contract starts unpaused, unpause should succeed
+    client.try_unpause(&admin).unwrap();
+    
+    // Verify paused state is false
+    let paused: bool = env
+        .as_contract(&contract_id, || {
+            env.storage()
+                .instance()
+                .get(&StorageKey::Paused)
+                .unwrap()
+        });
+    assert_eq!(paused, false);
+    
+    // Unpause again (should succeed without error)
+    client.try_unpause(&admin).unwrap();
+    
+    // Verify paused state is still false
+    let paused: bool = env
+        .as_contract(&contract_id, || {
+            env.storage()
+                .instance()
+                .get(&StorageKey::Paused)
+                .unwrap()
+        });
+    assert_eq!(paused, false);
+}
+
+#[test]
+fn test_pause_unpause_cycle() {
+    let env = Env::default();
+    let contract_id = env.register(TransactionReceiptContract, ());
+    let client = TransactionReceiptContractClient::new(&env, &contract_id);
+    
+    let admin = Address::generate(&env);
+    let operator = Address::generate(&env);
+    
+    // Initialize the contract
+    client.try_init(&admin, &operator).unwrap();
+    
+    // Mock admin authentication
+    env.mock_all_auths();
+    
+    // Initial state should be unpaused
+    let paused: bool = env
+        .as_contract(&contract_id, || {
+            env.storage()
+                .instance()
+                .get(&StorageKey::Paused)
+                .unwrap()
+        });
+    assert_eq!(paused, false);
+    
+    // Pause
+    client.try_pause(&admin).unwrap();
+    let paused: bool = env
+        .as_contract(&contract_id, || {
+            env.storage()
+                .instance()
+                .get(&StorageKey::Paused)
+                .unwrap()
+        });
+    assert_eq!(paused, true);
+    
+    // Unpause
+    client.try_unpause(&admin).unwrap();
+    let paused: bool = env
+        .as_contract(&contract_id, || {
+            env.storage()
+                .instance()
+                .get(&StorageKey::Paused)
+                .unwrap()
+        });
+    assert_eq!(paused, false);
+    
+    // Pause again
+    client.try_pause(&admin).unwrap();
+    let paused: bool = env
+        .as_contract(&contract_id, || {
+            env.storage()
+                .instance()
+                .get(&StorageKey::Paused)
+                .unwrap()
+        });
+    assert_eq!(paused, true);
+}

--- a/contracts/transaction-receipt-contract/test_snapshots/integration_tests/test_integration_authorization_flow.1.json
+++ b/contracts/transaction-receipt-contract/test_snapshots/integration_tests/test_integration_authorization_flow.1.json
@@ -1,0 +1,561 @@
+{
+  "generators": {
+    "address": 5,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "set_operator",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "record_receipt",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "amount_ngn"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "amount_usdc"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 50000000000
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "deal_id"
+                      },
+                      "val": {
+                        "string": "auth_deal"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "external_ref"
+                      },
+                      "val": {
+                        "string": "auth_ref"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "external_ref_source"
+                      },
+                      "val": {
+                        "symbol": "manual_admin"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "from"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "fx_provider"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "fx_rate_ngn_per_usdc"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "listing_id"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata_hash"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "to"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "token"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "tx_type"
+                      },
+                      "val": {
+                        "symbol": "rent_payment"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "DealCount"
+                },
+                {
+                  "string": "auth_deal"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "DealCount"
+                    },
+                    {
+                      "string": "auth_deal"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 1
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "DealIndex"
+                },
+                {
+                  "string": "auth_deal"
+                },
+                {
+                  "u32": 0
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "DealIndex"
+                    },
+                    {
+                      "string": "auth_deal"
+                    },
+                    {
+                      "u32": 0
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "bytes": "2a2dca1021013b0850a706b2cb92cc6771437326e3199dd26fb86ea586cf851d"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Receipt"
+                },
+                {
+                  "bytes": "2a2dca1021013b0850a706b2cb92cc6771437326e3199dd26fb86ea586cf851d"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Receipt"
+                    },
+                    {
+                      "bytes": "2a2dca1021013b0850a706b2cb92cc6771437326e3199dd26fb86ea586cf851d"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "amount_ngn"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "amount_usdc"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 50000000000
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "deal_id"
+                      },
+                      "val": {
+                        "string": "auth_deal"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "external_ref"
+                      },
+                      "val": {
+                        "bytes": "2a2dca1021013b0850a706b2cb92cc6771437326e3199dd26fb86ea586cf851d"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "from"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "fx_provider"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "fx_rate_ngn_per_usdc"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "listing_id"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata_hash"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "timestamp"
+                      },
+                      "val": {
+                        "u64": 0
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "to"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "token"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "tx_id"
+                      },
+                      "val": {
+                        "bytes": "2a2dca1021013b0850a706b2cb92cc6771437326e3199dd26fb86ea586cf851d"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "tx_type"
+                      },
+                      "val": {
+                        "symbol": "rent_payment"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Operator"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Paused"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 801925984706572462
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 5541220902715666415
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 5541220902715666415
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/transaction-receipt-contract/test_snapshots/integration_tests/test_integration_deal_queries_and_pagination.1.json
+++ b/contracts/transaction-receipt-contract/test_snapshots/integration_tests/test_integration_deal_queries_and_pagination.1.json
@@ -1,0 +1,1896 @@
+{
+  "generators": {
+    "address": 4,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "record_receipt",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "amount_ngn"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "amount_usdc"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 10000000000
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "deal_id"
+                      },
+                      "val": {
+                        "string": "paging_deal"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "external_ref"
+                      },
+                      "val": {
+                        "string": "p_ref_0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "external_ref_source"
+                      },
+                      "val": {
+                        "symbol": "manual_admin"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "from"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "fx_provider"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "fx_rate_ngn_per_usdc"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "listing_id"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata_hash"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "to"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "token"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "tx_type"
+                      },
+                      "val": {
+                        "symbol": "rent_payment"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "record_receipt",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "amount_ngn"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "amount_usdc"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 10000000001
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "deal_id"
+                      },
+                      "val": {
+                        "string": "paging_deal"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "external_ref"
+                      },
+                      "val": {
+                        "string": "p_ref_1"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "external_ref_source"
+                      },
+                      "val": {
+                        "symbol": "manual_admin"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "from"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "fx_provider"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "fx_rate_ngn_per_usdc"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "listing_id"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata_hash"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "to"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "token"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "tx_type"
+                      },
+                      "val": {
+                        "symbol": "rent_payment"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "record_receipt",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "amount_ngn"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "amount_usdc"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 10000000002
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "deal_id"
+                      },
+                      "val": {
+                        "string": "paging_deal"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "external_ref"
+                      },
+                      "val": {
+                        "string": "p_ref_2"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "external_ref_source"
+                      },
+                      "val": {
+                        "symbol": "manual_admin"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "from"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "fx_provider"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "fx_rate_ngn_per_usdc"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "listing_id"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata_hash"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "to"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "token"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "tx_type"
+                      },
+                      "val": {
+                        "symbol": "rent_payment"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "record_receipt",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "amount_ngn"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "amount_usdc"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 10000000003
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "deal_id"
+                      },
+                      "val": {
+                        "string": "paging_deal"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "external_ref"
+                      },
+                      "val": {
+                        "string": "p_ref_3"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "external_ref_source"
+                      },
+                      "val": {
+                        "symbol": "manual_admin"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "from"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "fx_provider"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "fx_rate_ngn_per_usdc"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "listing_id"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata_hash"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "to"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "token"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "tx_type"
+                      },
+                      "val": {
+                        "symbol": "rent_payment"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "record_receipt",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "amount_ngn"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "amount_usdc"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 10000000004
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "deal_id"
+                      },
+                      "val": {
+                        "string": "paging_deal"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "external_ref"
+                      },
+                      "val": {
+                        "string": "p_ref_4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "external_ref_source"
+                      },
+                      "val": {
+                        "symbol": "manual_admin"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "from"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "fx_provider"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "fx_rate_ngn_per_usdc"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "listing_id"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata_hash"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "to"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "token"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "tx_type"
+                      },
+                      "val": {
+                        "symbol": "rent_payment"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "DealCount"
+                },
+                {
+                  "string": "paging_deal"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "DealCount"
+                    },
+                    {
+                      "string": "paging_deal"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 5
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "DealIndex"
+                },
+                {
+                  "string": "paging_deal"
+                },
+                {
+                  "u32": 0
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "DealIndex"
+                    },
+                    {
+                      "string": "paging_deal"
+                    },
+                    {
+                      "u32": 0
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "bytes": "e6eae410edd8ebaaf741645533204f78a87ceeb679a1a45e5372c5d68845afd0"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "DealIndex"
+                },
+                {
+                  "string": "paging_deal"
+                },
+                {
+                  "u32": 1
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "DealIndex"
+                    },
+                    {
+                      "string": "paging_deal"
+                    },
+                    {
+                      "u32": 1
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "bytes": "b9d763820576c19f46180b326b0f1d60879d7401aa315d9ea7e541ecf21110e8"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "DealIndex"
+                },
+                {
+                  "string": "paging_deal"
+                },
+                {
+                  "u32": 2
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "DealIndex"
+                    },
+                    {
+                      "string": "paging_deal"
+                    },
+                    {
+                      "u32": 2
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "bytes": "20c939a1fd147a6b69e6c605ed7e5b1a1b9f70594d3b887933b26ca44e9206b4"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "DealIndex"
+                },
+                {
+                  "string": "paging_deal"
+                },
+                {
+                  "u32": 3
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "DealIndex"
+                    },
+                    {
+                      "string": "paging_deal"
+                    },
+                    {
+                      "u32": 3
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "bytes": "c92f5de55ec1b815fc9b09fa7d87ab09521a387e94aa54a38bfeb2c35135d750"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "DealIndex"
+                },
+                {
+                  "string": "paging_deal"
+                },
+                {
+                  "u32": 4
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "DealIndex"
+                    },
+                    {
+                      "string": "paging_deal"
+                    },
+                    {
+                      "u32": 4
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "bytes": "41341d04f1bfddafe768e1d991dd78c66ae47ae177e0e8e0d8a20e6b4d8ef43b"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Receipt"
+                },
+                {
+                  "bytes": "20c939a1fd147a6b69e6c605ed7e5b1a1b9f70594d3b887933b26ca44e9206b4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Receipt"
+                    },
+                    {
+                      "bytes": "20c939a1fd147a6b69e6c605ed7e5b1a1b9f70594d3b887933b26ca44e9206b4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "amount_ngn"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "amount_usdc"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 10000000002
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "deal_id"
+                      },
+                      "val": {
+                        "string": "paging_deal"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "external_ref"
+                      },
+                      "val": {
+                        "bytes": "20c939a1fd147a6b69e6c605ed7e5b1a1b9f70594d3b887933b26ca44e9206b4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "from"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "fx_provider"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "fx_rate_ngn_per_usdc"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "listing_id"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata_hash"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "timestamp"
+                      },
+                      "val": {
+                        "u64": 0
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "to"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "token"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "tx_id"
+                      },
+                      "val": {
+                        "bytes": "20c939a1fd147a6b69e6c605ed7e5b1a1b9f70594d3b887933b26ca44e9206b4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "tx_type"
+                      },
+                      "val": {
+                        "symbol": "rent_payment"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Receipt"
+                },
+                {
+                  "bytes": "41341d04f1bfddafe768e1d991dd78c66ae47ae177e0e8e0d8a20e6b4d8ef43b"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Receipt"
+                    },
+                    {
+                      "bytes": "41341d04f1bfddafe768e1d991dd78c66ae47ae177e0e8e0d8a20e6b4d8ef43b"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "amount_ngn"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "amount_usdc"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 10000000004
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "deal_id"
+                      },
+                      "val": {
+                        "string": "paging_deal"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "external_ref"
+                      },
+                      "val": {
+                        "bytes": "41341d04f1bfddafe768e1d991dd78c66ae47ae177e0e8e0d8a20e6b4d8ef43b"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "from"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "fx_provider"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "fx_rate_ngn_per_usdc"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "listing_id"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata_hash"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "timestamp"
+                      },
+                      "val": {
+                        "u64": 0
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "to"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "token"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "tx_id"
+                      },
+                      "val": {
+                        "bytes": "41341d04f1bfddafe768e1d991dd78c66ae47ae177e0e8e0d8a20e6b4d8ef43b"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "tx_type"
+                      },
+                      "val": {
+                        "symbol": "rent_payment"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Receipt"
+                },
+                {
+                  "bytes": "b9d763820576c19f46180b326b0f1d60879d7401aa315d9ea7e541ecf21110e8"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Receipt"
+                    },
+                    {
+                      "bytes": "b9d763820576c19f46180b326b0f1d60879d7401aa315d9ea7e541ecf21110e8"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "amount_ngn"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "amount_usdc"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 10000000001
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "deal_id"
+                      },
+                      "val": {
+                        "string": "paging_deal"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "external_ref"
+                      },
+                      "val": {
+                        "bytes": "b9d763820576c19f46180b326b0f1d60879d7401aa315d9ea7e541ecf21110e8"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "from"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "fx_provider"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "fx_rate_ngn_per_usdc"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "listing_id"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata_hash"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "timestamp"
+                      },
+                      "val": {
+                        "u64": 0
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "to"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "token"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "tx_id"
+                      },
+                      "val": {
+                        "bytes": "b9d763820576c19f46180b326b0f1d60879d7401aa315d9ea7e541ecf21110e8"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "tx_type"
+                      },
+                      "val": {
+                        "symbol": "rent_payment"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Receipt"
+                },
+                {
+                  "bytes": "c92f5de55ec1b815fc9b09fa7d87ab09521a387e94aa54a38bfeb2c35135d750"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Receipt"
+                    },
+                    {
+                      "bytes": "c92f5de55ec1b815fc9b09fa7d87ab09521a387e94aa54a38bfeb2c35135d750"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "amount_ngn"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "amount_usdc"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 10000000003
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "deal_id"
+                      },
+                      "val": {
+                        "string": "paging_deal"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "external_ref"
+                      },
+                      "val": {
+                        "bytes": "c92f5de55ec1b815fc9b09fa7d87ab09521a387e94aa54a38bfeb2c35135d750"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "from"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "fx_provider"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "fx_rate_ngn_per_usdc"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "listing_id"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata_hash"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "timestamp"
+                      },
+                      "val": {
+                        "u64": 0
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "to"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "token"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "tx_id"
+                      },
+                      "val": {
+                        "bytes": "c92f5de55ec1b815fc9b09fa7d87ab09521a387e94aa54a38bfeb2c35135d750"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "tx_type"
+                      },
+                      "val": {
+                        "symbol": "rent_payment"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Receipt"
+                },
+                {
+                  "bytes": "e6eae410edd8ebaaf741645533204f78a87ceeb679a1a45e5372c5d68845afd0"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Receipt"
+                    },
+                    {
+                      "bytes": "e6eae410edd8ebaaf741645533204f78a87ceeb679a1a45e5372c5d68845afd0"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "amount_ngn"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "amount_usdc"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 10000000000
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "deal_id"
+                      },
+                      "val": {
+                        "string": "paging_deal"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "external_ref"
+                      },
+                      "val": {
+                        "bytes": "e6eae410edd8ebaaf741645533204f78a87ceeb679a1a45e5372c5d68845afd0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "from"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "fx_provider"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "fx_rate_ngn_per_usdc"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "listing_id"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata_hash"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "timestamp"
+                      },
+                      "val": {
+                        "u64": 0
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "to"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "token"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "tx_id"
+                      },
+                      "val": {
+                        "bytes": "e6eae410edd8ebaaf741645533204f78a87ceeb679a1a45e5372c5d68845afd0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "tx_type"
+                      },
+                      "val": {
+                        "symbol": "rent_payment"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Operator"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Paused"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 801925984706572462
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 1033654523790656264
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 1033654523790656264
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 2032731177588607455
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 2032731177588607455
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 4837995959683129791
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 4837995959683129791
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 5541220902715666415
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 5541220902715666415
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/transaction-receipt-contract/test_snapshots/integration_tests/test_integration_init_record_query.1.json
+++ b/contracts/transaction-receipt-contract/test_snapshots/integration_tests/test_integration_init_record_query.1.json
@@ -1,0 +1,1249 @@
+{
+  "generators": {
+    "address": 4,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "record_receipt",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "amount_ngn"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "amount_usdc"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 10000000000
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "deal_id"
+                      },
+                      "val": {
+                        "string": "dealA"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "external_ref"
+                      },
+                      "val": {
+                        "string": "a_ref_1"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "external_ref_source"
+                      },
+                      "val": {
+                        "symbol": "manual_admin"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "from"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "fx_provider"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "fx_rate_ngn_per_usdc"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "listing_id"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata_hash"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "to"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "token"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "tx_type"
+                      },
+                      "val": {
+                        "symbol": "rent_payment"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "record_receipt",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "amount_ngn"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "amount_usdc"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 20000000000
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "deal_id"
+                      },
+                      "val": {
+                        "string": "dealA"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "external_ref"
+                      },
+                      "val": {
+                        "string": "a_ref_2"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "external_ref_source"
+                      },
+                      "val": {
+                        "symbol": "manual_admin"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "from"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "fx_provider"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "fx_rate_ngn_per_usdc"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "listing_id"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata_hash"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "to"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "token"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "tx_type"
+                      },
+                      "val": {
+                        "symbol": "rent_payment"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "record_receipt",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "amount_ngn"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "amount_usdc"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 30000000000
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "deal_id"
+                      },
+                      "val": {
+                        "string": "dealB"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "external_ref"
+                      },
+                      "val": {
+                        "string": "b_ref_1"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "external_ref_source"
+                      },
+                      "val": {
+                        "symbol": "manual_admin"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "from"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "fx_provider"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "fx_rate_ngn_per_usdc"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "listing_id"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata_hash"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "to"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "token"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "tx_type"
+                      },
+                      "val": {
+                        "symbol": "rent_payment"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [],
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "DealCount"
+                },
+                {
+                  "string": "dealA"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "DealCount"
+                    },
+                    {
+                      "string": "dealA"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "DealCount"
+                },
+                {
+                  "string": "dealB"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "DealCount"
+                    },
+                    {
+                      "string": "dealB"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 1
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "DealIndex"
+                },
+                {
+                  "string": "dealA"
+                },
+                {
+                  "u32": 0
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "DealIndex"
+                    },
+                    {
+                      "string": "dealA"
+                    },
+                    {
+                      "u32": 0
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "bytes": "659652e4e9d066be4210057a66f0f1788d74a6ef3eee17a1bfd6316402e5953c"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "DealIndex"
+                },
+                {
+                  "string": "dealA"
+                },
+                {
+                  "u32": 1
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "DealIndex"
+                    },
+                    {
+                      "string": "dealA"
+                    },
+                    {
+                      "u32": 1
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "bytes": "cc2e97b6f4064815f8d6f798edf9ea7c76d82275a0ec2361d0ef440032dc72f4"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "DealIndex"
+                },
+                {
+                  "string": "dealB"
+                },
+                {
+                  "u32": 0
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "DealIndex"
+                    },
+                    {
+                      "string": "dealB"
+                    },
+                    {
+                      "u32": 0
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "bytes": "89c0061a6629a341a4403a6adc27640976740271a9b031913ab68093871ed477"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Receipt"
+                },
+                {
+                  "bytes": "659652e4e9d066be4210057a66f0f1788d74a6ef3eee17a1bfd6316402e5953c"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Receipt"
+                    },
+                    {
+                      "bytes": "659652e4e9d066be4210057a66f0f1788d74a6ef3eee17a1bfd6316402e5953c"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "amount_ngn"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "amount_usdc"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 10000000000
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "deal_id"
+                      },
+                      "val": {
+                        "string": "dealA"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "external_ref"
+                      },
+                      "val": {
+                        "bytes": "659652e4e9d066be4210057a66f0f1788d74a6ef3eee17a1bfd6316402e5953c"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "from"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "fx_provider"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "fx_rate_ngn_per_usdc"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "listing_id"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata_hash"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "timestamp"
+                      },
+                      "val": {
+                        "u64": 0
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "to"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "token"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "tx_id"
+                      },
+                      "val": {
+                        "bytes": "659652e4e9d066be4210057a66f0f1788d74a6ef3eee17a1bfd6316402e5953c"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "tx_type"
+                      },
+                      "val": {
+                        "symbol": "rent_payment"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Receipt"
+                },
+                {
+                  "bytes": "89c0061a6629a341a4403a6adc27640976740271a9b031913ab68093871ed477"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Receipt"
+                    },
+                    {
+                      "bytes": "89c0061a6629a341a4403a6adc27640976740271a9b031913ab68093871ed477"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "amount_ngn"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "amount_usdc"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 30000000000
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "deal_id"
+                      },
+                      "val": {
+                        "string": "dealB"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "external_ref"
+                      },
+                      "val": {
+                        "bytes": "89c0061a6629a341a4403a6adc27640976740271a9b031913ab68093871ed477"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "from"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "fx_provider"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "fx_rate_ngn_per_usdc"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "listing_id"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata_hash"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "timestamp"
+                      },
+                      "val": {
+                        "u64": 0
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "to"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "token"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "tx_id"
+                      },
+                      "val": {
+                        "bytes": "89c0061a6629a341a4403a6adc27640976740271a9b031913ab68093871ed477"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "tx_type"
+                      },
+                      "val": {
+                        "symbol": "rent_payment"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Receipt"
+                },
+                {
+                  "bytes": "cc2e97b6f4064815f8d6f798edf9ea7c76d82275a0ec2361d0ef440032dc72f4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Receipt"
+                    },
+                    {
+                      "bytes": "cc2e97b6f4064815f8d6f798edf9ea7c76d82275a0ec2361d0ef440032dc72f4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "amount_ngn"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "amount_usdc"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 20000000000
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "deal_id"
+                      },
+                      "val": {
+                        "string": "dealA"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "external_ref"
+                      },
+                      "val": {
+                        "bytes": "cc2e97b6f4064815f8d6f798edf9ea7c76d82275a0ec2361d0ef440032dc72f4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "from"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "fx_provider"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "fx_rate_ngn_per_usdc"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "listing_id"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata_hash"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "timestamp"
+                      },
+                      "val": {
+                        "u64": 0
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "to"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "token"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "tx_id"
+                      },
+                      "val": {
+                        "bytes": "cc2e97b6f4064815f8d6f798edf9ea7c76d82275a0ec2361d0ef440032dc72f4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "tx_type"
+                      },
+                      "val": {
+                        "symbol": "rent_payment"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Operator"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Paused"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 801925984706572462
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 1033654523790656264
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 1033654523790656264
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 5541220902715666415
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 5541220902715666415
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/transaction-receipt-contract/test_snapshots/integration_tests/test_integration_pause_flow.1.json
+++ b/contracts/transaction-receipt-contract/test_snapshots/integration_tests/test_integration_pause_flow.1.json
@@ -1,0 +1,1083 @@
+{
+  "generators": {
+    "address": 4,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "record_receipt",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "amount_ngn"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "amount_usdc"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 100000000000
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "deal_id"
+                      },
+                      "val": {
+                        "string": "pause_deal"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "external_ref"
+                      },
+                      "val": {
+                        "string": "pause_ref"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "external_ref_source"
+                      },
+                      "val": {
+                        "symbol": "manual_admin"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "from"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "fx_provider"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "fx_rate_ngn_per_usdc"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "listing_id"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata_hash"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "to"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "token"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "tx_type"
+                      },
+                      "val": {
+                        "symbol": "rent_payment"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "pause",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "unpause",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "record_receipt",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "amount_ngn"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "amount_usdc"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 100000000000
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "deal_id"
+                      },
+                      "val": {
+                        "string": "pause_deal"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "external_ref"
+                      },
+                      "val": {
+                        "string": "pause_ref2"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "external_ref_source"
+                      },
+                      "val": {
+                        "symbol": "manual_admin"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "from"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "fx_provider"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "fx_rate_ngn_per_usdc"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "listing_id"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata_hash"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "to"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "token"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "tx_type"
+                      },
+                      "val": {
+                        "symbol": "rent_payment"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ]
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "DealCount"
+                },
+                {
+                  "string": "pause_deal"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "DealCount"
+                    },
+                    {
+                      "string": "pause_deal"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "DealIndex"
+                },
+                {
+                  "string": "pause_deal"
+                },
+                {
+                  "u32": 0
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "DealIndex"
+                    },
+                    {
+                      "string": "pause_deal"
+                    },
+                    {
+                      "u32": 0
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "bytes": "c8c6bfa19ffbbb8d01e85db166c1c3c2cc237b98ce052aa23476fd8f4eb2c9bf"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "DealIndex"
+                },
+                {
+                  "string": "pause_deal"
+                },
+                {
+                  "u32": 1
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "DealIndex"
+                    },
+                    {
+                      "string": "pause_deal"
+                    },
+                    {
+                      "u32": 1
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "bytes": "36d47119443a73f8c0fd40cf2861d787b15aa54a5db1a887283e716ed9ae51f7"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Receipt"
+                },
+                {
+                  "bytes": "36d47119443a73f8c0fd40cf2861d787b15aa54a5db1a887283e716ed9ae51f7"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Receipt"
+                    },
+                    {
+                      "bytes": "36d47119443a73f8c0fd40cf2861d787b15aa54a5db1a887283e716ed9ae51f7"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "amount_ngn"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "amount_usdc"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 100000000000
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "deal_id"
+                      },
+                      "val": {
+                        "string": "pause_deal"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "external_ref"
+                      },
+                      "val": {
+                        "bytes": "36d47119443a73f8c0fd40cf2861d787b15aa54a5db1a887283e716ed9ae51f7"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "from"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "fx_provider"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "fx_rate_ngn_per_usdc"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "listing_id"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata_hash"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "timestamp"
+                      },
+                      "val": {
+                        "u64": 0
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "to"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "token"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "tx_id"
+                      },
+                      "val": {
+                        "bytes": "36d47119443a73f8c0fd40cf2861d787b15aa54a5db1a887283e716ed9ae51f7"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "tx_type"
+                      },
+                      "val": {
+                        "symbol": "rent_payment"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Receipt"
+                },
+                {
+                  "bytes": "c8c6bfa19ffbbb8d01e85db166c1c3c2cc237b98ce052aa23476fd8f4eb2c9bf"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Receipt"
+                    },
+                    {
+                      "bytes": "c8c6bfa19ffbbb8d01e85db166c1c3c2cc237b98ce052aa23476fd8f4eb2c9bf"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "amount_ngn"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "amount_usdc"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 100000000000
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "deal_id"
+                      },
+                      "val": {
+                        "string": "pause_deal"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "external_ref"
+                      },
+                      "val": {
+                        "bytes": "c8c6bfa19ffbbb8d01e85db166c1c3c2cc237b98ce052aa23476fd8f4eb2c9bf"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "from"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "fx_provider"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "fx_rate_ngn_per_usdc"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "listing_id"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata_hash"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "timestamp"
+                      },
+                      "val": {
+                        "u64": 0
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "to"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "token"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "tx_id"
+                      },
+                      "val": {
+                        "bytes": "c8c6bfa19ffbbb8d01e85db166c1c3c2cc237b98ce052aa23476fd8f4eb2c9bf"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "tx_type"
+                      },
+                      "val": {
+                        "symbol": "rent_payment"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Operator"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Paused"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 4837995959683129791
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 4837995959683129791
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 5541220902715666415
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 5541220902715666415
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 801925984706572462
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 2032731177588607455
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 2032731177588607455
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "string": "receipt"
+              },
+              {
+                "bytes": "36d47119443a73f8c0fd40cf2861d787b15aa54a5db1a887283e716ed9ae51f7"
+              }
+            ],
+            "data": {
+              "map": [
+                {
+                  "key": {
+                    "symbol": "amount_ngn"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
+                    "symbol": "amount_usdc"
+                  },
+                  "val": {
+                    "i128": {
+                      "hi": 0,
+                      "lo": 100000000000
+                    }
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "deal_id"
+                  },
+                  "val": {
+                    "string": "pause_deal"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "external_ref"
+                  },
+                  "val": {
+                    "bytes": "36d47119443a73f8c0fd40cf2861d787b15aa54a5db1a887283e716ed9ae51f7"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "from"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
+                    "symbol": "fx_provider"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
+                    "symbol": "fx_rate_ngn_per_usdc"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
+                    "symbol": "listing_id"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
+                    "symbol": "metadata_hash"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
+                    "symbol": "timestamp"
+                  },
+                  "val": {
+                    "u64": 0
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "to"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
+                    "symbol": "token"
+                  },
+                  "val": {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "tx_id"
+                  },
+                  "val": {
+                    "bytes": "36d47119443a73f8c0fd40cf2861d787b15aa54a5db1a887283e716ed9ae51f7"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "tx_type"
+                  },
+                  "val": {
+                    "symbol": "rent_payment"
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    }
+  ]
+}

--- a/contracts/transaction-receipt-contract/test_snapshots/test/test_init_already_initialized.1.json
+++ b/contracts/transaction-receipt-contract/test_snapshots/test/test_init_already_initialized.1.json
@@ -1,0 +1,116 @@
+{
+  "generators": {
+    "address": 5,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [],
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Operator"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Paused"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/transaction-receipt-contract/test_snapshots/test/test_init_success.1.json
+++ b/contracts/transaction-receipt-contract/test_snapshots/test/test_init_success.1.json
@@ -1,0 +1,116 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [],
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Operator"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Paused"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/transaction-receipt-contract/test_snapshots/test/test_init_with_same_admin_and_operator.1.json
+++ b/contracts/transaction-receipt-contract/test_snapshots/test/test_init_with_same_admin_and_operator.1.json
@@ -1,0 +1,115 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Operator"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Paused"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/transaction-receipt-contract/test_snapshots/test/test_pause_idempotent.1.json
+++ b/contracts/transaction-receipt-contract/test_snapshots/test/test_pause_idempotent.1.json
@@ -1,0 +1,219 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "pause",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "pause",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Operator"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Paused"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": true
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 801925984706572462
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 5541220902715666415
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 5541220902715666415
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/transaction-receipt-contract/test_snapshots/test/test_pause_not_authorized.1.json
+++ b/contracts/transaction-receipt-contract/test_snapshots/test/test_pause_not_authorized.1.json
@@ -1,0 +1,115 @@
+{
+  "generators": {
+    "address": 4,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Operator"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Paused"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/transaction-receipt-contract/test_snapshots/test/test_pause_success.1.json
+++ b/contracts/transaction-receipt-contract/test_snapshots/test/test_pause_success.1.json
@@ -1,0 +1,166 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "pause",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Operator"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Paused"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": true
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 801925984706572462
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/transaction-receipt-contract/test_snapshots/test/test_pause_unpause_cycle.1.json
+++ b/contracts/transaction-receipt-contract/test_snapshots/test/test_pause_unpause_cycle.1.json
@@ -1,0 +1,273 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "pause",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "unpause",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "pause",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Operator"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Paused"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": true
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 801925984706572462
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 1033654523790656264
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 1033654523790656264
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 5541220902715666415
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 5541220902715666415
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/transaction-receipt-contract/test_snapshots/test/test_unpause_idempotent.1.json
+++ b/contracts/transaction-receipt-contract/test_snapshots/test/test_unpause_idempotent.1.json
@@ -1,0 +1,219 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "unpause",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "unpause",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Operator"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Paused"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 801925984706572462
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 5541220902715666415
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 5541220902715666415
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/transaction-receipt-contract/test_snapshots/test/test_unpause_not_authorized.1.json
+++ b/contracts/transaction-receipt-contract/test_snapshots/test/test_unpause_not_authorized.1.json
@@ -1,0 +1,167 @@
+{
+  "generators": {
+    "address": 4,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "pause",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Operator"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Paused"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": true
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 801925984706572462
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/transaction-receipt-contract/test_snapshots/test/test_unpause_success.1.json
+++ b/contracts/transaction-receipt-contract/test_snapshots/test/test_unpause_success.1.json
@@ -1,0 +1,219 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "pause",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "unpause",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Operator"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Paused"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 801925984706572462
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 5541220902715666415
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 5541220902715666415
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}


### PR DESCRIPTION
## Summary
The Transaction Receipt Contract is a Soroban smart contract that provides immutable, auditable storage for all money movements in the Sheltaflex hybrid system. Every transaction is recorded on-chain with standardized USDC amounts, while NGN values serve as metadata only. The contract enforces strict duplicate prevention through deterministic transaction ID generation and provides query capabilities for audit purposes.

## Linked issue

Closes #43 

## Changes

The contract:
- Records canonical transaction receipts for on-chain indexing and audit.
- Prevents duplicate receipts using a deterministic tx_id derived from external payment references.
- Provides query APIs to fetch receipts and list receipts by deal with pagination.
## How to test

Run the contract tests with:

```bash
cargo test --manifest-path monorepo/contracts/transaction-receipt-contract/Cargo.toml
```
## Screenshots (if UI)

## Checklist

- [ x] I linked an issue (or explained why one is not needed)
- [ x] I tested locally
- [ ] I did not commit secrets
- [ x] I updated docs if needed
