### PR TITLE
feat: Staking rewards accounting (index-based accrual, no loops)

### DIFF
--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -1578,6 +1578,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "staking_rewards"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -4,4 +4,5 @@ members = [
   "rent_wallet",
   "rent_payments",
   "transaction-receipt-contract",
+  "staking_rewards",
 ]

--- a/contracts/rent_payments/src/lib.rs
+++ b/contracts/rent_payments/src/lib.rs
@@ -1,8 +1,6 @@
 #![no_std]
 
-use soroban_sdk::{
-    contract, contractimpl, contracttype, vec, Address, Env, Symbol, Vec, BytesN,
-};
+use soroban_sdk::{contract, contractimpl, contracttype, vec, Address, BytesN, Env, Symbol, Vec};
 
 /// Deal ID type - using u64 for simplicity
 pub type DealId = u64;
@@ -42,7 +40,7 @@ pub struct Receipt {
 #[derive(Clone, Debug)]
 pub struct ReceiptPage {
     pub receipts: Vec<Receipt>,
-    pub has_next: bool, // True if there are more receipts
+    pub has_next: bool,      // True if there are more receipts
     pub next_cursor: Cursor, // Cursor for next page (only valid if has_next is true)
 }
 
@@ -105,11 +103,12 @@ fn get_tx_id(env: &Env) -> TxId {
     // For now, we'll use a combination of timestamp and sequence number
     let ledger_info = env.ledger();
     let timestamp = ledger_info.timestamp();
-    
+
     // Get a global counter from storage to ensure uniqueness across all receipts
     // Use a special deal_id (u64::MAX) as the key for the global counter
     let global_counter_key = DataKey::ReceiptCount(u64::MAX);
-    let counter: u64 = env.storage()
+    let counter: u64 = env
+        .storage()
         .persistent()
         .get(&global_counter_key)
         .unwrap_or(0);
@@ -117,30 +116,30 @@ fn get_tx_id(env: &Env) -> TxId {
     env.storage()
         .persistent()
         .set(&global_counter_key, &new_counter);
-    
+
     // Create a deterministic tx_id from timestamp and counter
     // In a real implementation, you'd get this from the actual transaction hash
     let mut bytes = [0u8; 32];
-    
+
     // Convert timestamp (u64) to bytes manually
     let mut ts = timestamp;
     for i in (0..8).rev() {
         bytes[i] = (ts & 0xFF) as u8;
         ts >>= 8;
     }
-    
-    // Convert counter (u64) to bytes manually  
+
+    // Convert counter (u64) to bytes manually
     let mut cnt = new_counter;
     for i in (8..16).rev() {
         bytes[i] = (cnt & 0xFF) as u8;
         cnt >>= 8;
     }
-    
+
     // Fill remaining bytes with a pattern for uniqueness
     for i in 16..32 {
         bytes[i] = (timestamp as u8).wrapping_add(i as u8);
     }
-    
+
     BytesN::from_array(env, &bytes)
 }
 
@@ -156,14 +155,9 @@ impl RentPayments {
 
     /// Create a new receipt for a deal
     /// This function records a monthly payment receipt
-    pub fn create_receipt(
-        env: Env,
-        deal_id: DealId,
-        amount: i128,
-        payer: Address,
-    ) -> Receipt {
+    pub fn create_receipt(env: Env, deal_id: DealId, amount: i128, payer: Address) -> Receipt {
         require_admin(&env);
-        
+
         if amount <= 0 {
             panic!("amount must be positive");
         }
@@ -195,23 +189,23 @@ impl RentPayments {
     }
 
     /// List receipts for a deal with cursor-based pagination
-    /// 
+    ///
     /// # Arguments
     /// * `deal_id` - The deal ID to list receipts for
     /// * `limit` - Maximum number of receipts to return (must be > 0 and <= 100)
     /// * `cursor` - Optional cursor for pagination. If None, starts from the beginning.
     ///              Cursor format: (timestamp, tx_id) tuple
-    /// 
+    ///
     /// # Returns
     /// * `ReceiptPage` containing:
     ///   - `receipts`: Vec of receipts ordered by (timestamp ASC, tx_id ASC)
     ///   - `next_cursor`: Optional cursor for the next page, None if this is the last page
-    /// 
+    ///
     /// # Ordering
     /// Receipts are ordered by:
     /// 1. `timestamp` (ascending)
     /// 2. `tx_id` (ascending, as bytes comparison)
-    /// 
+    ///
     /// This ensures stable, deterministic ordering even if multiple receipts have the same timestamp.
     pub fn list_receipts_by_deal(
         env: Env,
@@ -229,7 +223,7 @@ impl RentPayments {
         // Convert to a sortable format - we'll need to collect into a Vec for sorting
         // Since Soroban Vec doesn't support sort_by directly, we'll build a sorted Vec
         let mut sorted_receipts = vec![&env];
-        
+
         // Collect all receipts into the sorted Vec
         for i in 0..receipts_len {
             sorted_receipts.push_back(receipts.get(i).unwrap());
@@ -246,15 +240,13 @@ impl RentPayments {
                 for i in 0..(len - 1) {
                     let a = sorted_receipts.get(i).unwrap();
                     let b = sorted_receipts.get(i + 1).unwrap();
-                    
+
                     let should_swap = match a.timestamp.cmp(&b.timestamp) {
                         core::cmp::Ordering::Greater => true,
-                        core::cmp::Ordering::Equal => {
-                            a.tx_id.to_array() > b.tx_id.to_array()
-                        }
+                        core::cmp::Ordering::Equal => a.tx_id.to_array() > b.tx_id.to_array(),
                         core::cmp::Ordering::Less => false,
                     };
-                    
+
                     if should_swap {
                         sorted_receipts.set(i, b.clone());
                         sorted_receipts.set(i + 1, a.clone());
@@ -268,14 +260,13 @@ impl RentPayments {
         let mut start_index = 0u32;
         if let Some(cursor) = cursor {
             let cursor_tx_id_array = cursor.tx_id.to_array();
-            
+
             // Find the first receipt with (timestamp, tx_id) > cursor
             for i in 0..sorted_receipts.len() {
                 let r = sorted_receipts.get(i).unwrap();
                 let r_tx_id_array = r.tx_id.to_array();
                 if r.timestamp > cursor.timestamp
-                    || (r.timestamp == cursor.timestamp
-                        && r_tx_id_array > cursor_tx_id_array)
+                    || (r.timestamp == cursor.timestamp && r_tx_id_array > cursor_tx_id_array)
                 {
                     start_index = i;
                     break;
@@ -320,23 +311,32 @@ impl RentPayments {
                 0
             };
             if let Some(last_receipt) = page_receipts.get(last_index) {
-                (true, Cursor {
-                    timestamp: last_receipt.timestamp,
-                    tx_id: last_receipt.tx_id.clone(),
-                })
+                (
+                    true,
+                    Cursor {
+                        timestamp: last_receipt.timestamp,
+                        tx_id: last_receipt.tx_id.clone(),
+                    },
+                )
             } else {
                 // Fallback: create empty cursor
-                (false, Cursor {
-                    timestamp: 0,
-                    tx_id: empty_tx_id,
-                })
+                (
+                    false,
+                    Cursor {
+                        timestamp: 0,
+                        tx_id: empty_tx_id,
+                    },
+                )
             }
         } else {
             // No more receipts
-            (false, Cursor {
-                timestamp: 0,
-                tx_id: empty_tx_id,
-            })
+            (
+                false,
+                Cursor {
+                    timestamp: 0,
+                    tx_id: empty_tx_id,
+                },
+            )
         };
 
         ReceiptPage {
@@ -370,7 +370,6 @@ mod test {
         client.init(&admin);
         (admin, client, contract_id)
     }
-
 
     #[test]
     fn test_list_receipts_by_deal_empty() {
@@ -442,16 +441,8 @@ mod test {
         assert!(!page2.has_next);
 
         // Verify no duplicates between pages
-        let page1_ids: std::vec::Vec<u64> = page1
-            .receipts
-            .iter()
-            .map(|r| r.id)
-            .collect();
-        let page2_ids: std::vec::Vec<u64> = page2
-            .receipts
-            .iter()
-            .map(|r| r.id)
-            .collect();
+        let page1_ids: std::vec::Vec<u64> = page1.receipts.iter().map(|r| r.id).collect();
+        let page2_ids: std::vec::Vec<u64> = page2.receipts.iter().map(|r| r.id).collect();
 
         for id in &page1_ids {
             assert!(!page2_ids.contains(id), "Duplicate receipt found: {}", id);
@@ -498,7 +489,7 @@ mod test {
 
         // Verify we got exactly 25 receipts (no skipping)
         assert_eq!(all_receipt_ids.len(), 25);
-        
+
         // Verify all IDs are unique (no duplicates)
         let mut sorted_ids = all_receipt_ids.clone();
         sorted_ids.sort();
@@ -529,7 +520,7 @@ mod test {
 
         // Get all receipts in one call
         let all_page = client.list_receipts_by_deal(&deal_id, &100u32, &None);
-        
+
         // Get receipts in pages and verify ordering is consistent
         let mut cursor = None;
         let mut prev_timestamp = 0u64;
@@ -537,14 +528,14 @@ mod test {
 
         loop {
             let page = client.list_receipts_by_deal(&deal_id, &3u32, &cursor);
-            
+
             for receipt in page.receipts.iter() {
                 // Verify ordering: timestamp should be >= previous
                 assert!(
                     receipt.timestamp >= prev_timestamp,
                     "Receipts not in ascending timestamp order"
                 );
-                
+
                 // If timestamp is equal, tx_id should be >= previous
                 if receipt.timestamp == prev_timestamp {
                     if let Some(ref prev) = prev_tx_id {
@@ -556,7 +547,7 @@ mod test {
                         );
                     }
                 }
-                
+
                 prev_timestamp = receipt.timestamp;
                 prev_tx_id = Some(receipt.tx_id.clone());
             }
@@ -582,7 +573,10 @@ mod test {
         }
 
         let all_ids: std::vec::Vec<u64> = all_page.receipts.iter().map(|r| r.id).collect();
-        assert_eq!(paginated_ids, all_ids, "Paginated results don't match full results");
+        assert_eq!(
+            paginated_ids, all_ids,
+            "Paginated results don't match full results"
+        );
     }
 
     #[test]

--- a/contracts/rent_wallet/src/lib.rs
+++ b/contracts/rent_wallet/src/lib.rs
@@ -1,17 +1,11 @@
 #![no_std]
 
-
-
 use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, Map, Symbol};
 
-
-
 #[contracttype]
-
 #[derive(Clone)]
 
 pub enum DataKey {
-
     Admin,
 
     Balances,
@@ -19,52 +13,30 @@ pub enum DataKey {
     Paused,
 }
 
-
-
 #[contract]
 
 pub struct RentWallet;
 
-
-
 fn balances(env: &Env) -> Map<Address, i128> {
-
     env.storage()
-
         .instance()
-
         .get::<_, Map<Address, i128>>(&DataKey::Balances)
-
         .unwrap_or_else(|| Map::new(env))
-
 }
-
-
 
 fn put_balances(env: &Env, b: Map<Address, i128>) {
-
     env.storage().instance().set(&DataKey::Balances, &b)
-
 }
 
-
-
 fn require_admin(env: &Env) {
-
     let admin: Address = env
-
         .storage()
-
         .instance()
-
         .get(&DataKey::Admin)
-
         .expect("admin not set");
 
     admin.require_auth();
-
 }
-
 
 fn get_paused_state(env: &Env) -> bool {
     env.storage()
@@ -79,47 +51,30 @@ fn require_not_paused(env: &Env) {
     }
 }
 
-
 #[contractimpl]
 
 impl RentWallet {
-
     pub fn init(env: Env, admin: Address) {
-
         if env.storage().instance().has(&DataKey::Admin) {
-
             panic!("already initialized")
-
         }
 
         env.storage().instance().set(&DataKey::Admin, &admin);
 
         env.storage()
-
             .instance()
-
             .set(&DataKey::Balances, &Map::<Address, i128>::new(&env));
 
-
-
         env.events().publish((Symbol::new(&env, "init"),), admin);
-
     }
 
-
-
     pub fn credit(env: Env, user: Address, amount: i128) {
-
         require_admin(&env);
 
         require_not_paused(&env);
         if amount <= 0 {
-
             panic!("amount must be positive")
-
         }
-
-
 
         let mut b = balances(&env);
 
@@ -129,75 +84,48 @@ impl RentWallet {
 
         put_balances(&env, b);
 
-
-
         env.events()
-
             .publish((Symbol::new(&env, "credit"), user), amount);
-
     }
 
-
-
     pub fn debit(env: Env, user: Address, amount: i128) {
-
         require_admin(&env);
 
         require_not_paused(&env);
         if amount <= 0 {
-
             panic!("amount must be positive")
-
         }
-
-
 
         let mut b = balances(&env);
 
         let cur = b.get(user.clone()).unwrap_or(0);
 
         if cur < amount {
-
             panic!("insufficient balance")
-
         }
 
         b.set(user.clone(), cur - amount);
 
         put_balances(&env, b);
 
-
-
         env.events()
-
             .publish((Symbol::new(&env, "debit"), user), amount);
-
     }
 
-
-
     pub fn balance(env: Env, user: Address) -> i128 {
-
         let b = balances(&env);
 
         b.get(user).unwrap_or(0)
-
     }
 
-
-
     pub fn set_admin(env: Env, new_admin: Address) {
-
         require_admin(&env);
 
         env.storage().instance().set(&DataKey::Admin, &new_admin);
 
         env.events()
-
             .publish((Symbol::new(&env, "set_admin"),), new_admin);
-
     }
-
 
     pub fn pause(env: Env) {
         require_admin(&env);
@@ -216,23 +144,25 @@ impl RentWallet {
     }
 }
 
-
-
 #[cfg(test)]
 
 mod test {
 
     extern crate std;
 
-
-
     use super::{RentWallet, RentWalletClient};
-    use soroban_sdk::testutils::{Address as _, MockAuth, MockAuthInvoke, Events};
+    use soroban_sdk::testutils::{Address as _, Events, MockAuth, MockAuthInvoke};
     use soroban_sdk::{Address, Env, IntoVal, Symbol, TryIntoVal};
 
-
-    fn setup(env: &Env) -> (soroban_sdk::Address, RentWalletClient<'_>, Address, Address, Address) {
-
+    fn setup(
+        env: &Env,
+    ) -> (
+        soroban_sdk::Address,
+        RentWalletClient<'_>,
+        Address,
+        Address,
+        Address,
+    ) {
         let contract_id = env.register_contract(None, RentWallet);
 
         let client = RentWalletClient::new(env, &contract_id);
@@ -246,9 +176,7 @@ mod test {
         client.init(&admin);
 
         (contract_id, client, admin, user, non_admin)
-
     }
-
 
     // ============================================================================
     // Init Tests
@@ -631,25 +559,18 @@ mod test {
     // Admin Authorization Tests
     // ============================================================================
 
-
     #[test]
-
     #[should_panic]
 
     fn non_admin_cannot_credit() {
-
         let env = Env::default();
 
         let (contract_id, client, _admin, user, non_admin) = setup(&env);
 
-
-
         env.mock_auths(&[MockAuth {
-
             address: &non_admin,
 
             invoke: &MockAuthInvoke {
-
                 contract: &contract_id,
 
                 fn_name: "credit",
@@ -657,37 +578,24 @@ mod test {
                 args: (user.clone(), 100i128).into_val(&env),
 
                 sub_invokes: &[],
-
             },
-
         }]);
 
-
-
         client.credit(&user, &100i128);
-
     }
 
-
-
     #[test]
-
     #[should_panic]
 
     fn non_admin_cannot_debit() {
-
         let env = Env::default();
 
         let (contract_id, client, _admin, user, non_admin) = setup(&env);
 
-
-
         env.mock_auths(&[MockAuth {
-
             address: &non_admin,
 
             invoke: &MockAuthInvoke {
-
                 contract: &contract_id,
 
                 fn_name: "debit",
@@ -695,17 +603,11 @@ mod test {
                 args: (user.clone(), 1i128).into_val(&env),
 
                 sub_invokes: &[],
-
             },
-
         }]);
 
-
-
         client.debit(&user, &1i128);
-
     }
-
 
     #[test]
     fn admin_can_set_admin() {
@@ -739,27 +641,20 @@ mod test {
         assert_eq!(client.balance(&user), 50i128);
     }
 
-
     #[test]
-
     #[should_panic]
 
     fn non_admin_cannot_set_admin() {
-
         let env = Env::default();
 
         let (contract_id, client, _admin, _user, non_admin) = setup(&env);
 
         let new_admin = Address::generate(&env);
 
-
-
         env.mock_auths(&[MockAuth {
-
             address: &non_admin,
 
             invoke: &MockAuthInvoke {
-
                 contract: &contract_id,
 
                 fn_name: "set_admin",
@@ -767,17 +662,11 @@ mod test {
                 args: (new_admin.clone(),).into_val(&env),
 
                 sub_invokes: &[],
-
             },
-
         }]);
 
-
-
         client.set_admin(&new_admin);
-
     }
-
 
     #[test]
     fn admin_can_pause() {
@@ -1024,10 +913,10 @@ mod test {
 
         let topics: soroban_sdk::Vec<soroban_sdk::Val> = event.1.clone();
         assert_eq!(topics.len(), 2);
-        
+
         let event_name: Symbol = topics.get(0).unwrap().try_into_val(&env).unwrap();
         assert_eq!(event_name, Symbol::new(&env, "credit"));
-        
+
         let event_user: Address = topics.get(1).unwrap().try_into_val(&env).unwrap();
         assert_eq!(event_user, user);
 
@@ -1067,10 +956,10 @@ mod test {
 
         let topics: soroban_sdk::Vec<soroban_sdk::Val> = event.1.clone();
         assert_eq!(topics.len(), 2);
-        
+
         let event_name: Symbol = topics.get(0).unwrap().try_into_val(&env).unwrap();
         assert_eq!(event_name, Symbol::new(&env, "debit"));
-        
+
         let event_user: Address = topics.get(1).unwrap().try_into_val(&env).unwrap();
         assert_eq!(event_user, user);
 
@@ -1078,4 +967,3 @@ mod test {
         assert_eq!(data, 50i128);
     }
 }
-

--- a/contracts/staking_rewards/Cargo.toml
+++ b/contracts/staking_rewards/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "staking_rewards"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22"
+
+[dev-dependencies]
+soroban-sdk = { version = "22", features = ["testutils"] }
+
+[profile.release-with-logs]
+inherits = "release"
+debug-assertions = true

--- a/contracts/staking_rewards/src/lib.rs
+++ b/contracts/staking_rewards/src/lib.rs
@@ -1,0 +1,150 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env};
+
+#[contracttype]
+#[derive(Clone)]
+pub struct UserStake {
+    pub amount: i128,
+    pub user_index: i128,
+}
+
+const REWARD_INDEX: &str = "REWARD_IDX";
+const TOTAL_STAKED: &str = "TOTAL_STK";
+const SCALE: i128 = 1_000_000_000;
+
+#[contract]
+pub struct StakingRewards;
+
+#[contractimpl]
+impl StakingRewards {
+    pub fn stake(env: Env, user: Address, amount: i128) {
+        user.require_auth();
+
+        let mut user_stake = Self::get_user_stake(&env, &user);
+        let reward_index = Self::get_reward_index(&env);
+
+        user_stake.amount += amount;
+        user_stake.user_index = reward_index;
+
+        env.storage().persistent().set(&user, &user_stake);
+
+        let total = Self::get_total_staked(&env);
+        env.storage()
+            .persistent()
+            .set(&TOTAL_STAKED, &(total + amount));
+    }
+
+    pub fn distribute_rewards(env: Env, amount: i128) {
+        let total = Self::get_total_staked(&env);
+        if total == 0 {
+            return;
+        }
+
+        let reward_index = Self::get_reward_index(&env);
+        let new_index = reward_index + (amount * SCALE / total);
+        env.storage().persistent().set(&REWARD_INDEX, &new_index);
+    }
+
+    pub fn claim(env: Env, user: Address) -> i128 {
+        user.require_auth();
+
+        let mut user_stake = Self::get_user_stake(&env, &user);
+        let reward_index = Self::get_reward_index(&env);
+
+        let claimable = Self::calc_pending(&user_stake, reward_index);
+        user_stake.user_index = reward_index;
+
+        env.storage().persistent().set(&user, &user_stake);
+        claimable
+    }
+
+    pub fn get_claimable(env: Env, user: Address) -> i128 {
+        let user_stake = Self::get_user_stake(&env, &user);
+        let reward_index = Self::get_reward_index(&env);
+        Self::calc_pending(&user_stake, reward_index)
+    }
+
+    fn calc_pending(user_stake: &UserStake, reward_index: i128) -> i128 {
+        user_stake.amount * (reward_index - user_stake.user_index) / SCALE
+    }
+
+    fn get_user_stake(env: &Env, user: &Address) -> UserStake {
+        env.storage().persistent().get(user).unwrap_or(UserStake {
+            amount: 0,
+            user_index: 0,
+        })
+    }
+
+    fn get_reward_index(env: &Env) -> i128 {
+        env.storage().persistent().get(&REWARD_INDEX).unwrap_or(0)
+    }
+
+    fn get_total_staked(env: &Env) -> i128 {
+        env.storage().persistent().get(&TOTAL_STAKED).unwrap_or(0)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, Env};
+
+    #[test]
+    fn test_two_users_different_times() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(StakingRewards, ());
+        let client = StakingRewardsClient::new(&env, &contract_id);
+
+        let user1 = Address::generate(&env);
+        let user2 = Address::generate(&env);
+
+        client.stake(&user1, &1000);
+        client.distribute_rewards(&500);
+        client.stake(&user2, &1000);
+        client.distribute_rewards(&1000);
+
+        assert_eq!(client.get_claimable(&user1), 1000);
+        assert_eq!(client.get_claimable(&user2), 500);
+    }
+
+    #[test]
+    fn test_claim_does_not_affect_others() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(StakingRewards, ());
+        let client = StakingRewardsClient::new(&env, &contract_id);
+
+        let user1 = Address::generate(&env);
+        let user2 = Address::generate(&env);
+
+        client.stake(&user1, &1000);
+        client.stake(&user2, &1000);
+        client.distribute_rewards(&1000);
+
+        let before = client.get_claimable(&user2);
+        client.claim(&user1);
+        let after = client.get_claimable(&user2);
+
+        assert_eq!(before, 500);
+        assert_eq!(after, 500);
+    }
+
+    #[test]
+    fn test_rewards_distributed_fairly() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(StakingRewards, ());
+        let client = StakingRewardsClient::new(&env, &contract_id);
+
+        let user1 = Address::generate(&env);
+        let user2 = Address::generate(&env);
+
+        client.stake(&user1, &3000);
+        client.stake(&user2, &1000);
+        client.distribute_rewards(&4000);
+
+        assert_eq!(client.get_claimable(&user1), 3000);
+        assert_eq!(client.get_claimable(&user2), 1000);
+    }
+}

--- a/contracts/staking_rewards/test_snapshots/test/test_claim_does_not_affect_others.1.json
+++ b/contracts/staking_rewards/test_snapshots/test/test_claim_does_not_affect_others.1.json
@@ -1,0 +1,422 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "stake",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 1000
+                  }
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "stake",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 1000
+                  }
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "claim",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "string": "REWARD_IDX"
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "string": "REWARD_IDX"
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 500000000
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "string": "TOTAL_STK"
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "string": "TOTAL_STK"
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 2000
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "amount"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 1000
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "user_index"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 500000000
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "amount"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 1000
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "user_index"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 0
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 801925984706572462
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 1033654523790656264
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 1033654523790656264
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 5541220902715666415
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 5541220902715666415
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/staking_rewards/test_snapshots/test/test_rewards_distributed_fairly.1.json
+++ b/contracts/staking_rewards/test_snapshots/test/test_rewards_distributed_fairly.1.json
@@ -1,0 +1,370 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "stake",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 3000
+                  }
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "stake",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 1000
+                  }
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "string": "REWARD_IDX"
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "string": "REWARD_IDX"
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 1000000000
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "string": "TOTAL_STK"
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "string": "TOTAL_STK"
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 4000
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "amount"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 3000
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "user_index"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 0
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "amount"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 1000
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "user_index"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 0
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 801925984706572462
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 5541220902715666415
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 5541220902715666415
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/staking_rewards/test_snapshots/test/test_two_users_different_times.1.json
+++ b/contracts/staking_rewards/test_snapshots/test/test_two_users_different_times.1.json
@@ -1,0 +1,371 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "stake",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 1000
+                  }
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "stake",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 1000
+                  }
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "string": "REWARD_IDX"
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "string": "REWARD_IDX"
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 1000000000
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "string": "TOTAL_STK"
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "string": "TOTAL_STK"
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 2000
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "amount"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 1000
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "user_index"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 0
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "amount"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 1000
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "user_index"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 500000000
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 801925984706572462
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 5541220902715666415
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 5541220902715666415
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/transaction-receipt-contract/src/integration_tests.rs
+++ b/contracts/transaction-receipt-contract/src/integration_tests.rs
@@ -1,254 +1,280 @@
 #![cfg(test)]
 
 extern crate alloc;
-use alloc::format;
 use crate::{
-	ReceiptInput, TransactionReceiptContract, TransactionReceiptContractClient, ContractError,
+    ContractError, ReceiptInput, TransactionReceiptContract, TransactionReceiptContractClient,
 };
+use alloc::format;
 use soroban_sdk::{testutils::Address as _, Address, Env, String, Symbol};
 
 // Integration: init -> record multiple receipts -> query
 #[test]
 fn test_integration_init_record_query() {
-	let env = Env::default();
-	let contract_id = env.register(TransactionReceiptContract, ());
-	let client = TransactionReceiptContractClient::new(&env, &contract_id);
+    let env = Env::default();
+    let contract_id = env.register(TransactionReceiptContract, ());
+    let client = TransactionReceiptContractClient::new(&env, &contract_id);
 
-	let admin = Address::generate(&env);
-	let operator = Address::generate(&env);
+    let admin = Address::generate(&env);
+    let operator = Address::generate(&env);
 
-	client.try_init(&admin, &operator).unwrap();
+    client.try_init(&admin, &operator).unwrap();
 
-	// Allow require_auth to succeed for our mock calls
-	env.mock_all_auths();
+    // Allow require_auth to succeed for our mock calls
+    env.mock_all_auths();
 
-	let token = Address::generate(&env);
+    let token = Address::generate(&env);
 
-	// Record two receipts for deal "dealA" and one for "dealB"
-	let deal_a = String::from_str(&env, "dealA");
-	let deal_b = String::from_str(&env, "dealB");
+    // Record two receipts for deal "dealA" and one for "dealB"
+    let deal_a = String::from_str(&env, "dealA");
+    let deal_b = String::from_str(&env, "dealB");
 
-	let input_a1 = ReceiptInput {
-		external_ref_source: Symbol::new(&env, "manual_admin"),
-		external_ref: String::from_str(&env, "a_ref_1"),
-		tx_type: Symbol::new(&env, "rent_payment"),
-		amount_usdc: 1_000_0000000i128,
-		token: token.clone(),
-		deal_id: deal_a.clone(),
-		listing_id: None,
-		from: None,
-		to: None,
-		amount_ngn: None,
-		fx_rate_ngn_per_usdc: None,
-		fx_provider: None,
-		metadata_hash: None,
-	};
+    let input_a1 = ReceiptInput {
+        external_ref_source: Symbol::new(&env, "manual_admin"),
+        external_ref: String::from_str(&env, "a_ref_1"),
+        tx_type: Symbol::new(&env, "rent_payment"),
+        amount_usdc: 1_000_0000000i128,
+        token: token.clone(),
+        deal_id: deal_a.clone(),
+        listing_id: None,
+        from: None,
+        to: None,
+        amount_ngn: None,
+        fx_rate_ngn_per_usdc: None,
+        fx_provider: None,
+        metadata_hash: None,
+    };
 
-	let input_a2 = ReceiptInput {
-		external_ref_source: Symbol::new(&env, "manual_admin"),
-		external_ref: String::from_str(&env, "a_ref_2"),
-		tx_type: Symbol::new(&env, "rent_payment"),
-		amount_usdc: 2_000_0000000i128,
-		token: token.clone(),
-		deal_id: deal_a.clone(),
-		listing_id: None,
-		from: None,
-		to: None,
-		amount_ngn: None,
-		fx_rate_ngn_per_usdc: None,
-		fx_provider: None,
-		metadata_hash: None,
-	};
+    let input_a2 = ReceiptInput {
+        external_ref_source: Symbol::new(&env, "manual_admin"),
+        external_ref: String::from_str(&env, "a_ref_2"),
+        tx_type: Symbol::new(&env, "rent_payment"),
+        amount_usdc: 2_000_0000000i128,
+        token: token.clone(),
+        deal_id: deal_a.clone(),
+        listing_id: None,
+        from: None,
+        to: None,
+        amount_ngn: None,
+        fx_rate_ngn_per_usdc: None,
+        fx_provider: None,
+        metadata_hash: None,
+    };
 
-	let input_b1 = ReceiptInput {
-		external_ref_source: Symbol::new(&env, "manual_admin"),
-		external_ref: String::from_str(&env, "b_ref_1"),
-		tx_type: Symbol::new(&env, "rent_payment"),
-		amount_usdc: 3_000_0000000i128,
-		token: token.clone(),
-		deal_id: deal_b.clone(),
-		listing_id: None,
-		from: None,
-		to: None,
-		amount_ngn: None,
-		fx_rate_ngn_per_usdc: None,
-		fx_provider: None,
-		metadata_hash: None,
-	};
+    let input_b1 = ReceiptInput {
+        external_ref_source: Symbol::new(&env, "manual_admin"),
+        external_ref: String::from_str(&env, "b_ref_1"),
+        tx_type: Symbol::new(&env, "rent_payment"),
+        amount_usdc: 3_000_0000000i128,
+        token: token.clone(),
+        deal_id: deal_b.clone(),
+        listing_id: None,
+        from: None,
+        to: None,
+        amount_ngn: None,
+        fx_rate_ngn_per_usdc: None,
+        fx_provider: None,
+        metadata_hash: None,
+    };
 
-	let tx_a1 = client.try_record_receipt(&operator, &input_a1).unwrap().unwrap();
-	let tx_a2 = client.try_record_receipt(&operator, &input_a2).unwrap().unwrap();
-	let tx_b1 = client.try_record_receipt(&operator, &input_b1).unwrap().unwrap();
+    let tx_a1 = client
+        .try_record_receipt(&operator, &input_a1)
+        .unwrap()
+        .unwrap();
+    let tx_a2 = client
+        .try_record_receipt(&operator, &input_a2)
+        .unwrap()
+        .unwrap();
+    let tx_b1 = client
+        .try_record_receipt(&operator, &input_b1)
+        .unwrap()
+        .unwrap();
 
-	// Query by tx id
-	let got_a1 = client.get_receipt(&tx_a1);
-	assert!(got_a1.is_some());
-	let got = got_a1.unwrap();
-	assert_eq!(got.tx_id, tx_a1);
-	assert_eq!(got.deal_id, deal_a);
+    // Query by tx id
+    let got_a1 = client.get_receipt(&tx_a1);
+    assert!(got_a1.is_some());
+    let got = got_a1.unwrap();
+    assert_eq!(got.tx_id, tx_a1);
+    assert_eq!(got.deal_id, deal_a);
 
-	// List receipts by deal A
-	let list_a = client.list_receipts_by_deal(&deal_a, &10u32, &Option::<u32>::None);
-	assert_eq!(list_a.len(), 2);
+    // List receipts by deal A
+    let list_a = client.list_receipts_by_deal(&deal_a, &10u32, &Option::<u32>::None);
+    assert_eq!(list_a.len(), 2);
 
-	// List receipts by deal B
-	let list_b = client.list_receipts_by_deal(&deal_b, &10u32, &Option::<u32>::None);
-	assert_eq!(list_b.len(), 1);
+    // List receipts by deal B
+    let list_b = client.list_receipts_by_deal(&deal_b, &10u32, &Option::<u32>::None);
+    assert_eq!(list_b.len(), 1);
 
-	// Pagination: limit 1 should return first element only
-	let page1 = client.list_receipts_by_deal(&deal_a, &1u32, &Option::<u32>::None);
-	assert_eq!(page1.len(), 1);
+    // Pagination: limit 1 should return first element only
+    let page1 = client.list_receipts_by_deal(&deal_a, &1u32, &Option::<u32>::None);
+    assert_eq!(page1.len(), 1);
 
-	let page2 = client.list_receipts_by_deal(&deal_a, &1u32, &Some(1u32));
-	assert_eq!(page2.len(), 1);
+    let page2 = client.list_receipts_by_deal(&deal_a, &1u32, &Some(1u32));
+    assert_eq!(page2.len(), 1);
 }
 
 // Integration: authorization flow (init -> set_operator -> record with new operator)
 #[test]
 fn test_integration_authorization_flow() {
-	let env = Env::default();
-	let contract_id = env.register(TransactionReceiptContract, ());
-	let client = TransactionReceiptContractClient::new(&env, &contract_id);
+    let env = Env::default();
+    let contract_id = env.register(TransactionReceiptContract, ());
+    let client = TransactionReceiptContractClient::new(&env, &contract_id);
 
-	let admin = Address::generate(&env);
-	let operator1 = Address::generate(&env);
-	let operator2 = Address::generate(&env);
+    let admin = Address::generate(&env);
+    let operator1 = Address::generate(&env);
+    let operator2 = Address::generate(&env);
 
-	client.try_init(&admin, &operator1).unwrap();
+    client.try_init(&admin, &operator1).unwrap();
 
-	env.mock_all_auths();
+    env.mock_all_auths();
 
-	// Admin rotates operator to operator2
-	client.try_set_operator(&admin, &operator2).unwrap();
+    // Admin rotates operator to operator2
+    client.try_set_operator(&admin, &operator2).unwrap();
 
-	let token = Address::generate(&env);
-	let deal = String::from_str(&env, "auth_deal");
+    let token = Address::generate(&env);
+    let deal = String::from_str(&env, "auth_deal");
 
-	let input = ReceiptInput {
-		external_ref_source: Symbol::new(&env, "manual_admin"),
-		external_ref: String::from_str(&env, "auth_ref"),
-		tx_type: Symbol::new(&env, "rent_payment"),
-		amount_usdc: 5_000_0000000i128,
-		token: token.clone(),
-		deal_id: deal.clone(),
-		listing_id: None,
-		from: None,
-		to: None,
-		amount_ngn: None,
-		fx_rate_ngn_per_usdc: None,
-		fx_provider: None,
-		metadata_hash: None,
-	};
+    let input = ReceiptInput {
+        external_ref_source: Symbol::new(&env, "manual_admin"),
+        external_ref: String::from_str(&env, "auth_ref"),
+        tx_type: Symbol::new(&env, "rent_payment"),
+        amount_usdc: 5_000_0000000i128,
+        token: token.clone(),
+        deal_id: deal.clone(),
+        listing_id: None,
+        from: None,
+        to: None,
+        amount_ngn: None,
+        fx_rate_ngn_per_usdc: None,
+        fx_provider: None,
+        metadata_hash: None,
+    };
 
-	// Recording with new operator should succeed
-	let _tx = client.try_record_receipt(&operator2, &input).unwrap().unwrap();
+    // Recording with new operator should succeed
+    let _tx = client
+        .try_record_receipt(&operator2, &input)
+        .unwrap()
+        .unwrap();
 
-	// Recording with old operator should fail
-	let input2 = ReceiptInput { external_ref: String::from_str(&env, "auth_ref2"), ..input };
-	let res_err = client.try_record_receipt(&operator1, &input2);
-	assert!(res_err.is_err());
-	assert_eq!(res_err.unwrap_err().unwrap(), ContractError::NotAuthorized);
+    // Recording with old operator should fail
+    let input2 = ReceiptInput {
+        external_ref: String::from_str(&env, "auth_ref2"),
+        ..input
+    };
+    let res_err = client.try_record_receipt(&operator1, &input2);
+    assert!(res_err.is_err());
+    assert_eq!(res_err.unwrap_err().unwrap(), ContractError::NotAuthorized);
 }
 
 // Integration: pause flow (init -> record -> pause -> fail record -> unpause -> record)
 #[test]
 fn test_integration_pause_flow() {
-	let env = Env::default();
-	let contract_id = env.register(TransactionReceiptContract, ());
-	let client = TransactionReceiptContractClient::new(&env, &contract_id);
+    let env = Env::default();
+    let contract_id = env.register(TransactionReceiptContract, ());
+    let client = TransactionReceiptContractClient::new(&env, &contract_id);
 
-	let admin = Address::generate(&env);
-	let operator = Address::generate(&env);
+    let admin = Address::generate(&env);
+    let operator = Address::generate(&env);
 
-	client.try_init(&admin, &operator).unwrap();
+    client.try_init(&admin, &operator).unwrap();
 
-	env.mock_all_auths();
+    env.mock_all_auths();
 
-	let token = Address::generate(&env);
-	let deal = String::from_str(&env, "pause_deal");
+    let token = Address::generate(&env);
+    let deal = String::from_str(&env, "pause_deal");
 
-	let input = ReceiptInput {
-		external_ref_source: Symbol::new(&env, "manual_admin"),
-		external_ref: String::from_str(&env, "pause_ref"),
-		tx_type: Symbol::new(&env, "rent_payment"),
-		amount_usdc: 10_000_0000000i128,
-		token: token.clone(),
-		deal_id: deal.clone(),
-		listing_id: None,
-		from: None,
-		to: None,
-		amount_ngn: None,
-		fx_rate_ngn_per_usdc: None,
-		fx_provider: None,
-		metadata_hash: None,
-	};
+    let input = ReceiptInput {
+        external_ref_source: Symbol::new(&env, "manual_admin"),
+        external_ref: String::from_str(&env, "pause_ref"),
+        tx_type: Symbol::new(&env, "rent_payment"),
+        amount_usdc: 10_000_0000000i128,
+        token: token.clone(),
+        deal_id: deal.clone(),
+        listing_id: None,
+        from: None,
+        to: None,
+        amount_ngn: None,
+        fx_rate_ngn_per_usdc: None,
+        fx_provider: None,
+        metadata_hash: None,
+    };
 
-	// Record should succeed before pause
-	client.try_record_receipt(&operator, &input).unwrap().unwrap();
+    // Record should succeed before pause
+    client
+        .try_record_receipt(&operator, &input)
+        .unwrap()
+        .unwrap();
 
-	// Pause contract
-	client.try_pause(&admin).unwrap();
+    // Pause contract
+    client.try_pause(&admin).unwrap();
 
-	// Recording while paused should fail
-	let input2 = ReceiptInput { external_ref: String::from_str(&env, "pause_ref2"), ..input };
-	let res = client.try_record_receipt(&operator, &input2);
-	assert!(res.is_err());
-	assert_eq!(res.unwrap_err().unwrap(), ContractError::ContractPaused);
+    // Recording while paused should fail
+    let input2 = ReceiptInput {
+        external_ref: String::from_str(&env, "pause_ref2"),
+        ..input
+    };
+    let res = client.try_record_receipt(&operator, &input2);
+    assert!(res.is_err());
+    assert_eq!(res.unwrap_err().unwrap(), ContractError::ContractPaused);
 
-	// Unpause
-	client.try_unpause(&admin).unwrap();
+    // Unpause
+    client.try_unpause(&admin).unwrap();
 
-	// Now recording should succeed again
-	let _tx2 = client.try_record_receipt(&operator, &input2).unwrap().unwrap();
+    // Now recording should succeed again
+    let _tx2 = client
+        .try_record_receipt(&operator, &input2)
+        .unwrap()
+        .unwrap();
 }
 
 // Integration: deal queries with multiple receipts and pagination across pages
 #[test]
 fn test_integration_deal_queries_and_pagination() {
-	let env = Env::default();
-	let contract_id = env.register(TransactionReceiptContract, ());
-	let client = TransactionReceiptContractClient::new(&env, &contract_id);
+    let env = Env::default();
+    let contract_id = env.register(TransactionReceiptContract, ());
+    let client = TransactionReceiptContractClient::new(&env, &contract_id);
 
-	let admin = Address::generate(&env);
-	let operator = Address::generate(&env);
+    let admin = Address::generate(&env);
+    let operator = Address::generate(&env);
 
-	client.try_init(&admin, &operator).unwrap();
-	env.mock_all_auths();
+    client.try_init(&admin, &operator).unwrap();
+    env.mock_all_auths();
 
-	let token = Address::generate(&env);
-	let deal = String::from_str(&env, "paging_deal");
+    let token = Address::generate(&env);
+    let deal = String::from_str(&env, "paging_deal");
 
-	// Create 5 receipts for the same deal
-	for i in 0..5u8 {
-		let ext = format!("p_ref_{}", i);
-		let input = ReceiptInput {
-			external_ref_source: Symbol::new(&env, "manual_admin"),
-			external_ref: String::from_str(&env, &ext),
-			tx_type: Symbol::new(&env, "rent_payment"),
-			amount_usdc: 1_000_0000000i128 + (i as i128),
-			token: token.clone(),
-			deal_id: deal.clone(),
-			listing_id: None,
-			from: None,
-			to: None,
-			amount_ngn: None,
-			fx_rate_ngn_per_usdc: None,
-			fx_provider: None,
-			metadata_hash: None,
-		};
-		client.try_record_receipt(&operator, &input).unwrap().unwrap();
-	}
+    // Create 5 receipts for the same deal
+    for i in 0..5u8 {
+        let ext = format!("p_ref_{}", i);
+        let input = ReceiptInput {
+            external_ref_source: Symbol::new(&env, "manual_admin"),
+            external_ref: String::from_str(&env, &ext),
+            tx_type: Symbol::new(&env, "rent_payment"),
+            amount_usdc: 1_000_0000000i128 + (i as i128),
+            token: token.clone(),
+            deal_id: deal.clone(),
+            listing_id: None,
+            from: None,
+            to: None,
+            amount_ngn: None,
+            fx_rate_ngn_per_usdc: None,
+            fx_provider: None,
+            metadata_hash: None,
+        };
+        client
+            .try_record_receipt(&operator, &input)
+            .unwrap()
+            .unwrap();
+    }
 
-	// Page 0, limit 2
-	let p0 = client.list_receipts_by_deal(&deal, &2u32, &Option::<u32>::None);
-	assert_eq!(p0.len(), 2);
+    // Page 0, limit 2
+    let p0 = client.list_receipts_by_deal(&deal, &2u32, &Option::<u32>::None);
+    assert_eq!(p0.len(), 2);
 
-	// Page 1 (cursor 2), limit 2
-	let p1 = client.list_receipts_by_deal(&deal, &2u32, &Some(2u32));
-	assert_eq!(p1.len(), 2);
+    // Page 1 (cursor 2), limit 2
+    let p1 = client.list_receipts_by_deal(&deal, &2u32, &Some(2u32));
+    assert_eq!(p1.len(), 2);
 
-	// Page 2 (cursor 4), limit 2 -> should have 1
-	let p2 = client.list_receipts_by_deal(&deal, &2u32, &Some(4u32));
-	assert_eq!(p2.len(), 1);
+    // Page 2 (cursor 4), limit 2 -> should have 1
+    let p2 = client.list_receipts_by_deal(&deal, &2u32, &Some(4u32));
+    assert_eq!(p2.len(), 1);
 }
-

--- a/contracts/transaction-receipt-contract/src/lib.rs
+++ b/contracts/transaction-receipt-contract/src/lib.rs
@@ -9,7 +9,9 @@
 
 extern crate alloc;
 
-use soroban_sdk::{contract, contractimpl, contracttype, contracterror, Address, BytesN, String, Symbol};
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contracttype, Address, BytesN, String, Symbol,
+};
 
 /// Allowed external reference sources for transaction ID generation
 pub const ALLOWED_SOURCES: [&str; 7] = [
@@ -137,48 +139,54 @@ pub struct TransactionReceiptContract;
 #[contractimpl]
 impl TransactionReceiptContract {
     /// Initialize the contract with admin and operator addresses
-    /// 
+    ///
     /// # Arguments
     /// * `env` - The Soroban environment
     /// * `admin` - The admin address (can manage operator and pause state)
     /// * `operator` - The operator address (can record receipts)
-    /// 
+    ///
     /// # Returns
     /// * `Ok(())` - If initialization succeeds
     /// * `Err(ContractError::AlreadyInitialized)` - If contract is already initialized
-    /// 
+    ///
     /// # Requirements
     /// * Can only be called once (Requirements 1.3)
     /// * Stores admin and operator addresses (Requirements 1.1, 1.2)
     /// * Initializes paused state to false
-    pub fn init(env: soroban_sdk::Env, admin: Address, operator: Address) -> Result<(), ContractError> {
+    pub fn init(
+        env: soroban_sdk::Env,
+        admin: Address,
+        operator: Address,
+    ) -> Result<(), ContractError> {
         // Check if already initialized by checking if Admin key exists
         if env.storage().instance().has(&StorageKey::Admin) {
             return Err(ContractError::AlreadyInitialized);
         }
-        
+
         // Store admin address
         env.storage().instance().set(&StorageKey::Admin, &admin);
-        
+
         // Store operator address
-        env.storage().instance().set(&StorageKey::Operator, &operator);
-        
+        env.storage()
+            .instance()
+            .set(&StorageKey::Operator, &operator);
+
         // Initialize paused state to false
         env.storage().instance().set(&StorageKey::Paused, &false);
-        
+
         Ok(())
     }
 
     /// Pause the contract to prevent receipt recording
-    /// 
+    ///
     /// # Arguments
     /// * `env` - The Soroban environment
     /// * `admin` - The admin address attempting to pause
-    /// 
+    ///
     /// # Returns
     /// * `Ok(())` - If pause succeeds
     /// * `Err(ContractError::NotAuthorized)` - If caller is not admin
-    /// 
+    ///
     /// # Requirements
     /// * Only admin can pause (Requirement 5.3)
     /// * Updates paused state to true (Requirement 6.1)
@@ -186,26 +194,26 @@ impl TransactionReceiptContract {
     pub fn pause(env: soroban_sdk::Env, admin: Address) -> Result<(), ContractError> {
         // Require authentication from the admin
         admin.require_auth();
-        
+
         // Verify caller is admin
         require_admin(&env, &admin)?;
-        
+
         // Set paused state to true (idempotent - no error if already paused)
         env.storage().instance().set(&StorageKey::Paused, &true);
-        
+
         Ok(())
     }
 
     /// Unpause the contract to allow receipt recording
-    /// 
+    ///
     /// # Arguments
     /// * `env` - The Soroban environment
     /// * `admin` - The admin address attempting to unpause
-    /// 
+    ///
     /// # Returns
     /// * `Ok(())` - If unpause succeeds
     /// * `Err(ContractError::NotAuthorized)` - If caller is not admin
-    /// 
+    ///
     /// # Requirements
     /// * Only admin can unpause (Requirement 5.4)
     /// * Updates paused state to false (Requirement 6.1)
@@ -213,55 +221,61 @@ impl TransactionReceiptContract {
     pub fn unpause(env: soroban_sdk::Env, admin: Address) -> Result<(), ContractError> {
         // Require authentication from the admin
         admin.require_auth();
-        
+
         // Verify caller is admin
         require_admin(&env, &admin)?;
-        
+
         // Set paused state to false (idempotent - no error if already unpaused)
         env.storage().instance().set(&StorageKey::Paused, &false);
-        
+
         Ok(())
     }
 
     /// Set a new operator address
-    /// 
+    ///
     /// # Arguments
     /// * `env` - The Soroban environment
     /// * `admin` - The admin address attempting to set operator
     /// * `new_operator` - The new operator address
-    /// 
+    ///
     /// # Returns
     /// * `Ok(())` - If operator update succeeds
     /// * `Err(ContractError::NotAuthorized)` - If caller is not admin
-    /// 
+    ///
     /// # Requirements
     /// * Only admin can set operator (Requirement 5.2, 7.2)
     /// * Updates operator address in storage (Requirement 7.1)
     /// * Accepts any valid Soroban Address (Requirement 7.3)
-    pub fn set_operator(env: soroban_sdk::Env, admin: Address, new_operator: Address) -> Result<(), ContractError> {
+    pub fn set_operator(
+        env: soroban_sdk::Env,
+        admin: Address,
+        new_operator: Address,
+    ) -> Result<(), ContractError> {
         // Require authentication from the admin
         admin.require_auth();
-        
+
         // Verify caller is admin
         require_admin(&env, &admin)?;
-        
+
         // Update operator address in storage
-        env.storage().instance().set(&StorageKey::Operator, &new_operator);
-        
+        env.storage()
+            .instance()
+            .set(&StorageKey::Operator, &new_operator);
+
         Ok(())
     }
 
     /// Record a new transaction receipt
-    /// 
+    ///
     /// # Arguments
     /// * `env` - The Soroban environment
     /// * `operator` - The operator address attempting to record
     /// * `input` - Receipt input parameters (ReceiptInput struct)
-    /// 
+    ///
     /// # Returns
     /// * `Ok(BytesN<32>)` - The generated tx_id
     /// * `Err(ContractError)` - If validation fails or duplicate detected
-    /// 
+    ///
     /// # Requirements
     /// * Only operator can record (Requirement 5.1)
     /// * Contract must not be paused (Requirement 6.2)
@@ -275,29 +289,33 @@ impl TransactionReceiptContract {
     ) -> Result<BytesN<32>, ContractError> {
         // Require authentication from the operator
         operator.require_auth();
-        
+
         // Verify caller is operator
         require_operator(&env, &operator)?;
-        
+
         // Verify contract is not paused
         require_not_paused(&env)?;
-        
+
         // Validate amount_usdc is positive
         if input.amount_usdc <= 0 {
             return Err(ContractError::InvalidAmount);
         }
-        
+
         // Generate tx_id from canonical external reference
         let tx_id = generate_tx_id(&env, &input.external_ref_source, &input.external_ref)?;
-        
+
         // Check for duplicate tx_id
-        if env.storage().persistent().has(&StorageKey::Receipt(tx_id.clone())) {
+        if env
+            .storage()
+            .persistent()
+            .has(&StorageKey::Receipt(tx_id.clone()))
+        {
             return Err(ContractError::DuplicateTransaction);
         }
-        
+
         // Get current ledger timestamp
         let timestamp = env.ledger().timestamp();
-        
+
         // Create Receipt struct
         let receipt = Receipt {
             tx_id: tx_id.clone(),
@@ -315,37 +333,41 @@ impl TransactionReceiptContract {
             metadata_hash: input.metadata_hash,
             timestamp,
         };
-        
+
         // Store receipt in persistent storage
-        env.storage().persistent().set(&StorageKey::Receipt(tx_id.clone()), &receipt);
-        
+        env.storage()
+            .persistent()
+            .set(&StorageKey::Receipt(tx_id.clone()), &receipt);
+
         // Update deal index
         let deal_count_key = StorageKey::DealCount(input.deal_id.clone());
         let current_count: u32 = env.storage().persistent().get(&deal_count_key).unwrap_or(0);
-        
+
         // Store tx_id in deal index
         let deal_index_key = StorageKey::DealIndex(input.deal_id.clone(), current_count);
         env.storage().persistent().set(&deal_index_key, &tx_id);
-        
+
         // Increment deal count
-        env.storage().persistent().set(&deal_count_key, &(current_count + 1));
-        
+        env.storage()
+            .persistent()
+            .set(&deal_count_key, &(current_count + 1));
+
         // Emit event with topic ("receipt", tx_id) and receipt payload
         env.events().publish(("receipt", tx_id.clone()), receipt);
-        
+
         Ok(tx_id)
     }
 
     /// Retrieve a receipt by transaction ID
-    /// 
+    ///
     /// # Arguments
     /// * `env` - The Soroban environment
     /// * `tx_id` - The transaction ID to look up
-    /// 
+    ///
     /// # Returns
     /// * `Some(Receipt)` - If the receipt exists
     /// * `None` - If the receipt does not exist
-    /// 
+    ///
     /// # Requirements
     /// * Returns complete receipt if exists (Requirement 8.1, 8.3)
     /// * Returns None for non-existent tx_id (Requirement 8.2)
@@ -355,16 +377,16 @@ impl TransactionReceiptContract {
     }
 
     /// List all receipts for a specific deal with pagination
-    /// 
+    ///
     /// # Arguments
     /// * `env` - The Soroban environment
     /// * `deal_id` - The deal identifier to query
     /// * `limit` - Maximum number of receipts to return
     /// * `cursor` - Optional starting index for pagination (default: 0)
-    /// 
+    ///
     /// # Returns
     /// * `Vec<Receipt>` - Vector of receipts matching the deal_id
-    /// 
+    ///
     /// # Requirements
     /// * Returns receipts matching deal_id (Requirement 9.1)
     /// * Supports pagination (Requirements 9.2, 9.4, 9.5)
@@ -377,42 +399,50 @@ impl TransactionReceiptContract {
         cursor: Option<u32>,
     ) -> soroban_sdk::Vec<Receipt> {
         use soroban_sdk::Vec;
-        
+
         let mut results = Vec::new(&env);
-        
+
         // Get total count of receipts for this deal
         let deal_count_key = StorageKey::DealCount(deal_id.clone());
         let total_count: u32 = env.storage().persistent().get(&deal_count_key).unwrap_or(0);
-        
+
         // Calculate start index from cursor (default 0)
         let start_index = cursor.unwrap_or(0);
-        
+
         // Calculate end index (start + limit, capped at total_count)
         let end_index = core::cmp::min(start_index + limit, total_count);
-        
+
         // Iterate through deal index to load receipts
         for index in start_index..end_index {
             let deal_index_key = StorageKey::DealIndex(deal_id.clone(), index);
-            
+
             // Load tx_id from deal index
-            if let Some(tx_id) = env.storage().persistent().get::<StorageKey, BytesN<32>>(&deal_index_key) {
+            if let Some(tx_id) = env
+                .storage()
+                .persistent()
+                .get::<StorageKey, BytesN<32>>(&deal_index_key)
+            {
                 // Load receipt for this tx_id
-                if let Some(receipt) = env.storage().persistent().get::<StorageKey, Receipt>(&StorageKey::Receipt(tx_id)) {
+                if let Some(receipt) = env
+                    .storage()
+                    .persistent()
+                    .get::<StorageKey, Receipt>(&StorageKey::Receipt(tx_id))
+                {
                     results.push_back(receipt);
                 }
             }
         }
-        
+
         results
     }
 }
 
 /// Helper function to verify that the caller is the admin
-/// 
+///
 /// # Arguments
 /// * `env` - The Soroban environment
 /// * `caller` - The address attempting the operation
-/// 
+///
 /// # Returns
 /// * `Ok(())` - If the caller is the admin
 /// * `Err(ContractError::NotAuthorized)` - If the caller is not the admin
@@ -423,21 +453,21 @@ fn require_admin(env: &soroban_sdk::Env, caller: &Address) -> Result<(), Contrac
         .instance()
         .get(&StorageKey::Admin)
         .unwrap_or_else(|| panic!("Admin not initialized"));
-    
+
     // Verify caller is admin
     if caller != &admin {
         return Err(ContractError::NotAuthorized);
     }
-    
+
     Ok(())
 }
 
 /// Helper function to verify that the caller is the operator
-/// 
+///
 /// # Arguments
 /// * `env` - The Soroban environment
 /// * `caller` - The address attempting the operation
-/// 
+///
 /// # Returns
 /// * `Ok(())` - If the caller is the operator
 /// * `Err(ContractError::NotAuthorized)` - If the caller is not the operator
@@ -448,20 +478,20 @@ fn require_operator(env: &soroban_sdk::Env, caller: &Address) -> Result<(), Cont
         .instance()
         .get(&StorageKey::Operator)
         .unwrap_or_else(|| panic!("Operator not initialized"));
-    
+
     // Verify caller is operator
     if caller != &operator {
         return Err(ContractError::NotAuthorized);
     }
-    
+
     Ok(())
 }
 
 /// Helper function to verify that the contract is not paused
-/// 
+///
 /// # Arguments
 /// * `env` - The Soroban environment
-/// 
+///
 /// # Returns
 /// * `Ok(())` - If the contract is not paused
 /// * `Err(ContractError::ContractPaused)` - If the contract is paused
@@ -472,32 +502,32 @@ fn require_not_paused(env: &soroban_sdk::Env) -> Result<(), ContractError> {
         .instance()
         .get(&StorageKey::Paused)
         .unwrap_or(false);
-    
+
     // Return error if contract is paused
     if paused {
         return Err(ContractError::ContractPaused);
     }
-    
+
     Ok(())
 }
 
 /// Helper function to generate a deterministic transaction ID from external payment references
-/// 
+///
 /// # Arguments
 /// * `env` - The Soroban environment
 /// * `external_ref_source` - The payment source (must be in ALLOWED_SOURCES)
 /// * `external_ref` - The external payment reference string
-/// 
+///
 /// # Returns
 /// * `Ok(BytesN<32>)` - SHA-256 hash of the canonical external reference string
 /// * `Err(ContractError)` - If validation fails
-/// 
+///
 /// # Validation Rules
 /// * external_ref_source must be in ALLOWED_SOURCES (case-insensitive)
 /// * external_ref must not be empty after trimming
 /// * external_ref must not contain pipe character (|)
 /// * external_ref must not exceed 256 characters
-/// 
+///
 /// # Canonical Format
 /// The canonical string format is: "v1|source=<lowercased_trimmed_source>|ref=<trimmed_ref>"
 fn generate_tx_id(
@@ -506,53 +536,53 @@ fn generate_tx_id(
     external_ref: &String,
 ) -> Result<BytesN<32>, ContractError> {
     use soroban_sdk::Bytes;
-    
+
     // Convert Symbol to string for validation
     // We need to use the alloc feature for string manipulation
     extern crate alloc;
-    use alloc::string::ToString;
     use alloc::string::String as StdString;
-    
+    use alloc::string::ToString;
+
     let source_str: StdString = external_ref_source.to_string();
     let source_trimmed = source_str.trim();
     let source_lower = source_trimmed.to_lowercase();
-    
+
     // Validate external_ref_source against ALLOWED_SOURCES
     if !ALLOWED_SOURCES.contains(&source_lower.as_str()) {
         return Err(ContractError::InvalidExternalRefSource);
     }
-    
+
     // Get the external_ref as a string and trim it
     let ref_str: StdString = external_ref.to_string();
     let ref_trimmed = ref_str.trim();
-    
+
     // Validate external_ref is not empty after trimming
     if ref_trimmed.is_empty() {
         return Err(ContractError::InvalidExternalRef);
     }
-    
+
     // Validate external_ref does not contain pipe character
     if ref_trimmed.contains('|') {
         return Err(ContractError::InvalidExternalRef);
     }
-    
+
     // Validate external_ref does not exceed 256 characters
     if ref_trimmed.len() > 256 {
         return Err(ContractError::InvalidExternalRef);
     }
-    
+
     // Construct canonical string: "v1|source=<lowercased_trimmed_source>|ref=<trimmed_ref>"
     use alloc::format;
     let canonical = format!("v1|source={}|ref={}", source_lower, ref_trimmed);
-    
+
     // Convert to Bytes for hashing
     let canonical_bytes = Bytes::from_slice(env, canonical.as_bytes());
-    
+
     // Compute SHA-256 hash using Soroban's crypto module
     let hash = env.crypto().sha256(&canonical_bytes);
-    
+
     Ok(hash.into())
 }
 
-mod test;
 mod integration_tests;
+mod test;

--- a/contracts/transaction-receipt-contract/src/test.rs
+++ b/contracts/transaction-receipt-contract/src/test.rs
@@ -32,11 +32,11 @@ fn test_contract_error_codes() {
 #[test]
 fn test_receipt_struct_creation() {
     let env = Env::default();
-    
+
     let tx_id = BytesN::from_array(&env, &[0u8; 32]);
     let token = Address::generate(&env);
     let deal_id = String::from_str(&env, "deal_123");
-    
+
     let receipt = Receipt {
         tx_id: tx_id.clone(),
         tx_type: Symbol::new(&env, "rent_payment"),
@@ -53,7 +53,7 @@ fn test_receipt_struct_creation() {
         metadata_hash: None,
         timestamp: 1234567890,
     };
-    
+
     // Verify receipt fields
     assert_eq!(receipt.tx_id, tx_id);
     assert_eq!(receipt.external_ref, tx_id);
@@ -64,15 +64,15 @@ fn test_receipt_struct_creation() {
 #[test]
 fn test_storage_key_variants() {
     let env = Env::default();
-    
+
     // Test that all StorageKey variants can be created
     let _admin_key = StorageKey::Admin;
     let _operator_key = StorageKey::Operator;
     let _paused_key = StorageKey::Paused;
-    
+
     let tx_id = BytesN::from_array(&env, &[1u8; 32]);
     let _receipt_key = StorageKey::Receipt(tx_id);
-    
+
     let deal_id = String::from_str(&env, "deal_456");
     let _deal_index_key = StorageKey::DealIndex(deal_id.clone(), 0);
     let _deal_count_key = StorageKey::DealCount(deal_id);
@@ -85,10 +85,10 @@ fn test_generate_tx_id_valid_input() {
     let env = Env::default();
     let source = Symbol::new(&env, "paystack");
     let reference = String::from_str(&env, "ref_12345");
-    
+
     let result = generate_tx_id(&env, &source, &reference);
     assert!(result.is_ok());
-    
+
     let tx_id = result.unwrap();
     // Verify it's a 32-byte hash
     assert_eq!(tx_id.len(), 32);
@@ -98,7 +98,7 @@ fn test_generate_tx_id_valid_input() {
 fn test_generate_tx_id_all_allowed_sources() {
     let env = Env::default();
     let reference = String::from_str(&env, "test_ref");
-    
+
     for source_str in ALLOWED_SOURCES.iter() {
         let source = Symbol::new(&env, source_str);
         let result = generate_tx_id(&env, &source, &reference);
@@ -111,7 +111,7 @@ fn test_generate_tx_id_invalid_source() {
     let env = Env::default();
     let source = Symbol::new(&env, "invalid_source");
     let reference = String::from_str(&env, "ref_12345");
-    
+
     let result = generate_tx_id(&env, &source, &reference);
     assert!(result.is_err());
     assert_eq!(result.unwrap_err(), ContractError::InvalidExternalRefSource);
@@ -122,7 +122,7 @@ fn test_generate_tx_id_empty_reference() {
     let env = Env::default();
     let source = Symbol::new(&env, "paystack");
     let reference = String::from_str(&env, "");
-    
+
     let result = generate_tx_id(&env, &source, &reference);
     assert!(result.is_err());
     assert_eq!(result.unwrap_err(), ContractError::InvalidExternalRef);
@@ -133,7 +133,7 @@ fn test_generate_tx_id_whitespace_only_reference() {
     let env = Env::default();
     let source = Symbol::new(&env, "paystack");
     let reference = String::from_str(&env, "   ");
-    
+
     let result = generate_tx_id(&env, &source, &reference);
     assert!(result.is_err());
     assert_eq!(result.unwrap_err(), ContractError::InvalidExternalRef);
@@ -144,7 +144,7 @@ fn test_generate_tx_id_reference_with_pipe() {
     let env = Env::default();
     let source = Symbol::new(&env, "paystack");
     let reference = String::from_str(&env, "ref|12345");
-    
+
     let result = generate_tx_id(&env, &source, &reference);
     assert!(result.is_err());
     assert_eq!(result.unwrap_err(), ContractError::InvalidExternalRef);
@@ -157,7 +157,7 @@ fn test_generate_tx_id_reference_too_long() {
     // Create a string with 257 characters
     let long_ref = "a".repeat(257);
     let reference = String::from_str(&env, &long_ref);
-    
+
     let result = generate_tx_id(&env, &source, &reference);
     assert!(result.is_err());
     assert_eq!(result.unwrap_err(), ContractError::InvalidExternalRef);
@@ -170,7 +170,7 @@ fn test_generate_tx_id_reference_exactly_256_chars() {
     // Create a string with exactly 256 characters
     let max_ref = "a".repeat(256);
     let reference = String::from_str(&env, &max_ref);
-    
+
     let result = generate_tx_id(&env, &source, &reference);
     assert!(result.is_ok());
 }
@@ -179,15 +179,15 @@ fn test_generate_tx_id_reference_exactly_256_chars() {
 fn test_generate_tx_id_source_case_insensitive() {
     let env = Env::default();
     let reference = String::from_str(&env, "ref_12345");
-    
+
     let source_lower = Symbol::new(&env, "paystack");
     let source_upper = Symbol::new(&env, "PAYSTACK");
     let source_mixed = Symbol::new(&env, "PayStack");
-    
+
     let result_lower = generate_tx_id(&env, &source_lower, &reference).unwrap();
     let result_upper = generate_tx_id(&env, &source_upper, &reference).unwrap();
     let result_mixed = generate_tx_id(&env, &source_mixed, &reference).unwrap();
-    
+
     // All should produce the same tx_id
     assert_eq!(result_lower, result_upper);
     assert_eq!(result_lower, result_mixed);
@@ -197,13 +197,13 @@ fn test_generate_tx_id_source_case_insensitive() {
 fn test_generate_tx_id_reference_case_sensitive() {
     let env = Env::default();
     let source = Symbol::new(&env, "paystack");
-    
+
     let ref_lower = String::from_str(&env, "ref_12345");
     let ref_upper = String::from_str(&env, "REF_12345");
-    
+
     let result_lower = generate_tx_id(&env, &source, &ref_lower).unwrap();
     let result_upper = generate_tx_id(&env, &source, &ref_upper).unwrap();
-    
+
     // Should produce different tx_ids (case-sensitive)
     assert_ne!(result_lower, result_upper);
 }
@@ -214,12 +214,12 @@ fn test_generate_tx_id_trimming() {
     // Note: Symbols cannot contain spaces, so we test reference trimming only
     let source = Symbol::new(&env, "paystack");
     let reference = String::from_str(&env, "  ref_12345  ");
-    
+
     let reference_clean = String::from_str(&env, "ref_12345");
-    
+
     let result_trimmed = generate_tx_id(&env, &source, &reference).unwrap();
     let result_clean = generate_tx_id(&env, &source, &reference_clean).unwrap();
-    
+
     // Should produce the same tx_id after trimming
     assert_eq!(result_trimmed, result_clean);
 }
@@ -229,10 +229,10 @@ fn test_generate_tx_id_deterministic() {
     let env = Env::default();
     let source = Symbol::new(&env, "paystack");
     let reference = String::from_str(&env, "ref_12345");
-    
+
     let result1 = generate_tx_id(&env, &source, &reference).unwrap();
     let result2 = generate_tx_id(&env, &source, &reference).unwrap();
-    
+
     // Should produce the same tx_id for the same inputs
     assert_eq!(result1, result2);
 }
@@ -241,13 +241,13 @@ fn test_generate_tx_id_deterministic() {
 fn test_generate_tx_id_different_sources_different_hashes() {
     let env = Env::default();
     let reference = String::from_str(&env, "ref_12345");
-    
+
     let source1 = Symbol::new(&env, "paystack");
     let source2 = Symbol::new(&env, "flutterwave");
-    
+
     let result1 = generate_tx_id(&env, &source1, &reference).unwrap();
     let result2 = generate_tx_id(&env, &source2, &reference).unwrap();
-    
+
     // Different sources should produce different tx_ids
     assert_ne!(result1, result2);
 }
@@ -256,13 +256,13 @@ fn test_generate_tx_id_different_sources_different_hashes() {
 fn test_generate_tx_id_different_references_different_hashes() {
     let env = Env::default();
     let source = Symbol::new(&env, "paystack");
-    
+
     let ref1 = String::from_str(&env, "ref_12345");
     let ref2 = String::from_str(&env, "ref_67890");
-    
+
     let result1 = generate_tx_id(&env, &source, &ref1).unwrap();
     let result2 = generate_tx_id(&env, &source, &ref2).unwrap();
-    
+
     // Different references should produce different tx_ids
     assert_ne!(result1, result2);
 }
@@ -277,41 +277,29 @@ fn test_init_success() {
     let env = Env::default();
     let contract_id = env.register(TransactionReceiptContract, ());
     let client = TransactionReceiptContractClient::new(&env, &contract_id);
-    
+
     let admin = Address::generate(&env);
     let operator = Address::generate(&env);
-    
+
     // Initialize the contract
     client.try_init(&admin, &operator).unwrap();
-    
+
     // Verify admin is stored by checking storage directly
-    let stored_admin: Address = env
-        .as_contract(&contract_id, || {
-            env.storage()
-                .instance()
-                .get(&StorageKey::Admin)
-                .unwrap()
-        });
+    let stored_admin: Address = env.as_contract(&contract_id, || {
+        env.storage().instance().get(&StorageKey::Admin).unwrap()
+    });
     assert_eq!(stored_admin, admin);
-    
+
     // Verify operator is stored
-    let stored_operator: Address = env
-        .as_contract(&contract_id, || {
-            env.storage()
-                .instance()
-                .get(&StorageKey::Operator)
-                .unwrap()
-        });
+    let stored_operator: Address = env.as_contract(&contract_id, || {
+        env.storage().instance().get(&StorageKey::Operator).unwrap()
+    });
     assert_eq!(stored_operator, operator);
-    
+
     // Verify paused state is false
-    let paused: bool = env
-        .as_contract(&contract_id, || {
-            env.storage()
-                .instance()
-                .get(&StorageKey::Paused)
-                .unwrap()
-        });
+    let paused: bool = env.as_contract(&contract_id, || {
+        env.storage().instance().get(&StorageKey::Paused).unwrap()
+    });
     assert_eq!(paused, false);
 }
 
@@ -320,39 +308,34 @@ fn test_init_already_initialized() {
     let env = Env::default();
     let contract_id = env.register(TransactionReceiptContract, ());
     let client = TransactionReceiptContractClient::new(&env, &contract_id);
-    
+
     let admin = Address::generate(&env);
     let operator = Address::generate(&env);
-    
+
     // Initialize the contract first time
     client.try_init(&admin, &operator).unwrap();
-    
+
     // Try to initialize again
     let admin2 = Address::generate(&env);
     let operator2 = Address::generate(&env);
     let result2 = client.try_init(&admin2, &operator2);
-    
+
     // Should fail with AlreadyInitialized error
     assert!(result2.is_err());
-    assert_eq!(result2.unwrap_err().unwrap(), ContractError::AlreadyInitialized);
-    
+    assert_eq!(
+        result2.unwrap_err().unwrap(),
+        ContractError::AlreadyInitialized
+    );
+
     // Verify original admin and operator are still stored
-    let stored_admin: Address = env
-        .as_contract(&contract_id, || {
-            env.storage()
-                .instance()
-                .get(&StorageKey::Admin)
-                .unwrap()
-        });
+    let stored_admin: Address = env.as_contract(&contract_id, || {
+        env.storage().instance().get(&StorageKey::Admin).unwrap()
+    });
     assert_eq!(stored_admin, admin);
-    
-    let stored_operator: Address = env
-        .as_contract(&contract_id, || {
-            env.storage()
-                .instance()
-                .get(&StorageKey::Operator)
-                .unwrap()
-        });
+
+    let stored_operator: Address = env.as_contract(&contract_id, || {
+        env.storage().instance().get(&StorageKey::Operator).unwrap()
+    });
     assert_eq!(stored_operator, operator);
 }
 
@@ -361,29 +344,21 @@ fn test_init_with_same_admin_and_operator() {
     let env = Env::default();
     let contract_id = env.register(TransactionReceiptContract, ());
     let client = TransactionReceiptContractClient::new(&env, &contract_id);
-    
+
     let address = Address::generate(&env);
-    
+
     // Initialize with same address for both admin and operator
     client.try_init(&address, &address).unwrap();
-    
+
     // Verify both are stored correctly
-    let stored_admin: Address = env
-        .as_contract(&contract_id, || {
-            env.storage()
-                .instance()
-                .get(&StorageKey::Admin)
-                .unwrap()
-        });
+    let stored_admin: Address = env.as_contract(&contract_id, || {
+        env.storage().instance().get(&StorageKey::Admin).unwrap()
+    });
     assert_eq!(stored_admin, address);
-    
-    let stored_operator: Address = env
-        .as_contract(&contract_id, || {
-            env.storage()
-                .instance()
-                .get(&StorageKey::Operator)
-                .unwrap()
-        });
+
+    let stored_operator: Address = env.as_contract(&contract_id, || {
+        env.storage().instance().get(&StorageKey::Operator).unwrap()
+    });
     assert_eq!(stored_operator, address);
 }
 
@@ -394,27 +369,23 @@ fn test_pause_success() {
     let env = Env::default();
     let contract_id = env.register(TransactionReceiptContract, ());
     let client = TransactionReceiptContractClient::new(&env, &contract_id);
-    
+
     let admin = Address::generate(&env);
     let operator = Address::generate(&env);
-    
+
     // Initialize the contract
     client.try_init(&admin, &operator).unwrap();
-    
+
     // Mock admin authentication
     env.mock_all_auths();
-    
+
     // Pause the contract
     client.try_pause(&admin).unwrap();
-    
+
     // Verify paused state is true
-    let paused: bool = env
-        .as_contract(&contract_id, || {
-            env.storage()
-                .instance()
-                .get(&StorageKey::Paused)
-                .unwrap()
-        });
+    let paused: bool = env.as_contract(&contract_id, || {
+        env.storage().instance().get(&StorageKey::Paused).unwrap()
+    });
     assert_eq!(paused, true);
 }
 
@@ -423,32 +394,28 @@ fn test_pause_not_authorized() {
     let env = Env::default();
     let contract_id = env.register(TransactionReceiptContract, ());
     let client = TransactionReceiptContractClient::new(&env, &contract_id);
-    
+
     let admin = Address::generate(&env);
     let operator = Address::generate(&env);
     let unauthorized = Address::generate(&env);
-    
+
     // Initialize the contract
     client.try_init(&admin, &operator).unwrap();
-    
+
     // Mock authentication for unauthorized address
     env.mock_all_auths();
-    
+
     // Try to pause with unauthorized address
     let result = client.try_pause(&unauthorized);
-    
+
     // Should fail with NotAuthorized error
     assert!(result.is_err());
     assert_eq!(result.unwrap_err().unwrap(), ContractError::NotAuthorized);
-    
+
     // Verify paused state is still false
-    let paused: bool = env
-        .as_contract(&contract_id, || {
-            env.storage()
-                .instance()
-                .get(&StorageKey::Paused)
-                .unwrap()
-        });
+    let paused: bool = env.as_contract(&contract_id, || {
+        env.storage().instance().get(&StorageKey::Paused).unwrap()
+    });
     assert_eq!(paused, false);
 }
 
@@ -457,40 +424,32 @@ fn test_pause_idempotent() {
     let env = Env::default();
     let contract_id = env.register(TransactionReceiptContract, ());
     let client = TransactionReceiptContractClient::new(&env, &contract_id);
-    
+
     let admin = Address::generate(&env);
     let operator = Address::generate(&env);
-    
+
     // Initialize the contract
     client.try_init(&admin, &operator).unwrap();
-    
+
     // Mock admin authentication
     env.mock_all_auths();
-    
+
     // Pause the contract first time
     client.try_pause(&admin).unwrap();
-    
+
     // Verify paused state is true
-    let paused: bool = env
-        .as_contract(&contract_id, || {
-            env.storage()
-                .instance()
-                .get(&StorageKey::Paused)
-                .unwrap()
-        });
+    let paused: bool = env.as_contract(&contract_id, || {
+        env.storage().instance().get(&StorageKey::Paused).unwrap()
+    });
     assert_eq!(paused, true);
-    
+
     // Pause again (should succeed without error)
     client.try_pause(&admin).unwrap();
-    
+
     // Verify paused state is still true
-    let paused: bool = env
-        .as_contract(&contract_id, || {
-            env.storage()
-                .instance()
-                .get(&StorageKey::Paused)
-                .unwrap()
-        });
+    let paused: bool = env.as_contract(&contract_id, || {
+        env.storage().instance().get(&StorageKey::Paused).unwrap()
+    });
     assert_eq!(paused, true);
 }
 
@@ -499,40 +458,32 @@ fn test_unpause_success() {
     let env = Env::default();
     let contract_id = env.register(TransactionReceiptContract, ());
     let client = TransactionReceiptContractClient::new(&env, &contract_id);
-    
+
     let admin = Address::generate(&env);
     let operator = Address::generate(&env);
-    
+
     // Initialize the contract
     client.try_init(&admin, &operator).unwrap();
-    
+
     // Mock admin authentication
     env.mock_all_auths();
-    
+
     // Pause the contract first
     client.try_pause(&admin).unwrap();
-    
+
     // Verify paused state is true
-    let paused: bool = env
-        .as_contract(&contract_id, || {
-            env.storage()
-                .instance()
-                .get(&StorageKey::Paused)
-                .unwrap()
-        });
+    let paused: bool = env.as_contract(&contract_id, || {
+        env.storage().instance().get(&StorageKey::Paused).unwrap()
+    });
     assert_eq!(paused, true);
-    
+
     // Unpause the contract
     client.try_unpause(&admin).unwrap();
-    
+
     // Verify paused state is false
-    let paused: bool = env
-        .as_contract(&contract_id, || {
-            env.storage()
-                .instance()
-                .get(&StorageKey::Paused)
-                .unwrap()
-        });
+    let paused: bool = env.as_contract(&contract_id, || {
+        env.storage().instance().get(&StorageKey::Paused).unwrap()
+    });
     assert_eq!(paused, false);
 }
 
@@ -541,35 +492,31 @@ fn test_unpause_not_authorized() {
     let env = Env::default();
     let contract_id = env.register(TransactionReceiptContract, ());
     let client = TransactionReceiptContractClient::new(&env, &contract_id);
-    
+
     let admin = Address::generate(&env);
     let operator = Address::generate(&env);
     let unauthorized = Address::generate(&env);
-    
+
     // Initialize the contract
     client.try_init(&admin, &operator).unwrap();
-    
+
     // Mock authentication
     env.mock_all_auths();
-    
+
     // Pause the contract first
     client.try_pause(&admin).unwrap();
-    
+
     // Try to unpause with unauthorized address
     let result = client.try_unpause(&unauthorized);
-    
+
     // Should fail with NotAuthorized error
     assert!(result.is_err());
     assert_eq!(result.unwrap_err().unwrap(), ContractError::NotAuthorized);
-    
+
     // Verify paused state is still true
-    let paused: bool = env
-        .as_contract(&contract_id, || {
-            env.storage()
-                .instance()
-                .get(&StorageKey::Paused)
-                .unwrap()
-        });
+    let paused: bool = env.as_contract(&contract_id, || {
+        env.storage().instance().get(&StorageKey::Paused).unwrap()
+    });
     assert_eq!(paused, true);
 }
 
@@ -578,40 +525,32 @@ fn test_unpause_idempotent() {
     let env = Env::default();
     let contract_id = env.register(TransactionReceiptContract, ());
     let client = TransactionReceiptContractClient::new(&env, &contract_id);
-    
+
     let admin = Address::generate(&env);
     let operator = Address::generate(&env);
-    
+
     // Initialize the contract
     client.try_init(&admin, &operator).unwrap();
-    
+
     // Mock admin authentication
     env.mock_all_auths();
-    
+
     // Contract starts unpaused, unpause should succeed
     client.try_unpause(&admin).unwrap();
-    
+
     // Verify paused state is false
-    let paused: bool = env
-        .as_contract(&contract_id, || {
-            env.storage()
-                .instance()
-                .get(&StorageKey::Paused)
-                .unwrap()
-        });
+    let paused: bool = env.as_contract(&contract_id, || {
+        env.storage().instance().get(&StorageKey::Paused).unwrap()
+    });
     assert_eq!(paused, false);
-    
+
     // Unpause again (should succeed without error)
     client.try_unpause(&admin).unwrap();
-    
+
     // Verify paused state is still false
-    let paused: bool = env
-        .as_contract(&contract_id, || {
-            env.storage()
-                .instance()
-                .get(&StorageKey::Paused)
-                .unwrap()
-        });
+    let paused: bool = env.as_contract(&contract_id, || {
+        env.storage().instance().get(&StorageKey::Paused).unwrap()
+    });
     assert_eq!(paused, false);
 }
 
@@ -620,56 +559,40 @@ fn test_pause_unpause_cycle() {
     let env = Env::default();
     let contract_id = env.register(TransactionReceiptContract, ());
     let client = TransactionReceiptContractClient::new(&env, &contract_id);
-    
+
     let admin = Address::generate(&env);
     let operator = Address::generate(&env);
-    
+
     // Initialize the contract
     client.try_init(&admin, &operator).unwrap();
-    
+
     // Mock admin authentication
     env.mock_all_auths();
-    
+
     // Initial state should be unpaused
-    let paused: bool = env
-        .as_contract(&contract_id, || {
-            env.storage()
-                .instance()
-                .get(&StorageKey::Paused)
-                .unwrap()
-        });
+    let paused: bool = env.as_contract(&contract_id, || {
+        env.storage().instance().get(&StorageKey::Paused).unwrap()
+    });
     assert_eq!(paused, false);
-    
+
     // Pause
     client.try_pause(&admin).unwrap();
-    let paused: bool = env
-        .as_contract(&contract_id, || {
-            env.storage()
-                .instance()
-                .get(&StorageKey::Paused)
-                .unwrap()
-        });
+    let paused: bool = env.as_contract(&contract_id, || {
+        env.storage().instance().get(&StorageKey::Paused).unwrap()
+    });
     assert_eq!(paused, true);
-    
+
     // Unpause
     client.try_unpause(&admin).unwrap();
-    let paused: bool = env
-        .as_contract(&contract_id, || {
-            env.storage()
-                .instance()
-                .get(&StorageKey::Paused)
-                .unwrap()
-        });
+    let paused: bool = env.as_contract(&contract_id, || {
+        env.storage().instance().get(&StorageKey::Paused).unwrap()
+    });
     assert_eq!(paused, false);
-    
+
     // Pause again
     client.try_pause(&admin).unwrap();
-    let paused: bool = env
-        .as_contract(&contract_id, || {
-            env.storage()
-                .instance()
-                .get(&StorageKey::Paused)
-                .unwrap()
-        });
+    let paused: bool = env.as_contract(&contract_id, || {
+        env.storage().instance().get(&StorageKey::Paused).unwrap()
+    });
     assert_eq!(paused, true);
 }


### PR DESCRIPTION
## Summary
Implements O(1) reward distribution using an index-based model that scales to unlimited stakers without iteration.

## Linked issue
### Closes: #76 

## Changes
- Added `staking_rewards` contract with index-based accounting
- `reward_index`: global cumulative rewards per staked token
- `user_index`: per-user snapshot for calculating pending rewards
- Functions: `stake()`, `distribute_rewards()`, `claim()`, `get_claimable()`

### Implementation Details
**Algorithm**: When rewards are distributed, the global index increases by `(rewards * SCALE) / total_staked`. Each user's pending rewards = `stake * (global_index - user_index) / SCALE`.

**Complexity**: All operations are O(1) - no loops over stakers.

### Tests
✅ Two users stake at different times - rewards distributed proportionally  
✅ Claim does not affect other users' claimable amounts  
✅ Rewards distributed fairly based on stake weight (3:1 verified)

## How to test
cargo test

## Screenshots (if UI)

## Checklist

- [ ] I linked an issue (or explained why one is not needed)
- [ ] I tested locally
- [ ] I did not commit secrets
- [ ] I updated docs if needed
