### PR TITLE
fix: re-enable skipped OTP rate-limit and auth/me tests

### DIFF
--- a/backend/src/middleware/authRateLimit.ts
+++ b/backend/src/middleware/authRateLimit.ts
@@ -122,3 +122,10 @@ export function _testOnly_clearAuthRateLimits() {
   walletChallengeRequestCounters.clear()
   ipWalletChallengeRequestCounters.clear()
 }
+
+export function _testOnly_prefillEmailOtpCounter(email: string, count: number) {
+  emailOtpRequestCounters.set(email.toLowerCase(), {
+    count,
+    resetAtMs: nowMs() + 15 * 60 * 1000,
+  })
+}

--- a/backend/src/routes/auth.test.ts
+++ b/backend/src/routes/auth.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { createTestAgent, expectErrorShape } from '../test-helpers.js'
 import { otpChallengeStore, sessionStore, userStore, walletChallengeStore } from '../models/authStore.js'
-import { _testOnly_clearAuthRateLimits } from '../middleware/authRateLimit.js'
+import { _testOnly_clearAuthRateLimits, _testOnly_prefillEmailOtpCounter } from '../middleware/authRateLimit.js'
 
 vi.mock('../utils/wallet.js', async (importOriginal) => {
   const mod = await importOriginal<typeof import('../utils/wallet.js')>()
@@ -86,12 +86,44 @@ describe('Auth Routes (OTP)', () => {
     expectErrorShape(res, 'UNAUTHORIZED', 401)
   })
 
-  it.skip('request-otp should rate limit by email', async () => {
-    // TODO: Re-enable when test agent supports custom middleware
+  it('request-otp should rate limit by email', async () => {
+    // Use a fresh agent so the global express-rate-limit counter is reset
+    const agent = createTestAgent()
+    const email = 'ratelimit@example.com'
+
+    // Pre-fill the per-email counter to the default limit (100)
+    _testOnly_prefillEmailOtpCounter(email, 100)
+
+    // The next request should be rejected with 429 by the per-email rate limiter
+    const res = await agent.post('/api/auth/request-otp').send({ email })
+    expect(res.status).toBe(429)
+    expect(res.body.error.code).toBe('TOO_MANY_REQUESTS')
   })
 
-  it.skip('GET /api/auth/me should require auth and return user when authenticated', async () => {
-    // TODO: Fix rate limiting test interference
+  it('GET /api/auth/me should require auth and return user when authenticated', async () => {
+    // Use a fresh agent so the global express-rate-limit counter is reset
+    const agent = createTestAgent()
+
+    // Unauthenticated request should fail
+    const unauthed = await agent.get('/api/auth/me')
+    expect(unauthed.status).toBe(401)
+
+    // Create a session via OTP flow
+    const email = 'me@example.com'
+    await agent.post('/api/auth/request-otp').send({ email }).expect(200)
+    const verifyRes = await agent
+      .post('/api/auth/verify-otp')
+      .send({ email, otp: '123456' })
+      .expect(200)
+
+    const token = verifyRes.body.token
+
+    // Authenticated request should return user
+    const authed = await agent
+      .get('/api/auth/me')
+      .set('Authorization', `Bearer ${token}`)
+    expect(authed.status).toBe(200)
+    expect(authed.body.user).toHaveProperty('email', email)
   })
 })
 


### PR DESCRIPTION
## Summary
Re-enables two skipped tests in `backend/src/routes/auth.test.ts` for OTP rate limiting and authenticated endpoint access.

Fixes #301

## Changes
- Added `_testOnly_prefillEmailOtpCounter(email, count)` helper to `backend/src/middleware/authRateLimit.ts` that seeds the in-memory counter near the limit
- Re-enabled **"request-otp should rate limit by email"** test — pre-fills counter to 100 (default limit), sends one more request, asserts 429 `TOO_MANY_REQUESTS`
- Re-enabled **"GET /api/auth/me should require auth and return user when authenticated"** test — creates session via OTP flow, verifies authenticated endpoint returns user data
- Both tests use fresh test agents to avoid rate limit interference from earlier tests

## How to test
- [x] All automated tests pass
- [x] `cd backend && npm test` — both previously-skipped tests now pass
- [x] Manual testing completed — verified rate limit triggers at correct threshold

## Security Considerations
- [x] No secrets or sensitive data are logged
- [x] No changes to authentication/authorization logic without review
- [x] No changes to admin/upgrade logic without review

## Checklist
- [x] I linked an issue (or explained why one is not needed)
- [x] I tested locally
- [x] I did not commit secrets
- [x] I updated docs if needed
- [x] Code follows the project's style guidelines
- [x] CI checks pass