### PR TITLE
backend: add staking finalize endpoint

### DIFF
--- a/backend/src/routes/staking.ts
+++ b/backend/src/routes/staking.ts
@@ -6,6 +6,7 @@ import { AppError } from '../errors/AppError.js'
 import { ErrorCode } from '../errors/errorCodes.js'
 import { validate } from '../middleware/validate.js'
 import { stakeFromDepositSchema, type StakeFromDepositRequest } from '../schemas/stakeFromDeposit.js'
+import { stakeFinalizeSchema, type StakeFinalizeRequest } from '../schemas/stakeFinalize.js'
 import { conversionStore } from '../models/conversionStore.js'
 import { depositStore } from '../models/depositStore.js'
 import {
@@ -22,6 +23,75 @@ import {
 export function createStakingRouter(adapter: SorobanAdapter) {
   const router = Router()
   const sender = new OutboxSender(adapter)
+
+  /**
+   * POST /api/staking/finalize
+   *
+   * Finalizes staking using the canonical USDC amount produced by a conversion.
+   * - If conversion not completed -> 409
+   * - Idempotent by conversionId
+   */
+  router.post(
+    '/finalize',
+    validate(stakeFinalizeSchema),
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const { conversionId } = req.body as StakeFinalizeRequest
+
+        const conversion = await conversionStore.getByConversionId(conversionId)
+        if (!conversion) {
+          throw new AppError(ErrorCode.NOT_FOUND, 404, 'Conversion not found')
+        }
+        if (conversion.status !== 'completed') {
+          throw new AppError(ErrorCode.CONFLICT, 409, 'Conversion not completed')
+        }
+
+        // Create outbox item idempotent by conversionId
+        const outboxItem = await outboxStore.create({
+          txType: TxType.STAKE,
+          source: 'conversion',
+          ref: conversion.conversionId,
+          payload: {
+            txType: TxType.STAKE,
+            amountUsdc: conversion.amountUsdc,
+
+            // Include FX metadata so receipt is deterministic.
+            amountNgn: conversion.amountNgn,
+            fxRateNgnPerUsdc: conversion.fxRateNgnPerUsdc,
+            fxProvider: conversion.provider,
+
+            conversionId: conversion.conversionId,
+            depositId: conversion.depositId,
+            conversionProviderRef: conversion.providerRef,
+            userId: conversion.userId,
+          },
+        })
+
+        const sent = await sender.send(outboxItem)
+
+        const updatedItem = await outboxStore.getById(outboxItem.id)
+        if (!updatedItem) {
+          throw new AppError(
+            ErrorCode.INTERNAL_ERROR,
+            500,
+            'Failed to retrieve outbox item after send attempt',
+          )
+        }
+
+        res.status(sent ? 200 : 202).json({
+          success: true,
+          outboxId: updatedItem.id,
+          txId: updatedItem.txId,
+          status: updatedItem.status,
+          message: sent
+            ? 'Staking finalized and receipt written to chain'
+            : 'Staking finalized, receipt queued for retry',
+        })
+      } catch (error) {
+        next(error)
+      }
+    },
+  )
 
   /**
    * POST /api/staking/stake_from_deposit

--- a/backend/src/routes/stakingFinalize.test.ts
+++ b/backend/src/routes/stakingFinalize.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import request from 'supertest'
+import { createApp } from '../app.js'
+import { outboxStore } from '../outbox/index.js'
+import { conversionStore } from '../models/conversionStore.js'
+import { depositStore } from '../models/depositStore.js'
+import { OutboxStatus } from '../outbox/types.js'
+
+describe('POST /api/staking/finalize', () => {
+  let app: any
+
+  beforeEach(async () => {
+    app = createApp()
+    await outboxStore.clear()
+    await conversionStore.clear()
+    await depositStore.clear()
+    vi.clearAllMocks()
+  })
+
+  it('returns 409 if conversion is not completed', async () => {
+    const pending = await conversionStore.createPending({
+      depositId: 'onramp:dep_pending',
+      userId: 'user_1',
+      amountNgn: 1000,
+      provider: 'onramp',
+    })
+
+    const res = await request(app)
+      .post('/api/staking/finalize')
+      .send({ conversionId: pending.conversionId })
+      .expect(409)
+
+    expect(res.body.error.code).toBe('CONFLICT')
+  })
+
+  it('finalizes staking from a completed conversion (idempotent by conversionId)', async () => {
+    const confirmRes = await request(app)
+      .post('/api/deposits/confirm')
+      .send({
+        depositId: 'onramp:dep_010',
+        userId: 'user_1',
+        amountNgn: 160000,
+        provider: 'onramp',
+        providerRef: 'provider-ref-010',
+      })
+      .expect(200)
+
+    const conversionId = confirmRes.body.conversion.conversionId
+
+    const finalize1 = await request(app)
+      .post('/api/staking/finalize')
+      .send({ conversionId })
+      .expect((r) => {
+        expect([200, 202]).toContain(r.status)
+      })
+
+    const finalize2 = await request(app)
+      .post('/api/staking/finalize')
+      .send({ conversionId })
+      .expect((r) => {
+        expect([200, 202]).toContain(r.status)
+      })
+
+    expect(finalize1.body.outboxId).toBe(finalize2.body.outboxId)
+    expect(finalize1.body.txId).toBe(finalize2.body.txId)
+    expect([OutboxStatus.SENT, OutboxStatus.PENDING, OutboxStatus.FAILED]).toContain(finalize1.body.status)
+  })
+})

--- a/backend/src/schemas/stakeFinalize.ts
+++ b/backend/src/schemas/stakeFinalize.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod'
+
+export const stakeFinalizeSchema = z.object({
+  conversionId: z.string().min(1),
+})
+
+export type StakeFinalizeRequest = z.infer<typeof stakeFinalizeSchema>


### PR DESCRIPTION
## Summary
Staking: Finalize stake on-chain after conversion (outbox-driven, receipt recorded)
## Linked issue
Closes #134 
## Changes

## How to test
cargo test
## Screenshots (if UI)

## Checklist

- [x] I linked an issue (or explained why one is not needed)
- [x] I tested locally
- [x] I did not commit secrets
- [x] I updated docs if needed
