### PR TITLE
Remove XOR encryption and standardize AES-256-GCM envelope for wallet…

### DIFF
--- a/backend/src/services/walletService.test.ts
+++ b/backend/src/services/walletService.test.ts
@@ -126,6 +126,28 @@ describe('EnvironmentEncryptionService', () => {
     expect(cipherText).not.toEqual(originalData)
   })
 
+  it('should fail to decrypt when ciphertext is tampered with', async () => {
+    const originalData = Buffer.from('secret-key-data', 'utf8')
+    const keyId = encryptionService.getCurrentKeyId()
+
+    const { cipherText } = await encryptionService.encrypt(originalData, keyId)
+    const parsed = JSON.parse(cipherText.toString('utf8')) as {
+      version: number
+      iv: string
+      authTag: string
+      ciphertext: string
+    }
+
+    const ct = Buffer.from(parsed.ciphertext, 'base64')
+    ct[0] = ct[0] ^ 0x01
+    parsed.ciphertext = ct.toString('base64')
+    const tampered = Buffer.from(JSON.stringify(parsed), 'utf8')
+
+    await expect(encryptionService.decrypt(tampered, keyId)).rejects.toThrow(
+      'Decryption failed: authentication tag verification failed'
+    )
+  })
+
   it('should throw error with short encryption key', () => {
     expect(() => new EnvironmentEncryptionService('short')).toThrow('Encryption key must be at least 32 characters')
   })

--- a/backend/src/services/walletService.ts
+++ b/backend/src/services/walletService.ts
@@ -1,5 +1,5 @@
 import { Keypair } from '@stellar/stellar-sdk'
-import { createHmac, randomBytes, scrypt } from 'node:crypto'
+import { createCipheriv, createDecipheriv, randomBytes, scrypt } from 'node:crypto'
 import { WalletStore } from '../models/wallet.js'
 
 export interface EncryptionService {
@@ -98,8 +98,6 @@ export class WalletServiceImpl implements WalletService {
  * Uses scrypt with environment variable to derive encryption keys
  */
 export class EnvironmentEncryptionService implements EncryptionService {
-  private keyCache: Map<string, Buffer> = new Map()
-
   constructor(private encryptionKeyBase: string) {
     if (!encryptionKeyBase || encryptionKeyBase.length < 32) {
       throw new Error('Encryption key must be at least 32 characters')
@@ -122,39 +120,74 @@ export class EnvironmentEncryptionService implements EncryptionService {
   }
 
   async encrypt(data: Buffer, keyId: string): Promise<{ cipherText: Buffer; keyId: string }> {
-    const salt = randomBytes(16)
-    const iv = randomBytes(16)
-    const key = await this.deriveKey(salt)
-    
-    // Simple XOR encryption for MVP (replace with AES in production)
-    const encrypted = Buffer.alloc(data.length)
-    for (let i = 0; i < data.length; i++) {
-      encrypted[i] = data[i] ^ key[i % key.length] ^ iv[i % iv.length]
+    const envelopeVersion = 1
+    const iv = randomBytes(12)
+    const key = await this.deriveKey(Buffer.from(keyId, 'utf8'))
+
+    const cipher = createCipheriv('aes-256-gcm', key, iv)
+    const encrypted = Buffer.concat([cipher.update(data), cipher.final()])
+    const authTag = cipher.getAuthTag()
+
+    const envelope = {
+      version: envelopeVersion,
+      iv: iv.toString('base64'),
+      authTag: authTag.toString('base64'),
+      ciphertext: encrypted.toString('base64'),
     }
 
-    // Combine salt + iv + encrypted data
-    const cipherText = Buffer.concat([salt, iv, encrypted])
-    
+    const cipherText = Buffer.from(JSON.stringify(envelope), 'utf8')
     return { cipherText, keyId }
   }
 
   async decrypt(cipherText: Buffer, keyId: string): Promise<Buffer> {
-    if (cipherText.length < 32) {
-      throw new Error('Invalid ciphertext: too short')
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(cipherText.toString('utf8'))
+    } catch {
+      throw new Error('Invalid ciphertext: not valid envelope JSON')
     }
 
-    const salt = cipherText.subarray(0, 16)
-    const iv = cipherText.subarray(16, 32)
-    const encrypted = cipherText.subarray(32)
-    
-    const key = await this.deriveKey(salt)
-    
-    // Reverse the XOR encryption
-    const decrypted = Buffer.alloc(encrypted.length)
-    for (let i = 0; i < encrypted.length; i++) {
-      decrypted[i] = encrypted[i] ^ key[i % key.length] ^ iv[i % iv.length]
+    if (
+      !parsed ||
+      typeof parsed !== 'object' ||
+      !('version' in parsed) ||
+      !('iv' in parsed) ||
+      !('authTag' in parsed) ||
+      !('ciphertext' in parsed)
+    ) {
+      throw new Error('Invalid ciphertext: missing envelope fields')
     }
 
-    return decrypted
+    const envelope = parsed as {
+      version: number
+      iv: string
+      authTag: string
+      ciphertext: string
+    }
+
+    if (envelope.version !== 1) {
+      throw new Error(`Invalid ciphertext: unsupported envelope version ${String(envelope.version)}`)
+    }
+
+    const iv = Buffer.from(envelope.iv, 'base64')
+    const tag = Buffer.from(envelope.authTag, 'base64')
+    const encrypted = Buffer.from(envelope.ciphertext, 'base64')
+
+    if (iv.length !== 12) {
+      throw new Error('Invalid ciphertext: invalid IV length')
+    }
+    if (tag.length !== 16) {
+      throw new Error('Invalid ciphertext: invalid authTag length')
+    }
+
+    const key = await this.deriveKey(Buffer.from(keyId, 'utf8'))
+    const decipher = createDecipheriv('aes-256-gcm', key, iv)
+    decipher.setAuthTag(tag)
+
+    try {
+      return Buffer.concat([decipher.update(encrypted), decipher.final()])
+    } catch {
+      throw new Error('Decryption failed: authentication tag verification failed')
+    }
   }
 }

--- a/docs/security/CUSTODIAL_WALLET_SECURITY.md
+++ b/docs/security/CUSTODIAL_WALLET_SECURITY.md
@@ -163,6 +163,33 @@ DEK → Encrypted with KMS KEK
 * DEKs never stored plaintext
 * All key structs implement `Zeroize`
 
+### Envelope Format (Persisted Encrypted Secret Key)
+
+The backend persists custodial wallet secret keys as a **base64-encoded UTF-8 JSON envelope**.
+
+Storage representation:
+
+```
+encryptedSecretKey = base64(utf8(JSON.stringify(envelope)))
+```
+
+Envelope JSON (versioned):
+
+```json
+{
+  "version": 1,
+  "iv": "<base64-encoded 12-byte nonce>",
+  "authTag": "<base64-encoded 16-byte GCM auth tag>",
+  "ciphertext": "<base64-encoded ciphertext bytes>"
+}
+```
+
+Notes:
+
+* `version` allows future envelope upgrades without ambiguity.
+* Any modification to `iv`, `authTag`, or `ciphertext` must cause decryption to fail.
+* The `keyId` stored alongside the envelope identifies which master key material/version was used, to support rotation.
+
 ### Required Env Vars
 
 | Variable                     | Purpose          |


### PR DESCRIPTION
… keys

## Summary
Remove XOR encryption and standardize AES-256-GCM envelope for wallet keys
## Linked issue
Closes #139 
## Changes

## How to test
cargo test
## Screenshots (if UI)

## Checklist

- [x] I linked an issue (or explained why one is not needed)
- [x] I tested locally
- [x] I did not commit secrets
- [x] I updated docs if needed
