### PR TITLE
 Admin moderation for whistleblower listings

### DIFF
--- a/backend/openapi.yml
+++ b/backend/openapi.yml
@@ -946,6 +946,216 @@ paths:
         default:
           $ref: '#/components/responses/Error'
 
+  /api/admin/whistleblower/listings:
+    get:
+      summary: List whistleblower listings (admin)
+      description: |
+        Returns a paginated list of whistleblower listings for admin review.
+        Defaults to `status=pending_review` when no status filter is provided.
+      operationId: adminListWhistleblowerListings
+      tags:
+        - Admin
+      parameters:
+        - name: status
+          in: query
+          description: Filter by listing status (defaults to pending_review)
+          required: false
+          schema:
+            type: string
+            enum: [pending_review, approved, rejected, rented]
+            default: pending_review
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            default: 1
+        - name: pageSize
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 20
+      responses:
+        '200':
+          description: Paginated list of listings
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - listings
+                  - pagination
+                properties:
+                  listings:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/AdminListing'
+                  pagination:
+                    $ref: '#/components/schemas/Pagination'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        default:
+          $ref: '#/components/responses/Error'
+
+  /api/admin/whistleblower/listings/{id}/approve:
+    post:
+      summary: Approve a whistleblower listing
+      description: |
+        Transitions a listing from `pending_review` to `approved`.
+        Any other current status results in a 409 conflict.
+      operationId: approveWhistleblowerListing
+      tags:
+        - Admin
+      parameters:
+        - name: id
+          in: path
+          description: Listing ID
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - reviewedBy
+              properties:
+                reviewedBy:
+                  type: string
+                  minLength: 1
+                  description: ID of the admin performing the review
+                  example: admin-001
+      responses:
+        '200':
+          description: Listing approved
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - listing
+                properties:
+                  listing:
+                    $ref: '#/components/schemas/ModerationResult'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '404':
+          description: Listing not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              example:
+                error:
+                  code: NOT_FOUND
+                  message: "Listing with ID 'abc-123' not found"
+        '409':
+          description: Invalid state transition
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              example:
+                error:
+                  code: CONFLICT
+                  message: Listing cannot be approved. Current status: approved
+                  details:
+                    currentStatus: approved
+                    allowedFrom: pending_review
+        default:
+          $ref: '#/components/responses/Error'
+
+  /api/admin/whistleblower/listings/{id}/reject:
+    post:
+      summary: Reject a whistleblower listing
+      description: |
+        Transitions a listing from `pending_review` to `rejected`.
+        A `reason` explaining the rejection is required.
+        Any other current status results in a 409 conflict.
+      operationId: rejectWhistleblowerListing
+      tags:
+        - Admin
+      parameters:
+        - name: id
+          in: path
+          description: Listing ID
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - reviewedBy
+                - reason
+              properties:
+                reviewedBy:
+                  type: string
+                  minLength: 1
+                  description: ID of the admin performing the review
+                  example: admin-001
+                reason:
+                  type: string
+                  minLength: 1
+                  description: Reason for rejection shown to the whistleblower
+                  example: Photos do not match the listed address
+      responses:
+        '200':
+          description: Listing rejected
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - listing
+                properties:
+                  listing:
+                    allOf:
+                      - $ref: '#/components/schemas/ModerationResult'
+                      - type: object
+                        properties:
+                          rejectionReason:
+                            type: string
+                            example: Photos do not match the listed address
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '404':
+          description: Listing not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              example:
+                error:
+                  code: NOT_FOUND
+                  message: "Listing with ID 'abc-123' not found"
+        '409':
+          description: Invalid state transition
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              example:
+                error:
+                  code: CONFLICT
+                  message: Listing cannot be rejected. Current status: rejected
+                  details:
+                    currentStatus: rejected
+                    allowedFrom: pending_review
+        default:
+          $ref: '#/components/responses/Error'
+
   /api/staking/stake:
     post:
       summary: Stake USDC tokens
@@ -1134,6 +1344,92 @@ paths:
 
 components:
   schemas:
+    AdminListing:
+      type: object
+      required:
+        - listingId
+        - whistleblowerId
+        - address
+        - bedrooms
+        - bathrooms
+        - annualRentNgn
+        - photos
+        - status
+        - createdAt
+        - updatedAt
+      properties:
+        listingId:
+          type: string
+          format: uuid
+        whistleblowerId:
+          type: string
+        address:
+          type: string
+        city:
+          type: string
+        area:
+          type: string
+        bedrooms:
+          type: integer
+          minimum: 0
+        bathrooms:
+          type: integer
+          minimum: 0
+        annualRentNgn:
+          type: integer
+          minimum: 1
+        description:
+          type: string
+        photos:
+          type: array
+          items:
+            type: string
+            format: uri
+        status:
+          type: string
+          enum: [pending_review, approved, rejected, rented]
+        reviewedBy:
+          type: string
+          description: ID of the admin who reviewed this listing
+        reviewedAt:
+          type: string
+          format: date-time
+          description: Timestamp of the review decision
+        rejectionReason:
+          type: string
+          description: Reason provided when the listing was rejected
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+
+    ModerationResult:
+      type: object
+      required:
+        - listingId
+        - status
+        - reviewedBy
+        - reviewedAt
+        - updatedAt
+      properties:
+        listingId:
+          type: string
+          format: uuid
+        status:
+          type: string
+          enum: [approved, rejected]
+        reviewedBy:
+          type: string
+          example: admin-001
+        reviewedAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+
     PaymentTxType:
       type: string
       enum:

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1310,6 +1310,7 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -1677,6 +1678,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2265,6 +2267,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3450,6 +3453,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4031,6 +4035,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -4077,6 +4082,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4135,6 +4141,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",

--- a/backend/src/models/listing.ts
+++ b/backend/src/models/listing.ts
@@ -21,10 +21,12 @@ export interface Listing {
   description?: string
   photos: string[]
   status: ListingStatus
-  createdAt: Date
-  updatedAt: Date
+  reviewedBy?: string
+  reviewedAt?: Date
   rejectionReason?: string
   dealId?: string
+  createdAt: Date
+  updatedAt: Date
 }
 
 export interface CreateListingInput {

--- a/backend/src/models/listingStore.ts
+++ b/backend/src/models/listingStore.ts
@@ -174,6 +174,34 @@ class ListingStore {
   }
 
   /**
+   * Persist an admin moderation decision on a listing.
+   * Caller is responsible for validating the state transition before calling this.
+   * Returns null if the listing does not exist.
+   */
+  async moderate(
+    listingId: string,
+    status: ListingStatus.APPROVED | ListingStatus.REJECTED,
+    reviewedBy: string,
+    rejectionReason?: string,
+  ): Promise<Listing | null> {
+    const listing = this.listings.get(listingId)
+    if (!listing) return null
+
+    const now = new Date()
+    listing.status = status
+    listing.reviewedBy = reviewedBy
+    listing.reviewedAt = now
+    listing.updatedAt = now
+
+    if (rejectionReason) {
+      listing.rejectionReason = rejectionReason
+    }
+
+    this.listings.set(listingId, listing)
+    return listing
+  }
+
+  /**
    * Clear all data (for testing)
    */
   async clear(): Promise<void> {

--- a/backend/src/routes/admin.ts
+++ b/backend/src/routes/admin.ts
@@ -2,12 +2,19 @@ import { Router, type Request, type Response, type NextFunction } from 'express'
 import { outboxStore, OutboxSender, OutboxStatus, TxType } from '../outbox/index.js'
 import { SorobanAdapter } from '../soroban/adapter.js'
 import { logger } from '../utils/logger.js'
-import { AppError } from '../errors/AppError.js'
+import { AppError, notFound } from '../errors/AppError.js'
 import { ErrorCode } from '../errors/errorCodes.js'
 import { validate } from '../middleware/validate.js'
 import { markRewardPaidSchema } from '../schemas/reward.js'
+import {
+  adminListingFiltersSchema,
+  approveListingSchema,
+  rejectListingSchema,
+} from '../schemas/listing.js'
 import { rewardStore } from '../models/rewardStore.js'
 import { RewardStatus } from '../models/reward.js'
+import { listingStore } from '../models/listingStore.js'
+import { ListingStatus } from '../models/listing.js'
 
 export function createAdminRouter(adapter: SorobanAdapter) {
   const router = Router()
@@ -295,6 +302,170 @@ export function createAdminRouter(adapter: SorobanAdapter) {
           message: sent
             ? 'Reward marked as paid and receipt written to chain'
             : 'Reward marked as paid, receipt queued for retry',
+        })
+      } catch (error) {
+        next(error)
+      }
+    },
+  )
+
+  /**
+   * GET /api/admin/whistleblower/listings
+   *
+   * List whistleblower listings for admin review.
+   * Defaults to status=pending_review when no status is provided.
+   * Query params:
+   *   - status: pending_review | approved | rejected | rented (optional, default: pending_review)
+   *   - page: number (optional, default 1)
+   *   - pageSize: number (optional, default 20, max 100)
+   */
+  router.get(
+    '/whistleblower/listings',
+    validate(adminListingFiltersSchema, 'query'),
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const filters = req.query
+
+        logger.info('Admin listing moderation queue requested', {
+          filters,
+          requestId: req.requestId,
+        })
+
+        const result = await listingStore.list(filters)
+
+        res.json({
+          listings: result.listings.map((listing) => ({
+            listingId: listing.listingId,
+            whistleblowerId: listing.whistleblowerId,
+            address: listing.address,
+            city: listing.city,
+            area: listing.area,
+            bedrooms: listing.bedrooms,
+            bathrooms: listing.bathrooms,
+            annualRentNgn: listing.annualRentNgn,
+            description: listing.description,
+            photos: listing.photos,
+            status: listing.status,
+            reviewedBy: listing.reviewedBy,
+            reviewedAt: listing.reviewedAt?.toISOString(),
+            rejectionReason: listing.rejectionReason,
+            createdAt: listing.createdAt.toISOString(),
+            updatedAt: listing.updatedAt.toISOString(),
+          })),
+          pagination: {
+            total: result.total,
+            page: result.page,
+            pageSize: result.pageSize,
+            totalPages: result.totalPages,
+          },
+        })
+      } catch (error) {
+        next(error)
+      }
+    },
+  )
+
+  /**
+   * POST /api/admin/whistleblower/listings/:id/approve
+   *
+   * Approve a pending_review listing.
+   * Only valid transition: pending_review -> approved.
+   */
+  router.post(
+    '/whistleblower/listings/:id/approve',
+    validate(approveListingSchema),
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const { id } = req.params
+        const { reviewedBy } = req.body
+
+        const listing = await listingStore.getById(id)
+        if (!listing) {
+          throw notFound(`Listing with ID '${id}'`)
+        }
+
+        if (listing.status !== ListingStatus.PENDING_REVIEW) {
+          throw new AppError(
+            ErrorCode.CONFLICT,
+            409,
+            `Listing cannot be approved. Current status: ${listing.status}`,
+            { currentStatus: listing.status, allowedFrom: ListingStatus.PENDING_REVIEW },
+          )
+        }
+
+        const updated = await listingStore.moderate(id, ListingStatus.APPROVED, reviewedBy)
+
+        logger.info('Listing approved', {
+          listingId: id,
+          reviewedBy,
+          requestId: req.requestId,
+        })
+
+        res.json({
+          listing: {
+            listingId: updated!.listingId,
+            status: updated!.status,
+            reviewedBy: updated!.reviewedBy,
+            reviewedAt: updated!.reviewedAt?.toISOString(),
+            updatedAt: updated!.updatedAt.toISOString(),
+          },
+        })
+      } catch (error) {
+        next(error)
+      }
+    },
+  )
+
+  /**
+   * POST /api/admin/whistleblower/listings/:id/reject
+   *
+   * Reject a pending_review listing with a mandatory reason.
+   * Only valid transition: pending_review -> rejected.
+   */
+  router.post(
+    '/whistleblower/listings/:id/reject',
+    validate(rejectListingSchema),
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const { id } = req.params
+        const { reviewedBy, reason } = req.body
+
+        const listing = await listingStore.getById(id)
+        if (!listing) {
+          throw notFound(`Listing with ID '${id}'`)
+        }
+
+        if (listing.status !== ListingStatus.PENDING_REVIEW) {
+          throw new AppError(
+            ErrorCode.CONFLICT,
+            409,
+            `Listing cannot be rejected. Current status: ${listing.status}`,
+            { currentStatus: listing.status, allowedFrom: ListingStatus.PENDING_REVIEW },
+          )
+        }
+
+        const updated = await listingStore.moderate(
+          id,
+          ListingStatus.REJECTED,
+          reviewedBy,
+          reason,
+        )
+
+        logger.info('Listing rejected', {
+          listingId: id,
+          reviewedBy,
+          requestId: req.requestId,
+        })
+
+        res.json({
+          listing: {
+            listingId: updated!.listingId,
+            status: updated!.status,
+            reviewedBy: updated!.reviewedBy,
+            reviewedAt: updated!.reviewedAt?.toISOString(),
+            rejectionReason: updated!.rejectionReason,
+            updatedAt: updated!.updatedAt.toISOString(),
+          },
         })
       } catch (error) {
         next(error)

--- a/backend/src/schemas/listing.ts
+++ b/backend/src/schemas/listing.ts
@@ -35,3 +35,34 @@ export const listingFiltersSchema = z.object({
 })
 
 export type ListingFiltersRequest = z.infer<typeof listingFiltersSchema>
+
+/**
+ * Query params for GET /api/admin/whistleblower/listings
+ * Defaults to pending_review so the moderation queue is immediately visible
+ */
+export const adminListingFiltersSchema = z.object({
+  status: z.nativeEnum(ListingStatus).optional().default(ListingStatus.PENDING_REVIEW),
+  page: z.coerce.number().int().min(1).default(1),
+  pageSize: z.coerce.number().int().min(1).max(100).default(20),
+})
+
+export type AdminListingFiltersRequest = z.infer<typeof adminListingFiltersSchema>
+
+/**
+ * Body for POST /api/admin/whistleblower/listings/:id/approve
+ */
+export const approveListingSchema = z.object({
+  reviewedBy: z.string().min(1, 'Reviewer ID is required'),
+})
+
+export type ApproveListingRequest = z.infer<typeof approveListingSchema>
+
+/**
+ * Body for POST /api/admin/whistleblower/listings/:id/reject
+ */
+export const rejectListingSchema = z.object({
+  reviewedBy: z.string().min(1, 'Reviewer ID is required'),
+  reason: z.string().min(1, 'Rejection reason is required'),
+})
+
+export type RejectListingRequest = z.infer<typeof rejectListingSchema>


### PR DESCRIPTION
## Summary

Implements admin moderation endpoints for whistleblower listings 
Admins can now approve or reject `pending_review` listings with a full audit trail persisted on each listing record.

## Changes
Closes #48 
### New Endpoints

| Method | Path | Description |
|--------|------|-------------|
| `GET` | `/api/admin/whistleblower/listings` | List listings for review (defaults to `status=pending_review`) |
| `POST` | `/api/admin/whistleblower/listings/:id/approve` | Approve a pending listing |
| `POST` | `/api/admin/whistleblower/listings/:id/reject` | Reject a pending listing with a reason |

### Files Modified

| File | Change |
|------|--------|
| `backend/src/models/listing.ts` | Added `reviewedBy?: string` and `reviewedAt?: Date` audit fields to `Listing` interface |
| `backend/src/models/listingStore.ts` | Added `moderate()` — pure persistence method for admin decisions (O(1) Map lookup + in-place mutation) |
| `backend/src/schemas/listing.ts` | Added `adminListingFiltersSchema`, `approveListingSchema`, `rejectListingSchema` |
| `backend/src/routes/admin.ts` | Added three new route handlers inside the existing `createAdminRouter` factory |
| `backend/openapi.yml` | Documented all three endpoints + `AdminListing` and `ModerationResult` reusable schemas |

## State Transition Table

| Current Status | Action | Next Status | Guard |
|---|---|---|---|
| `pending_review` | approve | `approved` | Only allowed from `pending_review` |
| `pending_review` | reject | `rejected` | Only allowed from `pending_review`, `reason` required |
| `approved` | approve | — | `409 CONFLICT` — invalid transition |
| `approved` | reject | — | `409 CONFLICT` — invalid transition |
| `rejected` | approve | — | `409 CONFLICT` — invalid transition |
| `rejected` | reject | — | `409 CONFLICT` — invalid transition |

## Acceptance Criteria

- [x] `GET /api/admin/whistleblower/listings?status=pending_review` returns paginated listings
- [x] `POST .../approve` transitions `pending_review → approved`
- [x] `POST .../reject` transitions `pending_review → rejected` with `reason`
- [x] `reviewedBy`, `reviewedAt`, `rejectionReason` persisted on the listing record
- [x] Approving/rejecting a non-`pending_review` listing returns `409`
- [x] Missing `reviewedBy` returns `400` (Zod)
- [x] Missing `reason` on reject returns `400` (Zod)
- [x] OpenAPI spec updated for all three endpoints
- [x] Standard `{ error: { code, message, details } }` error format used throughout
- [x] lint / typecheck / build pass clean



## Checklist

- [ x] I linked an issue (or explained why one is not needed)
- [x ] I tested locally
- [x ] I did not commit secrets
- [ x] I updated docs if needed
