### PR TITLE
test: cover validation middleware errors

### DIFF
--- a/backend/src/middleware/validate.test.ts
+++ b/backend/src/middleware/validate.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest'
+import express from 'express'
+import request from 'supertest'
+import { z } from 'zod'
+import { validate } from './validate.js'
+import { requestIdMiddleware } from './requestId.js'
+
+describe('validate middleware', () => {
+  it('returns a 400 validation error with field details', async () => {
+    const app = express()
+    app.use(requestIdMiddleware)
+    app.use(express.json())
+
+    const schema = z.object({
+      name: z.string().min(1),
+      count: z.number().int().positive(),
+    })
+
+    app.post('/test', validate(schema, 'body'), (_req, res) => {
+      res.json({ ok: true })
+    })
+
+    const response = await request(app)
+      .post('/test')
+      .send({ name: '', count: -1 })
+
+    expect(response.status).toBe(400)
+    expect(response.body.error.code).toBe('VALIDATION_ERROR')
+    expect(response.body.error.message).toBe('Invalid request data')
+    expect(response.body.error.details).toMatchObject({
+      name: expect.any(String),
+      count: expect.any(String),
+    })
+  })
+})


### PR DESCRIPTION
## Summary
Add a unit test that asserts the validation middleware returns a 400 with field-level details.

## Linked issue
Closes #279

## Changes
- add a focused validate middleware test with an invalid body payload

## How to test
- Not run (backend dependencies not installed on this host)

## Screenshots (if UI)
N/A

## Checklist
- [x] I linked an issue (or explained why one is not needed)
- [ ] I tested locally
- [x] I did not commit secrets
- [ ] I updated docs if needed