### PR TITLE
feat: Add OTP delivery abstraction with console and email providers

### DIFF
--- a/backend/src/routes/auth.test.ts
+++ b/backend/src/routes/auth.test.ts
@@ -32,7 +32,7 @@ describe('Auth Routes (OTP)', () => {
     const res = await request.post('/api/auth/request-otp').send({ email })
     expect(res.status).toBe(200)
 
-    const challenge = otpChallengeStore.getByEmail(email)
+    const challenge = await otpChallengeStore.getByEmail(email)
     expect(challenge).toBeDefined()
     expect(challenge!.email).toBe(email)
     expect(typeof challenge!.otpHash).toBe('string')
@@ -55,7 +55,7 @@ describe('Auth Routes (OTP)', () => {
     expect(res.body).toHaveProperty('user')
     expect(res.body.user).toHaveProperty('email', email)
 
-    const session = sessionStore.getByToken('session-token-abc')
+    const session = await sessionStore.getByToken('session-token-abc')
     expect(session).toBeDefined()
     expect(session!.email).toBe(email)
   })

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -10,13 +10,18 @@ import { generateNonce, generateChallengeXdr, verifySignedChallenge, normalizeSt
 import { otpChallengeStore, sessionStore, userStore, walletChallengeStore } from '../models/authStore.js'
 import { authenticateToken, type AuthenticatedRequest } from '../middleware/auth.js'
 import { PostgresLinkedAddressStore } from '../models/linkedAddressStore.js'
+import { createOtpDeliveryProvider } from '../services/otpDeliveryFactory.js'
 
 const router = Router()
 
 const OTP_TTL_MS = 10 * 60 * 1000
+const OTP_TTL_MINUTES = OTP_TTL_MS / (60 * 1000)
 const OTP_MAX_ATTEMPTS = 5
 const WALLET_TTL_MS = 5 * 60 * 1000
 const WALLET_MAX_ATTEMPTS = 3
+
+// Initialize OTP delivery provider
+const otpDeliveryProvider = createOtpDeliveryProvider()
 
 /**
  * POST /api/auth/request-otp
@@ -37,9 +42,10 @@ router.post(
 
       await otpChallengeStore.set({ email, otpHash, salt, expiresAt, attempts: 0 })
 
-      // MVP: No email provider integrated. For development, log OTP.
-      // Never persist plaintext OTP.
-      console.log(`[auth] OTP for ${email}: ${otp}`)
+      // Send OTP via configured delivery provider
+      // The provider handles logging appropriately (console in dev, email in production)
+      // Plaintext OTP is never stored or logged in production mode
+      await otpDeliveryProvider.sendOtp(email, otp, OTP_TTL_MINUTES)
 
       res.json({ message: 'OTP sent to your email' })
     } catch (error) {

--- a/backend/src/schemas/env.ts
+++ b/backend/src/schemas/env.ts
@@ -34,6 +34,8 @@ export const envSchema = z.object({
   QUOTE_EXPIRY_MS: z.coerce.number().positive().default(5 * 60_000),
   QUOTE_FEE_PERCENT: z.coerce.number().min(0).max(1).default(0.015),
   QUOTE_SLIPPAGE_PERCENT: z.coerce.number().min(0).max(1).default(0.005),
+  // OTP delivery provider: 'console' for dev, 'email' for production
+  OTP_DELIVERY_PROVIDER: z.enum(['console', 'email']).default('console'),
 }).refine((data) => {
   // Accept either field name; prefer SOROBAN_USDC_TOKEN_ID if provided
   const tokenId = data.SOROBAN_USDC_TOKEN_ID || data.USDC_TOKEN_ADDRESS

--- a/backend/src/services/consoleOtpProvider.ts
+++ b/backend/src/services/consoleOtpProvider.ts
@@ -1,0 +1,43 @@
+import { OtpDeliveryProvider, generateOtpEmailTemplate } from './otpDeliveryProvider.js'
+import { logger } from '../utils/logger.js'
+import { env } from '../schemas/env.js'
+
+/**
+ * Console OTP Provider
+ * 
+ * For development only. Logs OTP to console.
+ * Never use in production.
+ */
+export class ConsoleOtpProvider implements OtpDeliveryProvider {
+  async sendOtp(email: string, otp: string, ttlMinutes: number): Promise<void> {
+    const template = generateOtpEmailTemplate(otp, ttlMinutes)
+    
+    // Only log OTP in development/test environments
+    // In production, this provider should not be used
+    if (env.NODE_ENV === 'production') {
+      logger.warn('[OTP Delivery] Console Provider used in production - this should not happen', {
+        email,
+        // OTP is intentionally NOT logged in production
+      })
+      throw new Error('ConsoleOtpProvider should not be used in production. Set OTP_DELIVERY_PROVIDER=email')
+    }
+    
+    // Log to console for development
+    logger.info('[OTP Delivery] Console Provider', {
+      email,
+      subject: template.subject,
+      // Only log OTP in development - this is intentional for dev convenience
+      otp,
+      ttlMinutes,
+    })
+    
+    // Also log formatted email for easy copy-paste in dev
+    console.log('\n' + '='.repeat(60))
+    console.log('📧 OTP Email (Dev Mode)')
+    console.log('='.repeat(60))
+    console.log(`To: ${email}`)
+    console.log(`Subject: ${template.subject}`)
+    console.log(`\n${template.body}`)
+    console.log('='.repeat(60) + '\n')
+  }
+}

--- a/backend/src/services/emailOtpProvider.ts
+++ b/backend/src/services/emailOtpProvider.ts
@@ -1,0 +1,48 @@
+import { OtpDeliveryProvider, generateOtpEmailTemplate } from './otpDeliveryProvider.js'
+import { logger } from '../utils/logger.js'
+
+/**
+ * Email OTP Provider
+ * 
+ * Production-ready email provider for sending OTP codes.
+ * Currently a stub implementation that can be extended with actual email service integration
+ * (e.g., SendGrid, AWS SES, Resend, etc.)
+ * 
+ * IMPORTANT: Never log the plaintext OTP in production.
+ */
+export class EmailOtpProvider implements OtpDeliveryProvider {
+  constructor(
+    private config?: {
+      // Future: Add email service configuration here
+      // apiKey?: string
+      // fromEmail?: string
+      // service?: 'sendgrid' | 'ses' | 'resend'
+    }
+  ) {}
+
+  async sendOtp(email: string, otp: string, ttlMinutes: number): Promise<void> {
+    const template = generateOtpEmailTemplate(otp, ttlMinutes)
+    
+    // TODO: Integrate with actual email service
+    // For now, this is a stub that logs (without OTP) for visibility
+    logger.info('[OTP Delivery] Email Provider', {
+      email,
+      subject: template.subject,
+      ttlMinutes,
+      // NOTE: OTP is intentionally NOT logged here for security
+    })
+    
+    // Stub implementation - replace with actual email service call
+    // Example integration points:
+    // - SendGrid: https://github.com/sendgrid/sendgrid-nodejs
+    // - AWS SES: https://github.com/aws/aws-sdk-js-v3
+    // - Resend: https://github.com/resendlabs/resend-node
+    // - Nodemailer: https://github.com/nodemailer/nodemailer
+    
+    throw new Error(
+      'EmailOtpProvider is not yet implemented. ' +
+      'Please integrate with an email service (SendGrid, AWS SES, Resend, etc.) ' +
+      'or use ConsoleOtpProvider for development.'
+    )
+  }
+}

--- a/backend/src/services/otpDeliveryFactory.ts
+++ b/backend/src/services/otpDeliveryFactory.ts
@@ -1,0 +1,22 @@
+import { env } from '../schemas/env.js'
+import { OtpDeliveryProvider } from './otpDeliveryProvider.js'
+import { ConsoleOtpProvider } from './consoleOtpProvider.js'
+import { EmailOtpProvider } from './emailOtpProvider.js'
+
+/**
+ * Factory function to create the appropriate OTP delivery provider
+ * based on environment configuration.
+ */
+export function createOtpDeliveryProvider(): OtpDeliveryProvider {
+  const provider = env.OTP_DELIVERY_PROVIDER
+
+  switch (provider) {
+    case 'console':
+      return new ConsoleOtpProvider()
+    case 'email':
+      return new EmailOtpProvider()
+    default:
+      // Fallback to console for safety in development
+      return new ConsoleOtpProvider()
+  }
+}

--- a/backend/src/services/otpDeliveryProvider.ts
+++ b/backend/src/services/otpDeliveryProvider.ts
@@ -1,0 +1,46 @@
+/**
+ * OTP Delivery Provider Interface
+ * 
+ * Abstraction for delivering OTP codes to users via different channels.
+ * Ensures plaintext OTP is never stored or logged in production.
+ */
+export interface OtpDeliveryProvider {
+  /**
+   * Send an OTP code to the user
+   * @param email - User's email address
+   * @param otp - The OTP code (plaintext, must not be stored or logged in production)
+   * @param ttlMinutes - Time to live in minutes
+   * @returns Promise that resolves when OTP is sent
+   */
+  sendOtp(email: string, otp: string, ttlMinutes: number): Promise<void>
+}
+
+/**
+ * OTP email template data
+ */
+export interface OtpEmailTemplate {
+  subject: string
+  body: string
+}
+
+/**
+ * Generate OTP email template with security hints
+ */
+export function generateOtpEmailTemplate(
+  otp: string,
+  ttlMinutes: number,
+): OtpEmailTemplate {
+  const subject = 'Your Verification Code'
+  
+  const body = `
+Your verification code is: ${otp}
+
+This code will expire in ${ttlMinutes} minutes.
+
+Security tip: Never share this code with anyone. We will never ask for it via phone or email.
+
+If you didn't request this code, please ignore this message.
+`.trim()
+
+  return { subject, body }
+}

--- a/backend/src/utils/logger.ts
+++ b/backend/src/utils/logger.ts
@@ -34,10 +34,10 @@ function write(level: LogLevel, message: string, fields?: LogFields): void {
           ...fields,
      };
 
-     // Never leak secrets
-     const REDACTED_KEYS = new Set([
+    // Never leak secrets
+    const REDACTED_KEYS = new Set([
           'password', 'secret', 'token', 'authorization', 'apiKey', 'api_key',
-          'privateKey', 'private_key', 'accessToken', 'access_token',
+          'privateKey', 'private_key', 'accessToken', 'access_token', 'otp',
      ]);
      for (const key of REDACTED_KEYS) {
           if (key in entry) entry[key] = '[REDACTED]';


### PR DESCRIPTION
- Create OtpDeliveryProvider interface for OTP delivery abstraction
- Implement ConsoleOtpProvider for development (logs to console)
- Implement EmailOtpProvider stub for production (ready for email service integration)
- Add OTP_DELIVERY_PROVIDER env variable (console|email, defaults to console)
- Add email templating with subject, body, TTL, and security hints
- Update auth route to use OTP delivery provider instead of console.log
- Ensure OTP never logged in production (logger redacts 'otp' key, console provider blocks production)
- Fix missing await calls in auth tests

closes #267 