### PR TITLE
Postgres-backed receipt repository + indexer checkpointing

### DIFF
--- a/backend/migrations/003_receipt_indexer.sql
+++ b/backend/migrations/003_receipt_indexer.sql
@@ -1,0 +1,35 @@
+-- Migration: 003_receipt_indexer.sql
+-- Description: Tables for receipt indexing and checkpointing
+
+CREATE TABLE IF NOT EXISTS indexed_receipts (
+    tx_id TEXT PRIMARY KEY,
+    tx_type TEXT NOT NULL,
+    deal_id TEXT NOT NULL,
+    listing_id TEXT,
+    amount_usdc TEXT NOT NULL,
+    amount_ngn NUMERIC,
+    fx_rate NUMERIC,
+    fx_provider TEXT,
+    sender TEXT,
+    receiver TEXT,
+    external_ref_hash TEXT NOT NULL,
+    metadata_hash TEXT,
+    ledger BIGINT NOT NULL,
+    indexed_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_receipts_deal_id ON indexed_receipts(deal_id);
+CREATE INDEX idx_receipts_tx_type ON indexed_receipts(tx_type);
+CREATE INDEX idx_receipts_ledger ON indexed_receipts(ledger);
+CREATE INDEX idx_receipts_indexed_at ON indexed_receipts(indexed_at);
+
+CREATE TABLE IF NOT EXISTS indexer_checkpoint (
+    name TEXT PRIMARY KEY,
+    last_ledger BIGINT NOT NULL,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Seed with default name
+INSERT INTO indexer_checkpoint (name, last_ledger)
+VALUES ('receipt_indexer', 0)
+ON CONFLICT DO NOTHING;

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -34,7 +34,7 @@ import { InMemoryWalletStore } from "./models/walletStore.js"
 import { InMemoryLinkedAddressStore } from "./models/linkedAddressStore.js"
 import { StubRewardsDataLayer } from "./services/stub-rewards-data-layer.js"
 import authRouter from "./routes/auth.js"
-import { StubReceiptRepository } from "./indexer/receipt-repository.js"
+import { StubReceiptRepository, PostgresReceiptRepository } from "./indexer/receipt-repository.js"
 import { ReceiptIndexer } from "./indexer/worker.js"
 import { createReceiptsRouter } from "./routes/receiptsRoute.js"
 import { getPool } from "./db.js"
@@ -83,7 +83,9 @@ export function createApp() {
   stakingFinalizer.start()
 
   // Indexer
-  const receiptRepo = new StubReceiptRepository()
+  const receiptRepo = process.env.DATABASE_URL 
+    ? new PostgresReceiptRepository() 
+    : new StubReceiptRepository()
   const indexer = new ReceiptIndexer(sorobanAdapter, receiptRepo, {
     pollIntervalMs: parseInt(process.env.INDEXER_POLL_MS ?? '5000'),
     startLedger: process.env.INDEXER_START_LEDGER ? parseInt(process.env.INDEXER_START_LEDGER) : undefined,

--- a/backend/src/indexer/receipt-repository.test.ts
+++ b/backend/src/indexer/receipt-repository.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { PostgresReceiptRepository, IndexedReceipt } from './receipt-repository.js'
+import { getPool } from '../db.js'
+import { TxType } from '../outbox/types.js'
+
+vi.mock('../db.js', () => ({
+  getPool: vi.fn()
+}))
+
+describe('PostgresReceiptRepository', () => {
+  let repo: PostgresReceiptRepository
+  let mockPool: any
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockPool = {
+      query: vi.fn()
+    }
+    ;(getPool as any).mockResolvedValue(mockPool)
+    repo = new PostgresReceiptRepository()
+  })
+
+  const sampleReceipt: IndexedReceipt = {
+    txId: 'tx123',
+    txType: TxType.STAKE,
+    dealId: 'deal123',
+    amountUsdc: '100.00',
+    externalRefHash: 'hash123',
+    ledger: 1000,
+    indexedAt: new Date('2024-01-01T00:00:00Z')
+  }
+
+  it('should upsert receipts correctly', async () => {
+    await repo.upsertMany([sampleReceipt])
+
+    expect(mockPool.query).toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO indexed_receipts'),
+      expect.arrayContaining([sampleReceipt.txId, sampleReceipt.txType, sampleReceipt.dealId])
+    )
+  })
+
+  it('should get checkpoint correctly', async () => {
+    mockPool.query.mockResolvedValue({
+      rows: [{ last_ledger: '1234' }]
+    })
+
+    const checkpoint = await repo.getCheckpoint()
+    expect(checkpoint).toBe(1234)
+    expect(mockPool.query).toHaveBeenCalledWith(
+      expect.stringContaining("SELECT last_ledger FROM indexer_checkpoint WHERE name = 'receipt_indexer'")
+    )
+  })
+
+  it('should return null when no checkpoint exists', async () => {
+    mockPool.query.mockResolvedValue({ rows: [] })
+    const checkpoint = await repo.getCheckpoint()
+    expect(checkpoint).toBeNull()
+  })
+
+  it('should save checkpoint correctly', async () => {
+    await repo.saveCheckpoint(5000)
+    expect(mockPool.query).toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO indexer_checkpoint'),
+      [5000]
+    )
+  })
+
+  it('should query receipts with filters and pagination', async () => {
+    mockPool.query
+      .mockResolvedValueOnce({ rows: [{ count: '100' }] }) // count query
+      .mockResolvedValueOnce({ rows: [] }) // data query
+
+    const result = await repo.query({ dealId: 'deal1', page: 2, pageSize: 10 })
+
+    expect(result.total).toBe(100)
+    expect(result.page).toBe(2)
+    expect(mockPool.query).toHaveBeenCalledWith(
+      expect.stringContaining('SELECT COUNT(*) FROM indexed_receipts'),
+      ['deal1']
+    )
+    expect(mockPool.query).toHaveBeenCalledWith(
+      expect.stringContaining('SELECT * FROM indexed_receipts'),
+      ['deal1', 10, 10]
+    )
+  })
+})

--- a/backend/src/indexer/receipt-repository.ts
+++ b/backend/src/indexer/receipt-repository.ts
@@ -1,4 +1,5 @@
 import { TxType } from '../outbox/types.js'
+import { getPool } from '../db.js'
 
 export interface IndexedReceipt {
      txId: string; txType: TxType; dealId: string; listingId?: string
@@ -31,4 +32,121 @@ export class StubReceiptRepository implements ReceiptRepository {
      }
      async getCheckpoint() { return this.checkpoint }
      async saveCheckpoint(ledger: number) { this.checkpoint = ledger }
+}
+
+export class PostgresReceiptRepository implements ReceiptRepository {
+     private async pool() {
+          const pool = await getPool()
+          if (!pool) throw new Error('Postgres pool not available')
+          return pool
+     }
+
+     async upsertMany(receipts: IndexedReceipt[]): Promise<void> {
+          if (!receipts.length) return
+          const pool = await this.pool()
+          
+          for (const r of receipts) {
+               await pool.query(
+                    `INSERT INTO indexed_receipts (
+                         tx_id, tx_type, deal_id, listing_id, amount_usdc, amount_ngn, 
+                         fx_rate, fx_provider, sender, receiver, external_ref_hash, 
+                         metadata_hash, ledger, indexed_at
+                    ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+                    ON CONFLICT (tx_id) DO UPDATE SET
+                         tx_type = EXCLUDED.tx_type,
+                         deal_id = EXCLUDED.deal_id,
+                         listing_id = EXCLUDED.listing_id,
+                         amount_usdc = EXCLUDED.amount_usdc,
+                         amount_ngn = EXCLUDED.amount_ngn,
+                         fx_rate = EXCLUDED.fx_rate,
+                         fx_provider = EXCLUDED.fx_provider,
+                         sender = EXCLUDED.sender,
+                         receiver = EXCLUDED.receiver,
+                         external_ref_hash = EXCLUDED.external_ref_hash,
+                         metadata_hash = EXCLUDED.metadata_hash,
+                         ledger = EXCLUDED.ledger,
+                         indexed_at = EXCLUDED.indexed_at`,
+                    [
+                         r.txId, r.txType, r.dealId, r.listingId ?? null, r.amountUsdc, r.amountNgn ?? null,
+                         r.fxRate ?? null, r.fxProvider ?? null, r.from ?? null, r.to ?? null,
+                         r.externalRefHash, r.metadataHash ?? null, r.ledger, r.indexedAt
+                    ]
+               )
+          }
+     }
+
+     async findByDealId(dealId: string): Promise<IndexedReceipt[]> {
+          const pool = await this.pool()
+          const { rows } = await pool.query(
+               `SELECT * FROM indexed_receipts WHERE deal_id = $1 ORDER BY indexed_at DESC`,
+               [dealId]
+          )
+          return rows.map(this.mapRow)
+     }
+
+     async query({ dealId, txType, page = 1, pageSize = 20 }: ReceiptQuery): Promise<PagedReceipts> {
+          const pool = await this.pool()
+          const offset = (page - 1) * pageSize
+          
+          let filter = 'WHERE 1=1'
+          const params: any[] = []
+          
+          if (dealId) {
+               params.push(dealId)
+               filter += ` AND deal_id = $${params.length}`
+          }
+          if (txType) {
+               params.push(txType)
+               filter += ` AND tx_type = $${params.length}`
+          }
+
+          const countRes = await pool.query(`SELECT COUNT(*) FROM indexed_receipts ${filter}`, params)
+          const total = parseInt(countRes.rows[0].count, 10)
+
+          const dataParams = [...params, pageSize, offset]
+          const { rows } = await pool.query(
+               `SELECT * FROM indexed_receipts ${filter} ORDER BY indexed_at DESC LIMIT $${dataParams.length - 1} OFFSET $${dataParams.length}`,
+               dataParams
+          )
+
+          return { data: rows.map(this.mapRow), total, page, pageSize }
+     }
+
+     async getCheckpoint(): Promise<number | null> {
+          const pool = await this.pool()
+          const { rows } = await pool.query(
+               `SELECT last_ledger FROM indexer_checkpoint WHERE name = 'receipt_indexer'`
+          )
+          if (!rows.length) return null
+          return parseInt(rows[0].last_ledger, 10)
+     }
+
+     async saveCheckpoint(ledger: number): Promise<void> {
+          const pool = await this.pool()
+          await pool.query(
+               `INSERT INTO indexer_checkpoint (name, last_ledger, updated_at)
+                VALUES ('receipt_indexer', $1, NOW())
+                ON CONFLICT (name) DO UPDATE SET last_ledger = EXCLUDED.last_ledger, updated_at = NOW()`,
+               [ledger]
+          )
+     }
+
+     private mapRow(row: any): IndexedReceipt {
+          return {
+               txId: row.tx_id,
+               txType: row.tx_type as TxType,
+               dealId: row.deal_id,
+               listingId: row.listing_id,
+               amountUsdc: row.amount_usdc,
+               amountNgn: row.amount_ngn ? parseFloat(row.amount_ngn) : undefined,
+               fxRate: row.fx_rate ? parseFloat(row.fx_rate) : undefined,
+               fxProvider: row.fx_provider,
+               from: row.sender,
+               to: row.receiver,
+               externalRefHash: row.external_ref_hash,
+               metadataHash: row.metadata_hash,
+               ledger: parseInt(row.ledger, 10),
+               indexedAt: new Date(row.indexed_at)
+          }
+     }
 }


### PR DESCRIPTION
## Summary

I have implemented a permanent storage layer for indexed receipts and indexer checkpoints using Postgres.

## Changes

Database Schema
Migration 003
: Created indexed_receipts and indexer_checkpoint tables with appropriate indexes for performance.
Repository Implementation
PostgresReceiptRepository
:
upsertMany
: Uses ON CONFLICT (tx_id) DO UPDATE to ensure idempotency.
query
: Supports pagination and filtering by dealId and txType.
getCheckpoint
/
saveCheckpoint
: Ensures the indexer can resume from the last processed ledger across restarts.
Application Wiring
App Hook
: The indexer now automatically uses 
PostgresReceiptRepository
 if DATABASE_URL is configured, falling back to the in-memory stub otherwise.


## Checklist

- [ ] I linked an issue (or explained why one is not needed)
- [ ] I tested locally
- [ ] I did not commit secrets
- [ ] I updated docs if needed

Closes #193
