### PR TITLE
feat/Deal payment progress computed

### DIFF
--- a/backend/openapi.yml
+++ b/backend/openapi.yml
@@ -748,6 +748,68 @@ paths:
         default:
           $ref: '#/components/responses/Error'
 
+  /api/deals/{dealId}/progress:
+    get:
+      summary: Get deal payment progress from on-chain receipts
+      description: |
+        Computes and returns a deal's payment progress by reading `TENANT_REPAYMENT`
+        receipts from the on-chain ledger (outbox store).
+
+        Only receipts with status `sent` (confirmed on-chain) are counted.
+        USDC is the canonical accounting unit.
+      operationId: getDealProgress
+      tags:
+        - Deals
+      parameters:
+        - name: dealId
+          in: path
+          required: true
+          description: ID of the deal
+          schema:
+            type: string
+            format: uuid
+            example: 550e8400-e29b-41d4-a716-446655440000
+      responses:
+        '200':
+          description: Deal progress computed from on-chain receipts
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - success
+                  - data
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    $ref: '#/components/schemas/DealProgressResponse'
+              example:
+                success: true
+                data:
+                  totalPaidUsdc: "129.040000"
+                  periodsPaid: 2
+                  remainingPeriods: 10
+                  nextDueDate: "2024-04-15T00:00:00.000Z"
+                  lastPaymentTxId: "a3f2c1d4e5b6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2"
+                  lastPaymentExternalRefSource: stripe
+                  lastPaymentExternalRef: pi_3OZxyz123456
+        '404':
+          description: Deal not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              example:
+                error:
+                  code: NOT_FOUND
+                  message: Deal with ID '550e8400-e29b-41d4-a716-446655440000' not found
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        default:
+          $ref: '#/components/responses/Error'
+
   /api/admin/rewards/{rewardId}/mark-paid:
     post:
       summary: Mark reward as paid
@@ -1515,6 +1577,45 @@ components:
           format: date-time
           description: ISO 8601 timestamp when the reward was paid (only present when status is "paid")
           example: "2024-01-20T14:45:00Z"
+
+    DealProgressResponse:
+      type: object
+      required:
+        - totalPaidUsdc
+        - periodsPaid
+        - remainingPeriods
+        - nextDueDate
+      properties:
+        totalPaidUsdc:
+          type: string
+          description: Total USDC paid across all confirmed on-chain TENANT_REPAYMENT receipts (decimal string with 6 decimal places)
+          example: "129.040000"
+        periodsPaid:
+          type: integer
+          description: Number of TENANT_REPAYMENT receipts confirmed on-chain
+          example: 2
+        remainingPeriods:
+          type: integer
+          description: Number of remaining repayment periods (termMonths minus periodsPaid, clamped to >= 0)
+          example: 10
+        nextDueDate:
+          type: string
+          format: date-time
+          nullable: true
+          description: ISO 8601 due date of the next scheduled payment; null if fully paid
+          example: "2024-04-15T00:00:00.000Z"
+        lastPaymentTxId:
+          type: string
+          description: txId (SHA-256 hex) of the most recent confirmed receipt
+          example: "a3f2c1d4e5b6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2"
+        lastPaymentExternalRefSource:
+          type: string
+          description: Source part of the canonical external reference (e.g. "stripe", "manual")
+          example: stripe
+        lastPaymentExternalRef:
+          type: string
+          description: Reference part of the canonical external reference (e.g. payment intent ID)
+          example: pi_3OZxyz123456
 
     Error:
       type: object

--- a/backend/src/outbox/store.ts
+++ b/backend/src/outbox/store.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto'
 import {
   OutboxStatus,
+  TxType,
   type OutboxItem,
   type CreateOutboxItemInput,
   type CanonicalExternalRefV1,
@@ -108,6 +109,21 @@ class OutboxStore {
 
     this.items.set(id, item)
     return item
+  }
+
+  /**
+   * List items by dealId, optionally filtered by txType
+   * Only returns items whose payload.dealId matches.
+   */
+  async listByDealId(dealId: string, txType?: TxType): Promise<OutboxItem[]> {
+    const items: OutboxItem[] = []
+    for (const item of this.items.values()) {
+      if (item.payload.dealId !== dealId) continue
+      if (txType !== undefined && item.txType !== txType) continue
+      items.push(item)
+    }
+    // Sort by createdAt ascending (chronological order)
+    return items.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime())
   }
 
   /**

--- a/backend/src/routes/deals.test.ts
+++ b/backend/src/routes/deals.test.ts
@@ -2,6 +2,10 @@ import { describe, it, expect, beforeEach } from 'vitest'
 import request from 'supertest'
 import { createApp } from '../app.js'
 import { dealStore } from '../models/dealStore.js'
+import { outboxStore } from '../outbox/store.js'
+import { OutboxStatus, TxType } from '../outbox/types.js'
+import { listingStore } from '../models/listingStore.js'
+import { ListingStatus } from '../models/listing.js'
 
 describe('Deals API', () => {
   let app: any
@@ -12,11 +16,30 @@ describe('Deals API', () => {
   })
 
   describe('POST /api/deals', () => {
+    let approvedListingId: string
+
+    beforeEach(async () => {
+      await listingStore.clear()
+      const listing = await listingStore.create({
+        whistleblowerId: 'wb-001',
+        address: '123 Test St',
+        city: 'Lagos',
+        area: 'Ikeja',
+        bedrooms: 2,
+        bathrooms: 2,
+        annualRentNgn: 1200000,
+        description: 'Test listing',
+        photos: []
+      })
+      await listingStore.updateStatus(listing.listingId, ListingStatus.APPROVED)
+      approvedListingId = listing.listingId
+    })
+
     it('should create a new deal with valid data', async () => {
       const dealData = {
         tenantId: 'tenant-001',
         landlordId: 'landlord-001',
-        listingId: '550e8400-e29b-41d4-a716-446655440001',
+        listingId: approvedListingId,
         annualRentNgn: 1200000,
         depositNgn: 240000,
         termMonths: 12
@@ -273,6 +296,150 @@ describe('Deals API', () => {
       const response = await request(app)
         .patch(`/api/deals/${fakeId}/schedule/1`)
         .send({ status: 'paid' })
+        .expect(404)
+
+      expect(response.body.error.code).toBe('NOT_FOUND')
+    })
+  })
+
+  describe('GET /api/deals/:dealId/progress', () => {
+    let dealId: string
+
+    beforeEach(async () => {
+      await outboxStore.clear()
+      // Create a fresh deal for each test
+      const createRes = await request(app)
+        .post('/api/deals')
+        .send({
+          tenantId: 'tenant-001',
+          landlordId: 'landlord-001',
+          annualRentNgn: 1200000,
+          depositNgn: 240000,
+          termMonths: 12,
+        })
+      dealId = createRes.body.data.dealId
+    })
+
+    it('should return zero progress when no receipts exist', async () => {
+      const response = await request(app)
+        .get(`/api/deals/${dealId}/progress`)
+        .expect(200)
+
+      expect(response.body.success).toBe(true)
+      const data = response.body.data
+      expect(data.periodsPaid).toBe(0)
+      expect(data.totalPaidUsdc).toBe('0.000000')
+      expect(data.remainingPeriods).toBe(12)
+      expect(data.nextDueDate).toBeDefined()
+      expect(data.nextDueDate).not.toBeNull()
+      expect(data.lastPaymentTxId).toBeUndefined()
+    })
+
+    it('should count only SENT TENANT_REPAYMENT receipts', async () => {
+      // Create a SENT receipt
+      const sentItem = await outboxStore.create({
+        txType: TxType.TENANT_REPAYMENT,
+        canonicalExternalRefV1: 'stripe:pi_sent_001',
+        payload: { dealId, amountUsdc: '64.52', tokenAddress: 'USDC_ADDR', txType: TxType.TENANT_REPAYMENT },
+      })
+      await outboxStore.updateStatus(sentItem.id, OutboxStatus.SENT)
+
+      // Create a PENDING receipt (should NOT be counted)
+      await outboxStore.create({
+        txType: TxType.TENANT_REPAYMENT,
+        canonicalExternalRefV1: 'stripe:pi_pending_002',
+        payload: { dealId, amountUsdc: '64.52', tokenAddress: 'USDC_ADDR', txType: TxType.TENANT_REPAYMENT },
+      })
+
+      // Create a FAILED receipt (should NOT be counted)
+      const failedItem = await outboxStore.create({
+        txType: TxType.TENANT_REPAYMENT,
+        canonicalExternalRefV1: 'stripe:pi_failed_003',
+        payload: { dealId, amountUsdc: '64.52', tokenAddress: 'USDC_ADDR', txType: TxType.TENANT_REPAYMENT },
+      })
+      await outboxStore.updateStatus(failedItem.id, OutboxStatus.FAILED)
+
+      const response = await request(app)
+        .get(`/api/deals/${dealId}/progress`)
+        .expect(200)
+
+      const data = response.body.data
+      expect(data.periodsPaid).toBe(1)
+      expect(data.totalPaidUsdc).toBe('64.520000')
+      expect(data.remainingPeriods).toBe(11)
+      expect(data.lastPaymentTxId).toBe(sentItem.txId)
+      expect(data.lastPaymentExternalRefSource).toBe('stripe')
+      expect(data.lastPaymentExternalRef).toBe('pi_sent_001')
+    })
+
+    it('should sum multiple SENT receipts and pick the latest as last payment', async () => {
+      const item1 = await outboxStore.create({
+        txType: TxType.TENANT_REPAYMENT,
+        canonicalExternalRefV1: 'stripe:pi_aaa',
+        payload: { dealId, amountUsdc: '50.00', tokenAddress: 'USDC_ADDR', txType: TxType.TENANT_REPAYMENT },
+      })
+      await outboxStore.updateStatus(item1.id, OutboxStatus.SENT)
+
+      const item2 = await outboxStore.create({
+        txType: TxType.TENANT_REPAYMENT,
+        canonicalExternalRefV1: 'stellar:txhash_bbb',
+        payload: { dealId, amountUsdc: '79.04', tokenAddress: 'USDC_ADDR', txType: TxType.TENANT_REPAYMENT },
+      })
+      await outboxStore.updateStatus(item2.id, OutboxStatus.SENT)
+
+      const response = await request(app)
+        .get(`/api/deals/${dealId}/progress`)
+        .expect(200)
+
+      const data = response.body.data
+      expect(data.periodsPaid).toBe(2)
+      expect(data.totalPaidUsdc).toBe('129.040000')
+      expect(data.remainingPeriods).toBe(10)
+      expect(data.lastPaymentExternalRefSource).toBe('stellar')
+      expect(data.lastPaymentExternalRef).toBe('txhash_bbb')
+    })
+
+    it('should not count LANDLORD_PAYOUT receipts', async () => {
+      const item = await outboxStore.create({
+        txType: TxType.LANDLORD_PAYOUT,
+        canonicalExternalRefV1: 'manual:payout_001',
+        payload: { dealId, amountUsdc: '960.00', tokenAddress: 'USDC_ADDR', txType: TxType.LANDLORD_PAYOUT },
+      })
+      await outboxStore.updateStatus(item.id, OutboxStatus.SENT)
+
+      const response = await request(app)
+        .get(`/api/deals/${dealId}/progress`)
+        .expect(200)
+
+      expect(response.body.data.periodsPaid).toBe(0)
+      expect(response.body.data.totalPaidUsdc).toBe('0.000000')
+    })
+
+    it('should return nextDueDate as null when fully paid', async () => {
+      // Create 12 SENT receipts for a 12-month deal (= fully paid)
+      for (let i = 0; i < 12; i++) {
+        const item = await outboxStore.create({
+          txType: TxType.TENANT_REPAYMENT,
+          canonicalExternalRefV1: `stripe:pi_period_${i}`,
+          payload: { dealId, amountUsdc: '80000.00', tokenAddress: 'USDC_ADDR', txType: TxType.TENANT_REPAYMENT },
+        })
+        await outboxStore.updateStatus(item.id, OutboxStatus.SENT)
+      }
+
+      const response = await request(app)
+        .get(`/api/deals/${dealId}/progress`)
+        .expect(200)
+
+      const data = response.body.data
+      expect(data.periodsPaid).toBe(12)
+      expect(data.remainingPeriods).toBe(0)
+      expect(data.nextDueDate).toBeNull()
+    })
+
+    it('should return 404 for non-existent deal', async () => {
+      const fakeId = '550e8400-e29b-41d4-a716-446655440999'
+      const response = await request(app)
+        .get(`/api/deals/${fakeId}/progress`)
         .expect(404)
 
       expect(response.body.error.code).toBe('NOT_FOUND')

--- a/backend/src/routes/deals.ts
+++ b/backend/src/routes/deals.ts
@@ -18,6 +18,9 @@ import {
 } from '../schemas/deal.js'
 import { AppError } from '../errors/AppError.js'
 import { ErrorCode } from '../errors/errorCodes.js'
+import { outboxStore } from '../outbox/index.js'
+import { TxType } from '../outbox/types.js'
+import { computeDealProgress } from '../services/dealProgress.js'
 
 const router = Router()
 
@@ -40,7 +43,7 @@ const router = Router()
  * - Use distributed locks (Redis, etc.) for multi-instance deployments
  * - Add unique constraint on listing.dealId at database level
  */
-router.post('/', async (req: Request, res: Response) => {
+router.post('/', async (req: Request, res: Response, next) => {
   try {
     const validatedData: CreateDealRequest = createDealSchema.parse(req.body)
     
@@ -98,9 +101,41 @@ router.post('/', async (req: Request, res: Response) => {
     })
   } catch (error) {
     if (error instanceof Error && error.name === 'ZodError') {
-      throw new AppError(ErrorCode.VALIDATION_ERROR, 400, error.message)
+      return next(new AppError(ErrorCode.VALIDATION_ERROR, 400, error.message))
     }
-    throw error
+    next(error)
+  }
+})
+
+/**
+ * GET /api/deals/:dealId/progress
+ * Get a deal's payment progress computed from on-chain receipts
+ */
+router.get('/:dealId/progress', async (req: Request, res: Response, next) => {
+  try {
+    const { dealId } = req.params
+
+    if (!dealId) {
+      throw new AppError(ErrorCode.VALIDATION_ERROR, 400, 'Deal ID is required')
+    }
+
+    const deal = await dealStore.findById(dealId)
+
+    if (!deal) {
+      throw new AppError(ErrorCode.NOT_FOUND, 404, `Deal with ID ${dealId} not found`)
+    }
+
+    // Fetch all outbox items for this deal filtered to TENANT_REPAYMENT
+    const receipts = await outboxStore.listByDealId(dealId, TxType.TENANT_REPAYMENT)
+
+    const progress = computeDealProgress(deal, receipts)
+
+    res.json({
+      success: true,
+      data: progress,
+    })
+  } catch (error) {
+    next(error)
   }
 })
 
@@ -108,30 +143,34 @@ router.post('/', async (req: Request, res: Response) => {
  * GET /api/deals/:dealId
  * Get a specific deal by ID with schedule
  */
-router.get('/:dealId', async (req: Request, res: Response) => {
-  const { dealId } = req.params
-  
-  if (!dealId) {
-    throw new AppError(ErrorCode.VALIDATION_ERROR, 400, 'Deal ID is required')
+router.get('/:dealId', async (req: Request, res: Response, next) => {
+  try {
+    const { dealId } = req.params
+    
+    if (!dealId) {
+      throw new AppError(ErrorCode.VALIDATION_ERROR, 400, 'Deal ID is required')
+    }
+    
+    const deal = await dealStore.findById(dealId)
+    
+    if (!deal) {
+      throw new AppError(ErrorCode.NOT_FOUND, 404, `Deal with ID ${dealId} not found`)
+    }
+    
+    res.json({
+      success: true,
+      data: deal
+    })
+  } catch (error) {
+    next(error)
   }
-  
-  const deal = await dealStore.findById(dealId)
-  
-  if (!deal) {
-    throw new AppError(ErrorCode.NOT_FOUND, 404, `Deal with ID ${dealId} not found`)
-  }
-  
-  res.json({
-    success: true,
-    data: deal
-  })
 })
 
 /**
  * GET /api/deals
  * Get deals with optional filtering
  */
-router.get('/', async (req: Request, res: Response) => {
+router.get('/', async (req: Request, res: Response, next) => {
   try {
     const validatedFilters: DealFiltersRequest = dealFiltersSchema.parse(req.query)
     
@@ -143,9 +182,9 @@ router.get('/', async (req: Request, res: Response) => {
     })
   } catch (error) {
     if (error instanceof Error && error.name === 'ZodError') {
-      throw new AppError(ErrorCode.VALIDATION_ERROR, 400, error.message)
+      return next(new AppError(ErrorCode.VALIDATION_ERROR, 400, error.message))
     }
-    throw error
+    next(error)
   }
 })
 
@@ -153,11 +192,11 @@ router.get('/', async (req: Request, res: Response) => {
  * PATCH /api/deals/:dealId/status
  * Update deal status
  */
-router.patch('/:dealId/status', async (req: Request, res: Response) => {
+router.patch('/:dealId/status', async (req: Request, res: Response, next) => {
   const { dealId } = req.params
   
   if (!dealId) {
-    throw new AppError(ErrorCode.VALIDATION_ERROR, 400, 'Deal ID is required')
+    return next(new AppError(ErrorCode.VALIDATION_ERROR, 400, 'Deal ID is required'))
   }
   
   try {
@@ -175,9 +214,9 @@ router.patch('/:dealId/status', async (req: Request, res: Response) => {
     })
   } catch (error) {
     if (error instanceof Error && error.name === 'ZodError') {
-      throw new AppError(ErrorCode.VALIDATION_ERROR, 400, error.message)
+      return next(new AppError(ErrorCode.VALIDATION_ERROR, 400, error.message))
     }
-    throw error
+    next(error)
   }
 })
 
@@ -185,12 +224,12 @@ router.patch('/:dealId/status', async (req: Request, res: Response) => {
  * PATCH /api/deals/:dealId/schedule/:period
  * Update schedule item status
  */
-router.patch('/:dealId/schedule/:period', async (req: Request, res: Response) => {
+router.patch('/:dealId/schedule/:period', async (req: Request, res: Response, next) => {
   const { dealId } = req.params
   const period = parseInt(req.params.period, 10)
   
   if (!dealId || isNaN(period)) {
-    throw new AppError(ErrorCode.VALIDATION_ERROR, 400, 'Deal ID and period are required')
+    return next(new AppError(ErrorCode.VALIDATION_ERROR, 400, 'Deal ID and period are required'))
   }
   
   try {
@@ -215,9 +254,9 @@ router.patch('/:dealId/schedule/:period', async (req: Request, res: Response) =>
     })
   } catch (error) {
     if (error instanceof Error && error.name === 'ZodError') {
-      throw new AppError(ErrorCode.VALIDATION_ERROR, 400, error.message)
+      return next(new AppError(ErrorCode.VALIDATION_ERROR, 400, error.message))
     }
-    throw error
+    next(error)
   }
 })
 

--- a/backend/src/services/dealProgress.ts
+++ b/backend/src/services/dealProgress.ts
@@ -1,0 +1,87 @@
+/**
+ * Deal Progress Service
+ *
+ * Computes a deal's payment progress by reading TENANT_REPAYMENT receipts
+ * from the outbox store (the ledger proxy).
+ *
+ * USDC is canonical. Only SENT outbox items (i.e. confirmed on-chain) are counted.
+ */
+
+import { OutboxStatus, TxType, type OutboxItem } from '../outbox/types.js'
+import type { DealWithSchedule } from '../models/deal.js'
+
+export interface DealProgress {
+  /** Total USDC paid across all on-chain TENANT_REPAYMENT receipts */
+  totalPaidUsdc: string
+  /** Number of TENANT_REPAYMENT receipts confirmed on-chain */
+  periodsPaid: number
+  /** termMonths minus periodsPaid, clamped to >= 0 */
+  remainingPeriods: number
+  /** ISO date of next scheduled payment; null if fully paid */
+  nextDueDate: string | null
+  /** txId of the most recent confirmed receipt; undefined if no payments yet */
+  lastPaymentTxId?: string
+  /** Source part of canonicalExternalRefV1 (e.g. "stripe"); undefined if no payments yet */
+  lastPaymentExternalRefSource?: string
+  /** Ref part of canonicalExternalRefV1 (e.g. "pi_abc123"); undefined if no payments yet */
+  lastPaymentExternalRef?: string
+}
+
+/**
+ * Compute deal progress from on-chain receipts.
+ *
+ * @param deal   - Deal with schedule (used for termMonths and due dates)
+ * @param items  - All outbox items for this deal (any txType, any status)
+ */
+export function computeDealProgress(
+  deal: DealWithSchedule,
+  items: OutboxItem[],
+): DealProgress {
+  // Filter: only SENT TENANT_REPAYMENT receipts count as paid on-chain
+  const paidReceipts = items.filter(
+    (item) =>
+      item.txType === TxType.TENANT_REPAYMENT &&
+      item.status === OutboxStatus.SENT,
+  )
+
+  // Total USDC paid (sum amountUsdc from payload)
+  const totalPaidUsdcNum = paidReceipts.reduce((acc, item) => {
+    const amount = parseFloat(String(item.payload.amountUsdc ?? '0'))
+    return acc + (isNaN(amount) ? 0 : amount)
+  }, 0)
+
+  const periodsPaid = paidReceipts.length
+  const remainingPeriods = Math.max(0, deal.termMonths - periodsPaid)
+
+  // Next due date: look at schedule index = periodsPaid (0-indexed)
+  const nextScheduleItem = deal.schedule[periodsPaid] ?? null
+  const nextDueDate = nextScheduleItem ? nextScheduleItem.dueDate : null
+
+  // Last payment: most recent receipt (items are sorted ascending, so last = most recent)
+  const lastReceipt = paidReceipts[paidReceipts.length - 1]
+
+  let lastPaymentTxId: string | undefined
+  let lastPaymentExternalRefSource: string | undefined
+  let lastPaymentExternalRef: string | undefined
+
+  if (lastReceipt) {
+    lastPaymentTxId = lastReceipt.txId
+
+    // canonicalExternalRefV1 format: "{source}:{ref}"
+    const separatorIndex = lastReceipt.canonicalExternalRefV1.indexOf(':')
+    if (separatorIndex !== -1) {
+      lastPaymentExternalRefSource = lastReceipt.canonicalExternalRefV1.slice(0, separatorIndex)
+      lastPaymentExternalRef = lastReceipt.canonicalExternalRefV1.slice(separatorIndex + 1)
+    }
+  }
+
+  return {
+    totalPaidUsdc: totalPaidUsdcNum.toFixed(6),
+    periodsPaid,
+    remainingPeriods,
+    nextDueDate,
+    ...(lastPaymentTxId !== undefined && { lastPaymentTxId }),
+    ...(lastPaymentExternalRefSource !== undefined && { lastPaymentExternalRefSource }),
+    ...(lastPaymentExternalRef !== undefined && { lastPaymentExternalRef }),
+  }
+}

--- a/backend/vitest.config.ts
+++ b/backend/vitest.config.ts
@@ -5,6 +5,9 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     include: ['src/**/*.test.ts'],
+    env: {
+      NODE_ENV: 'development',
+    },
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],


### PR DESCRIPTION
## Summary
Notes
- USDC is canonical; NGN progress requires FX metadata and is not used here
- Outbox ensures idempotent receipts via canonicalExternalRefV1 and deterministic txId
- Only SENT receipts count, matching on-chain confirmation semantics

## Linked issue
Closed: #54 

## Changes

## How to test
- Create a deal
- POST /api/deals with tenantId, landlordId, annualRentNgn, depositNgn, termMonths
- Record a payment receipt
- POST /api/payments/confirm with txType=tenant_repayment, dealId, amountUsdc, tokenAddress, externalRefSource+externalRef
- Check progress
- GET /api/deals/{dealId}/progress
- Should show periodsPaid=1, totalPaidUsdc matching amountUsdc (fixed to 6 decimals), remainingPeriods decremented, nextDueDate advanced, lastPayment* fields populated

## Screenshots (if UI)

## Checklist

- [x ] I linked an issue (or explained why one is not needed)
- [ x] I tested locally
- [x ] I did not commit secrets
- [ x
<img width="665" height="505" alt="Screenshot 2026-03-03 111602" src="https://github.com/user-attachments/assets/85596e79-9289-42d6-9f02-eb71c8ce6ab2" />
] I updated docs if needed
