### PR TITLE
docs: update wallet copy to Stellar

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Shelterflex is an open-source project exploring **rent now, pay later** workflows with a modern web frontend, a Node.js backend, and Soroban smart contracts.
 
-**🔥 New Feature: Wallet Authentication** - Users can now connect their Ethereum wallet for secure, self-custody authentication alongside traditional email/OTP login.
+**🔥 New Feature: Wallet Authentication** - Users can now connect their Stellar wallet (e.g., Freighter) for secure, self-custody authentication alongside traditional email/OTP login.
 
 This repository is organized as **three independent projects**:
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -251,7 +251,7 @@ SOROBAN_CONTRACT_ID=
 **Important Notes:**
 - `USDC_TOKEN_ADDRESS` is **required** in `production` and `test` environments
 - In `development`, the address can be omitted (uses mock address for testing)
-- The address must be a valid Ethereum address format: `0x` followed by 40 hex characters
+- The address must be a valid Soroban contract ID (a 56-character Stellar StrKey starting with `C`)
 - Server will refuse to start if `USDC_TOKEN_ADDRESS` is missing in non-development environments
 
 ## Soroban integration


### PR DESCRIPTION
## Summary
Update wallet copy to refer to Stellar/Freighter instead of Ethereum.

## Linked issue
Closes #282

## Changes
- swap the wallet authentication blurb to Stellar/Freighter wording
- correct USDC token address guidance to Soroban contract ID wording

## How to test
- Not run (docs-only change)

## Screenshots (if UI)
N/A

## Checklist
- [x] I linked an issue (or explained why one is not needed)
- [ ] I tested locally
- [x] I did not commit secrets
- [x] I updated docs if needed