### PR TITLE
feat(259): introduce normalizeStellarAddress() and stop lowercasing Stellar keys

### DIFF
--- a/backend/src/routes/auth.test.ts
+++ b/backend/src/routes/auth.test.ts
@@ -97,7 +97,7 @@ describe('Auth Routes (Wallet)', () => {
   })
 
   it('POST /api/auth/wallet/challenge should create challenge XDR', async () => {
-    const address = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+    const address = 'GCSHKPO7MLEXGSZZF2KF54LMNDXNLORLRKD24DXXWHVJ5U6CVXVQAOVT'
 
     const res = await request.post('/api/auth/wallet/challenge').send({ address })
     expect(res.status).toBe(200)
@@ -105,9 +105,9 @@ describe('Auth Routes (Wallet)', () => {
     expect(res.body).toHaveProperty('challengeXdr')
     expect(res.body).toHaveProperty('expiresAt')
 
-    const challenge = walletChallengeStore.getByAddress(address.toLowerCase())
+    const challenge = walletChallengeStore.getByAddress(address)
     expect(challenge).toBeDefined()
-    expect(challenge!.address).toBe(address.toLowerCase())
+    expect(challenge!.address).toBe(address)
     expect(typeof challenge!.challengeXdr).toBe('string')
     expect(challenge!.attempts).toBe(0)
   })
@@ -117,11 +117,11 @@ describe('Auth Routes (Wallet)', () => {
   })
 
   it('POST /api/auth/wallet/verify should fail with expired challenge', async () => {
-    const address = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+    const address = 'GCSHKPO7MLEXGSZZF2KF54LMNDXNLORLRKD24DXXWHVJ5U6CVXVQAOVT'
 
-    // Create an expired challenge
+    // Seed with uppercase canonical address (normalizeStellarAddress output)
     const expiredChallenge = {
-      address: address.toLowerCase(),
+      address: address,
       challengeXdr: 'mock-xdr',
       nonce: 'mock-nonce',
       expiresAt: new Date(Date.now() - 1000), // Already expired
@@ -139,11 +139,11 @@ describe('Auth Routes (Wallet)', () => {
   })
 
   it('verify should increment attempts and eventually fail after too many attempts', async () => {
-    const address = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+    const address = 'GCSHKPO7MLEXGSZZF2KF54LMNDXNLORLRKD24DXXWHVJ5U6CVXVQAOVT'
 
-    // Create a challenge
+    // Seed with uppercase canonical address (normalizeStellarAddress output)
     const challenge = {
-      address: address.toLowerCase(),
+      address: address,
       challengeXdr: 'mock-xdr',
       nonce: 'mock-nonce',
       expiresAt: new Date(Date.now() + 60000),

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -6,7 +6,7 @@ import { otpRequestRateLimit, walletAuthRateLimit } from '../middleware/authRate
 import { requestOtpSchema, verifyOtpSchema, walletChallengeSchema, walletVerifySchema } from '../schemas/auth.js'
 import { generateOtp, generateToken } from '../utils/tokens.js'
 import { generateOtpSalt, hashOtp, verifyOtpHash } from '../utils/otp.js'
-import { generateNonce, generateChallengeXdr, verifySignedChallenge } from '../utils/wallet.js'
+import { generateNonce, generateChallengeXdr, verifySignedChallenge, normalizeStellarAddress } from '../utils/wallet.js'
 import { otpChallengeStore, sessionStore, userStore, walletChallengeStore } from '../models/authStore.js'
 import { authenticateToken, type AuthenticatedRequest } from '../middleware/auth.js'
 import { PostgresLinkedAddressStore } from '../models/linkedAddressStore.js'
@@ -133,7 +133,7 @@ router.post(
   walletAuthRateLimit(),
   async (req: Request, res: Response, next: NextFunction) => {
     const address = req.body.address as string
-    const normalizedAddress = address.toLowerCase()
+    const normalizedAddress = normalizeStellarAddress(address)
 
     // Check if wallet is already linked to another user
     const existingUser = await userStore.getByWalletAddress(normalizedAddress)
@@ -169,8 +169,8 @@ router.post(
     try {
       const address = req.body.address as string
       const signedChallengeXdr = req.body.signedChallengeXdr as string
-      // Stellar public keys are inherently uppercase — do not lowercase for SDK calls
-      const normalizedAddress = address.toLowerCase()
+      // Stellar public keys are base32/uppercase — use normalizeStellarAddress, never toLowerCase
+      const normalizedAddress = normalizeStellarAddress(address)
 
       const challenge = await walletChallengeStore.getByAddress(normalizedAddress)
       if (!challenge) {

--- a/backend/src/utils/wallet.ts
+++ b/backend/src/utils/wallet.ts
@@ -105,3 +105,20 @@ export function isValidStellarPublicKey(publicKey: string): boolean {
     return false
   }
 }
+
+/**
+ * Returns the canonical form of a Stellar public key:
+ * - Trims surrounding whitespace
+ * - Converts to uppercase (base32 is case-insensitive but the SDK expects uppercase)
+ * - Validates that the result is a proper Stellar public key (starts with "G")
+ *
+ * Throws an Error with a descriptive message if the address is invalid.
+ * All wallet auth paths must call this instead of .toLowerCase().
+ */
+export function normalizeStellarAddress(address: string): string {
+  const trimmed = address.trim().toUpperCase()
+  if (!isValidStellarPublicKey(trimmed)) {
+    throw new Error(`Invalid Stellar public key: "${address}". Must be a valid G... StrKey.`)
+  }
+  return trimmed
+}


### PR DESCRIPTION
Closes #259.

## Problem

`backend/src/routes/auth.ts` normalized Stellar public keys using `.toLowerCase()` before storing and indexing them. Stellar public keys are base32 uppercase — lowercasing them:
- Breaks external tooling and SDK calls that require uppercase keys
- Causes mismatches between stored and provided addresses
- Creates confusing user-facing values (lowercase `g...` instead of proper `G...`)

## Changes

### `backend/src/utils/wallet.ts` — new `normalizeStellarAddress()`
- Trims surrounding whitespace
- Converts to uppercase (canonical base32 form)
- Validates via Stellar SDK — throws a descriptive error if the address is not a valid `G...` StrKey

### `backend/src/routes/auth.ts`
- Import `normalizeStellarAddress` from wallet utils
- Replace `address.toLowerCase()` with `normalizeStellarAddress(address)` in `/wallet/challenge` and `/wallet/verify`
- All stored addresses (walletChallengeStore, userStore, linkedAddressStore) now use the validated uppercase canonical form
- SDK calls (`generateChallengeXdr`, `verifySignedChallenge`) always receive properly cased keys

### `backend/src/routes/auth.test.ts`
- Replace the invalid test address (bad checksum) with a valid Stellar keypair
- Update `walletChallengeStore` seeding/assertions to use uppercase canonical keys
