### PR TITLE
Implemented: GET /health/details

### DIFF
--- a/backend/src/routes/health.ts
+++ b/backend/src/routes/health.ts
@@ -1,4 +1,5 @@
 import { Router, Request, Response } from "express"
+import { env } from "../schemas/env.js"
 
 const router = Router()
 
@@ -6,6 +7,20 @@ router.get("/", (req: Request, res: Response) => {
   res.json({
     status: "ok",
     uptimeSeconds: Math.floor(process.uptime()),
+    requestId: req.requestId,
+  })
+})
+
+router.get("/details", (req: Request, res: Response) => {
+  const sorobanAdapterMode = (process.env.SOROBAN_ADAPTER_MODE ?? 'stub') === 'real'
+    ? 'real'
+    : 'stub'
+
+  res.json({
+    version: env.VERSION,
+    nodeEnv: env.NODE_ENV,
+    sorobanAdapterMode,
+    databaseEnabled: !!process.env.DATABASE_URL,
     requestId: req.requestId,
   })
 })

--- a/backend/src/routes/integration.test.ts
+++ b/backend/src/routes/integration.test.ts
@@ -34,6 +34,30 @@ describe('Integration Tests', () => {
     })
   })
 
+  describe('GET /health/details', () => {
+    it('should return 200 with correct response shape', async () => {
+      const response = await request.get('/health/details')
+
+      expect(response.status).toBe(200)
+      expect(response.body).toHaveProperty('version')
+      expect(typeof response.body.version).toBe('string')
+      expect(response.body).toHaveProperty('nodeEnv')
+      expect(typeof response.body.nodeEnv).toBe('string')
+      expect(response.body).toHaveProperty('sorobanAdapterMode')
+      expect(['stub', 'real']).toContain(response.body.sorobanAdapterMode)
+      expect(response.body).toHaveProperty('databaseEnabled')
+      expect(typeof response.body.databaseEnabled).toBe('boolean')
+      expect(response.body).toHaveProperty('requestId')
+      expect(typeof response.body.requestId).toBe('string')
+    })
+
+    it('should include x-request-id header', async () => {
+      const response = await request.get('/health/details')
+
+      expectRequestId(response)
+    })
+  })
+
   describe('GET /soroban/config', () => {
     it('should return 200 with correct config shape', async () => {
       const response = await request.get('/soroban/config')


### PR DESCRIPTION
A new endpoint at GET /health/details returning non-sensitive deployment/debug fields:

version: from env.VERSION
nodeEnv: from env.NODE_ENV
sorobanAdapterMode: 'stub' | 'real' derived from process.env.SOROBAN_ADAPTER_MODE (defaults to 'stub')
databaseEnabled: boolean derived from presence of process.env.DATABASE_URL (does not return the URL)
requestId: included (already used by /health; helpful for correlating logs)
Files changed
backend/src/routes/health.ts
Added GET /details handler.
Imports env from ../schemas/env.js.
backend/src/routes/integration.test.ts
Added tests for GET /health/details:
Asserts response shape + types
Asserts x-request-id header is present
Sensitive-data check
No secrets returned
No connection strings / URLs returned
databaseEnabled is only a boolean, not the value of DATABASE_URL.

closes #263