### PR TITLE
readme updated

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -17,6 +17,12 @@ This folder contains Soroban smart contracts written in Rust.
 ```bash
 cd contracts
 
+# Formatting
+cargo fmt
+
+# Linting
+cargo clippy --all-targets --all-features -- -D warnings
+
 # 1) Run unit tests
 cargo test
 


### PR DESCRIPTION
README now contains cargo fmt, cargo clippy, and cargo test
Commands are copy/paste friendly
Includes “run from /contracts” via cd contracts at the top of the block
closes #281