### PR TITLE
feat/Reconciliation dashboard (deposits, reversals, withdrawals, conv…

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1390,6 +1390,7 @@
       "integrity": "sha512-akNQMv0wW5uyRpD2v2IEyRSZiR+BeGuoB6L310EgGObO44HSMNT8z1xzio28V8qOrgYaopIDNA18YgdXd+qTiw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1512,6 +1513,7 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -1813,6 +1815,7 @@
       "integrity": "sha512-CGJ25bc8fRi8Lod/3GHSvXRKi7nBo3kxh0ApW4yCjmrWmRmlT53B5E08XRSZRliygG0aVNxLrBEqPYdz/KcCtQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.0.18",
         "fflate": "^0.8.2",
@@ -1862,6 +1865,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2626,6 +2630,7 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4092,6 +4097,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -4189,6 +4195,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4974,6 +4981,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -5034,6 +5042,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5105,6 +5114,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -5180,6 +5190,7 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -31,6 +31,7 @@ import { createRiskRouter } from "./routes/risk.js"
 import { WalletServiceImpl, EnvironmentEncryptionService, KeyringEncryptionService, readEncryptionKeyringFromEnv } from "./services/walletService.js"
 import { CustodialWalletServiceImpl } from "./services/CustodialWalletServiceImpl.js"
 import { NgnWalletService } from "./services/ngnWalletService.js"
+import { createAdminReconciliationRouter } from "./routes/adminReconciliation.js"
 import { InMemoryWalletStore, PostgresWalletStore } from "./models/walletStore.js"
 import { InMemoryLinkedAddressStore, PostgresLinkedAddressStore } from "./models/linkedAddressStore.js"
 import { StubRewardsDataLayer } from "./services/stub-rewards-data-layer.js"
@@ -190,6 +191,7 @@ export function createApp() {
   app.use('/api/admin', createAdminWithdrawalsRouter(ngnWalletService))
   app.use('/api/payments', createPaymentsRouter(sorobanAdapter))
   app.use('/api/admin', createAdminRouter(sorobanAdapter, walletStore as any, encryptionService as any))
+  app.use('/api/admin/reconciliation', createAdminReconciliationRouter(ngnWalletService))
   app.use('/api/deals', createDealsRouter())
   app.use('/api/whistleblower', createWhistleblowerRouter(earningsService))
   app.use('/api/staking', createStakingRouter(sorobanAdapter, walletService, linkedAddressStore, ngnWalletService, conversionService, stakingService))

--- a/backend/src/models/conversionStore.ts
+++ b/backend/src/models/conversionStore.ts
@@ -34,6 +34,47 @@ class ConversionStore {
     return pool
   }
 
+  async listByStatus(options?: {
+    status?: 'pending' | 'completed' | 'failed'
+    limit?: number
+    cursorCreatedAt?: Date
+  }): Promise<ConversionRecord[]> {
+    const pool = await this.pool()
+    const limit = Math.max(1, Math.min(1000, options?.limit ?? 50))
+    const status = options?.status
+    const cursor = options?.cursorCreatedAt
+
+    if (!pool) {
+      let items = Array.from(this.byId.values())
+      if (status) {
+        items = items.filter((r) => r.status === status)
+      }
+      items.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
+      if (cursor) {
+        items = items.filter((r) => r.createdAt < cursor)
+      }
+      return items.slice(0, limit)
+    }
+
+    const params: any[] = []
+    const where: string[] = []
+    if (status) {
+      params.push(status)
+      where.push(`status = $${params.length}`)
+    }
+    if (cursor) {
+      params.push(cursor.toISOString())
+      where.push(`created_at < $${params.length}`)
+    }
+    const whereSql = where.length ? `WHERE ${where.join(' AND ')}` : ''
+    params.push(limit)
+    const { rows } = await pool.query(
+      `SELECT * FROM conversions ${whereSql} ORDER BY created_at DESC LIMIT $${params.length}`,
+      params,
+    )
+    return rows.map(mapRow)
+  }
+
   async getByConversionId(conversionId: string): Promise<ConversionRecord | null> {
     const pool = await this.pool()
     if (!pool) {

--- a/backend/src/models/depositStore.ts
+++ b/backend/src/models/depositStore.ts
@@ -15,6 +15,44 @@ class DepositStore {
   // Confirmed deposits (idempotent by depositId)
   private deposits = new Map<string, DepositRecord>()
 
+  async listInitiations(options?: {
+    status?: DepositStatus
+    limit?: number
+    cursorCreatedAt?: Date
+  }): Promise<Deposit[]> {
+    const limit = Math.max(1, Math.min(1000, options?.limit ?? 50))
+    const status = options?.status
+    const cursor = options?.cursorCreatedAt
+    let items = Array.from(this.initiationsById.values())
+    if (status) {
+      items = items.filter((d) => d.status === status)
+    }
+    items.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
+    if (cursor) {
+      items = items.filter((d) => d.createdAt < cursor)
+    }
+    return items.slice(0, limit)
+  }
+
+  async listConfirmedRecords(options?: {
+    reversed?: boolean
+    limit?: number
+    cursorCreatedAt?: Date
+  }): Promise<DepositRecord[]> {
+    const limit = Math.max(1, Math.min(1000, options?.limit ?? 50))
+    const reversedOnly = options?.reversed ?? false
+    const cursor = options?.cursorCreatedAt
+    let items = Array.from(this.deposits.values())
+    if (reversedOnly) {
+      items = items.filter((d) => d.reversedAt != null)
+    }
+    items.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
+    if (cursor) {
+      items = items.filter((d) => d.createdAt < cursor)
+    }
+    return items.slice(0, limit)
+  }
+
   // Initiation flow
   async create(input: CreateDepositInput): Promise<Deposit> {
     const now = new Date()

--- a/backend/src/models/ngnDepositStore.ts
+++ b/backend/src/models/ngnDepositStore.ts
@@ -34,6 +34,47 @@ class NgnDepositStore {
     return pool
   }
 
+  async listByStatus(options?: {
+    status?: NgnDepositStatus
+    limit?: number
+    cursorCreatedAt?: Date
+  }): Promise<NgnDeposit[]> {
+    const pool = await this.pool()
+    const limit = Math.max(1, Math.min(1000, options?.limit ?? 50))
+    const status = options?.status
+    const cursor = options?.cursorCreatedAt
+
+    if (!pool) {
+      let items = Array.from(this.byId.values())
+      if (status) {
+        items = items.filter((d) => d.status === status)
+      }
+      items.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
+      if (cursor) {
+        items = items.filter((d) => d.createdAt < cursor)
+      }
+      return items.slice(0, limit)
+    }
+
+    const params: any[] = []
+    let where: string[] = []
+    if (status) {
+      params.push(status)
+      where.push(`status = $${params.length}`)
+    }
+    if (cursor) {
+      params.push(cursor.toISOString())
+      where.push(`created_at < $${params.length}`)
+    }
+    const whereSql = where.length ? `WHERE ${where.join(' AND ')}` : ''
+    params.push(limit)
+    const { rows } = await pool.query(
+      `SELECT * FROM ngn_deposits ${whereSql} ORDER BY created_at DESC LIMIT $${params.length}`,
+      params,
+    )
+    return rows.map(mapRow)
+  }
+
   async getById(depositId: string): Promise<NgnDeposit | null> {
     const pool = await this.pool()
     if (!pool) {

--- a/backend/src/routes/adminReconciliation.ts
+++ b/backend/src/routes/adminReconciliation.ts
@@ -1,0 +1,231 @@
+import { Router, type Request, type Response, type NextFunction } from 'express'
+import { validate } from '../middleware/validate.js'
+import { env } from '../schemas/env.js'
+import { ngnDepositStore } from '../models/ngnDepositStore.js'
+import { depositStore } from '../models/depositStore.js'
+import { conversionStore } from '../models/conversionStore.js'
+import { outboxStore, OutboxStatus } from '../outbox/index.js'
+import { NgnWalletService } from '../services/ngnWalletService.js'
+import {
+  depositsQuerySchema,
+  depositsResponseSchema,
+  conversionsQuerySchema,
+  conversionsResponseSchema,
+  outboxQuerySchema,
+  outboxResponseSchema,
+  walletsQuerySchema,
+  walletsResponseSchema,
+} from '../schemas/adminReconciliation.js'
+import { userRiskStateStore } from '../models/userRiskStateStore.js'
+import { AppError } from '../errors/AppError.js'
+import { ErrorCode } from '../errors/errorCodes.js'
+
+function requireAdminSecret(req: Request, _res: Response, next: NextFunction) {
+  const headerSecret = req.headers['x-admin-secret']
+  if (env.MANUAL_ADMIN_SECRET && headerSecret !== env.MANUAL_ADMIN_SECRET) {
+    return next(new AppError(ErrorCode.FORBIDDEN, 403, 'Invalid admin secret'))
+  }
+  return next()
+}
+
+export function createAdminReconciliationRouter(ngnWalletService: NgnWalletService) {
+  const router = Router()
+
+  router.get(
+    '/deposits',
+    requireAdminSecret,
+    validate(depositsQuerySchema, 'query'),
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const { status, limit: rawLimit, cursor: cursorStr } = req.query as any
+        const limit = Math.max(1, Math.min(1000, Number(rawLimit ?? 50)))
+        const cursorDate = cursorStr ? new Date(String(cursorStr)) : undefined
+        const fetchLimit = limit
+
+        const [ngn, staking] = await Promise.all([
+          ngnDepositStore.listByStatus({
+            status: status as any | undefined,
+            limit: fetchLimit,
+            cursorCreatedAt: cursorDate,
+          }),
+          depositStore.listInitiations({
+            status: status as any | undefined,
+            limit: fetchLimit,
+            cursorCreatedAt: cursorDate,
+          }),
+        ])
+
+        const merged = [
+          ...ngn.map((d) => ({
+            depositId: d.depositId,
+            userId: d.userId,
+            amountNgn: d.amountNgn,
+            rail: d.rail ?? null,
+            status: d.status,
+            hasExternalRef: !!(d.externalRefSource && d.externalRef),
+            createdAt: d.createdAt,
+            updatedAt: d.updatedAt,
+            flow: 'ngn_wallet' as const,
+          })),
+          ...staking.map((d) => ({
+            depositId: d.depositId,
+            userId: d.userId,
+            amountNgn: d.amountNgn,
+            rail: d.paymentRail ?? null,
+            status: d.status,
+            hasExternalRef: !!(d.externalRefSource && d.externalRef),
+            createdAt: d.createdAt,
+            updatedAt: d.updatedAt,
+            flow: 'staking' as const,
+          })),
+        ]
+          .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
+          .slice(0, limit)
+
+        const nextCursor =
+          merged.length === limit ? merged[merged.length - 1].createdAt.toISOString() : null
+
+        res.json(
+          depositsResponseSchema.parse({
+            items: merged.map((i) => ({
+              ...i,
+              createdAt: i.createdAt.toISOString(),
+              updatedAt: i.updatedAt.toISOString(),
+            })),
+            nextCursor,
+          }),
+        )
+      } catch (error) {
+        next(error)
+      }
+    },
+  )
+
+  router.get(
+    '/wallets',
+    requireAdminSecret,
+    validate(walletsQuerySchema, 'query'),
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const { negative, limit: rawLimit, cursor } = req.query as any
+        const limit = Math.max(1, Math.min(1000, Number(rawLimit ?? 50)))
+        const includeNonNegative = !(negative === true || negative === 'true')
+
+        const { items, nextCursor } = await ngnWalletService.listNegativeBalances({
+          limit,
+          cursor: cursor as string | undefined,
+          includeNonNegative,
+        })
+
+        const withFrozen = await Promise.all(
+          items.map(async (it) => {
+            const risk = await userRiskStateStore.getByUserId(it.userId)
+            return {
+              userId: it.userId,
+              availableNgn: it.balance.availableNgn,
+              heldNgn: it.balance.heldNgn,
+              totalNgn: it.balance.totalNgn,
+              isFrozen: risk?.isFrozen ?? false,
+            }
+          }),
+        )
+
+        res.json(
+          walletsResponseSchema.parse({
+            items: withFrozen,
+            nextCursor,
+          }),
+        )
+      } catch (error) {
+        next(error)
+      }
+    },
+  )
+
+  router.get(
+    '/conversions',
+    requireAdminSecret,
+    validate(conversionsQuerySchema, 'query'),
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const { status, limit: rawLimit, cursor: cursorStr } = req.query as any
+        const limit = Math.max(1, Math.min(1000, Number(rawLimit ?? 50)))
+        const cursorDate = cursorStr ? new Date(String(cursorStr)) : undefined
+
+        const items = await conversionStore.listByStatus({
+          status: status as any | undefined,
+          limit,
+          cursorCreatedAt: cursorDate,
+        })
+
+        const mapped = items.map((r) => ({
+          conversionId: r.conversionId,
+          depositId: r.depositId,
+          userId: r.userId,
+          amountNgn: r.amountNgn,
+          amountUsdc: r.amountUsdc,
+          fxRateNgnPerUsdc: r.fxRateNgnPerUsdc,
+          provider: r.provider,
+          status: r.status,
+          createdAt: r.createdAt.toISOString(),
+          updatedAt: r.updatedAt.toISOString(),
+          failedAt: r.failedAt ? r.failedAt.toISOString() : null,
+          completedAt: r.completedAt ? r.completedAt.toISOString() : null,
+          failureReason: r.failureReason ?? null,
+        }))
+
+        const nextCursor =
+          items.length === limit ? items[items.length - 1].createdAt.toISOString() : null
+
+        res.json(conversionsResponseSchema.parse({ items: mapped, nextCursor }))
+      } catch (error) {
+        next(error)
+      }
+    },
+  )
+
+  router.get(
+    '/outbox',
+    requireAdminSecret,
+    validate(outboxQuerySchema, 'query'),
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const { status, limit: rawLimit, cursor: cursorStr } = req.query as any
+        const limit = Math.max(1, Math.min(1000, Number(rawLimit ?? 50)))
+        const cursorDate = cursorStr ? new Date(String(cursorStr)) : undefined
+
+        let items =
+          status != null
+            ? await outboxStore.listByStatus(status as OutboxStatus)
+            : await outboxStore.listAll(limit * 2)
+
+        items = items.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
+        if (cursorDate) {
+          items = items.filter((i) => i.createdAt < cursorDate)
+        }
+        const slice = items.slice(0, limit)
+        const nextCursor =
+          slice.length === limit ? slice[slice.length - 1].createdAt.toISOString() : null
+
+        const mapped = slice.map((i) => ({
+          id: i.id,
+          txType: i.txType,
+          txId: i.txId,
+          externalRef: i.canonicalExternalRefV1,
+          status: i.status,
+          attempts: i.attempts,
+          lastError: i.lastError,
+          createdAt: i.createdAt.toISOString(),
+          updatedAt: i.updatedAt.toISOString(),
+        }))
+
+        res.json(outboxResponseSchema.parse({ items: mapped, nextCursor }))
+      } catch (error) {
+        next(error)
+      }
+    },
+  )
+
+  return router
+}
+

--- a/backend/src/schemas/adminReconciliation.ts
+++ b/backend/src/schemas/adminReconciliation.ts
@@ -1,0 +1,100 @@
+import { z } from 'zod'
+
+export const paginationQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(1000).optional(),
+  cursor: z.string().optional(),
+})
+
+export const depositsQuerySchema = paginationQuerySchema.extend({
+  status: z.enum(['pending', 'confirmed', 'failed', 'reversed']).optional(),
+})
+
+export const depositItemSchema = z.object({
+  depositId: z.string(),
+  userId: z.string(),
+  amountNgn: z.number(),
+  rail: z.string().nullable(),
+  status: z.enum(['pending', 'confirmed', 'failed', 'reversed']),
+  hasExternalRef: z.boolean(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  flow: z.enum(['ngn_wallet', 'staking']),
+})
+
+export const depositsResponseSchema = z.object({
+  items: z.array(depositItemSchema),
+  nextCursor: z.string().nullable(),
+})
+
+export const walletsQuerySchema = paginationQuerySchema.extend({
+  negative: z.coerce.boolean().default(true),
+})
+
+export const walletItemSchema = z.object({
+  userId: z.string(),
+  availableNgn: z.number(),
+  heldNgn: z.number(),
+  totalNgn: z.number(),
+  isFrozen: z.boolean().optional(),
+})
+
+export const walletsResponseSchema = z.object({
+  items: z.array(walletItemSchema),
+  nextCursor: z.string().nullable(),
+})
+
+export const conversionsQuerySchema = paginationQuerySchema.extend({
+  status: z.enum(['pending', 'completed', 'failed']).optional(),
+})
+
+export const conversionItemSchema = z.object({
+  conversionId: z.string(),
+  depositId: z.string(),
+  userId: z.string(),
+  amountNgn: z.number(),
+  amountUsdc: z.string(),
+  fxRateNgnPerUsdc: z.number(),
+  provider: z.string(),
+  status: z.enum(['pending', 'completed', 'failed']),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  failedAt: z.string().nullable(),
+  completedAt: z.string().nullable(),
+  failureReason: z.string().nullable(),
+})
+
+export const conversionsResponseSchema = z.object({
+  items: z.array(conversionItemSchema),
+  nextCursor: z.string().nullable(),
+})
+
+export const outboxQuerySchema = paginationQuerySchema.extend({
+  status: z.enum(['failed', 'pending']).optional(),
+})
+
+export const outboxItemSchema = z.object({
+  id: z.string(),
+  txType: z.string(),
+  txId: z.string(),
+  externalRef: z.string(),
+  status: z.string(),
+  attempts: z.number(),
+  lastError: z.string().optional(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+})
+
+export const outboxResponseSchema = z.object({
+  items: z.array(outboxItemSchema),
+  nextCursor: z.string().nullable(),
+})
+
+export type DepositsQuery = z.infer<typeof depositsQuerySchema>
+export type DepositsResponse = z.infer<typeof depositsResponseSchema>
+export type WalletsQuery = z.infer<typeof walletsQuerySchema>
+export type WalletsResponse = z.infer<typeof walletsResponseSchema>
+export type ConversionsQuery = z.infer<typeof conversionsQuerySchema>
+export type ConversionsResponse = z.infer<typeof conversionsResponseSchema>
+export type OutboxQuery = z.infer<typeof outboxQuerySchema>
+export type OutboxResponse = z.infer<typeof outboxResponseSchema>
+

--- a/backend/src/services/ngnWalletService.ts
+++ b/backend/src/services/ngnWalletService.ts
@@ -928,4 +928,23 @@ export class NgnWalletService {
 
     logger.info('Withdrawal processed', { withdrawalId, status, failureReason })
   }
+
+  async listNegativeBalances(options: { limit?: number; cursor?: string; includeNonNegative?: boolean } = {}): Promise<{ items: Array<{ userId: string; balance: NgnBalanceResponse }>; nextCursor: string | null }> {
+    const limit = Math.max(1, Math.min(1000, options?.limit ?? 50))
+    const includeNonNegative = options?.includeNonNegative ?? false
+    let items = Array.from(this.balances.entries()).map(([userId, balance]) => ({ userId, balance }))
+    if (!includeNonNegative) {
+      items = items.filter(({ balance }) => balance.totalNgn < 0 || balance.availableNgn < 0)
+    }
+    items.sort((a, b) => a.balance.totalNgn - b.balance.totalNgn || a.userId.localeCompare(b.userId))
+    if (options?.cursor) {
+      const [cursorTotalStr, cursorUserId] = options.cursor.split(':')
+      const cursorTotal = Number(cursorTotalStr)
+      items = items.filter(it => it.balance.totalNgn < cursorTotal || (it.balance.totalNgn === cursorTotal && it.userId > cursorUserId))
+    }
+    const slice = items.slice(0, limit)
+    const last = slice[slice.length - 1]
+    const nextCursor = slice.length === limit && last ? `${last.balance.totalNgn}:${last.userId}` : null
+    return { items: slice, nextCursor }
+  }
 }


### PR DESCRIPTION

<img width="665" height="505" alt="Screenshot 2026-03-03 111602" src="https://github.com/user-attachments/assets/94321be1-c940-471e-aca8-e9a5a1f8faf6" />
…ersion outcomes)

## Summary
Added a dedicated, read‑only admin reconciliation router under /api/admin/reconciliation with four endpoints:

## Linked issue
Closed: #161 

## Changes
- Added a dedicated, read‑only admin reconciliation router under /api/admin/reconciliation with four endpoints:
- GET /api/admin/reconciliation/deposits?status=...
- GET /api/admin/reconciliation/wallets?negative=true
- GET /api/admin/reconciliation/conversions?status=...
- GET /api/admin/reconciliation/outbox?status=failed|pending
- All endpoints support pagination via limit and cursor and exclude sensitive data.
- Reused existing stores/services and added minimal list capabilities where missing to keep the code consistent and testable.
## How to test

## Screenshots (if UI)

## Checklist

- [ x] I linked an issue (or explained why one is not needed)
- [ x] I tested locally
- [ x] I did not commit secrets
- [ x] I updated docs if needed
