### PR TITLE
Frontend: Create centralized API client and refactor 2 call sites

### DIFF
--- a/frontend/lib/apiClient.ts
+++ b/frontend/lib/apiClient.ts
@@ -1,0 +1,64 @@
+/**
+ * Centralized API client for backend communication.
+ *
+ * All fetch logic flows through this module so that auth headers, error
+ * handling, and base URL resolution happen in exactly one place.
+ */
+
+import { ApiError, apiFetch } from "./api";
+
+export { ApiError, isAccountFrozenError, ACCOUNT_FROZEN_MESSAGE } from "./api";
+
+// ── HTTP helpers ─────────────────────────────────────────────────────────────
+
+export async function apiGet<T>(path: string): Promise<T> {
+  return apiFetch<T>(path, { method: "GET" });
+}
+
+export async function apiPost<T>(path: string, body: unknown): Promise<T> {
+  return apiFetch<T>(path, {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+export async function apiPut<T>(path: string, body: unknown): Promise<T> {
+  return apiFetch<T>(path, {
+    method: "PUT",
+    body: JSON.stringify(body),
+  });
+}
+
+export async function apiPatch<T>(path: string, body: unknown): Promise<T> {
+  return apiFetch<T>(path, {
+    method: "PATCH",
+    body: JSON.stringify(body),
+  });
+}
+
+export async function apiDelete<T>(path: string): Promise<T> {
+  return apiFetch<T>(path, { method: "DELETE" });
+}
+
+// ── Query string helper ──────────────────────────────────────────────────────
+
+/**
+ * Build a URL path with query parameters, omitting undefined/null values.
+ *
+ * @example
+ * withQuery("/api/items", { status: "pending", limit: 10 })
+ * // => "/api/items?status=pending&limit=10"
+ */
+export function withQuery(
+  path: string,
+  params: Record<string, string | number | boolean | undefined | null>,
+): string {
+  const qs = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value != null) {
+      qs.append(key, String(value));
+    }
+  }
+  const query = qs.toString();
+  return query ? `${path}?${query}` : path;
+}

--- a/frontend/lib/reconciliationApi.ts
+++ b/frontend/lib/reconciliationApi.ts
@@ -1,4 +1,4 @@
-import { apiFetch, apiPost } from './api'
+import { apiGet, apiPost, withQuery } from './apiClient'
 
 export interface OutboxItem {
   id: string
@@ -45,16 +45,12 @@ export async function getOutboxItems(params?: {
   status?: 'pending' | 'sent' | 'failed'
   limit?: number
 }): Promise<OutboxResponse> {
-  const queryParams = new URLSearchParams()
-  if (params?.status) {
-    queryParams.append('status', params.status)
-  }
-  if (params?.limit) {
-    queryParams.append('limit', String(params.limit))
-  }
-
-  const query = queryParams.toString()
-  return apiFetch<OutboxResponse>(`/api/admin/outbox${query ? `?${query}` : ''}`)
+  return apiGet<OutboxResponse>(
+    withQuery('/api/admin/outbox', {
+      status: params?.status,
+      limit: params?.limit,
+    }),
+  )
 }
 
 /**

--- a/frontend/lib/risk.ts
+++ b/frontend/lib/risk.ts
@@ -1,4 +1,4 @@
-import { apiFetch } from "./api";
+import { apiGet } from "./apiClient";
 
 export interface RiskState {
   isFrozen: boolean;
@@ -37,7 +37,7 @@ export function humanizeFreezeReason(reason?: string | null): string | null {
 
 export async function getRiskState(): Promise<RiskState> {
   try {
-    const risk = await apiFetch<RiskStateResponse>("/api/risk/state");
+    const risk = await apiGet<RiskStateResponse>("/api/risk/state");
     return {
       isFrozen: Boolean(risk.isFrozen),
       freezeReason: humanizeFreezeReason(risk.freezeReason),
@@ -49,7 +49,7 @@ export async function getRiskState(): Promise<RiskState> {
   }
 
   try {
-    const me = await apiFetch<MeResponse>("/api/auth/me");
+    const me = await apiGet<MeResponse>("/api/auth/me");
     return {
       isFrozen: Boolean(me.user?.isFrozen),
       freezeReason: humanizeFreezeReason(me.user?.freezeReason),


### PR DESCRIPTION
## Summary

Add centralized API client and refactor 2 call sites.

Closes #328

## Changes

- Add `frontend/lib/apiClient.ts` with `apiGet`, `apiPost`, `apiPut`, `apiPatch`, `apiDelete`, and `withQuery` helper
- All methods delegate to the existing `apiFetch` core, providing a cleaner API surface
- Refactor `reconciliationApi.ts` to use `apiGet` + `withQuery` instead of manual URLSearchParams
- Refactor `risk.ts` to use `apiGet` instead of raw `apiFetch`
- No heavy dependencies added; pure wrapper around native fetch

## How to test

- [x] `cd frontend && npm run lint` passes
- [x] `cd frontend && npm run build` passes
- [ ] Verify reconciliation and risk API calls still work

## Security Considerations

- [x] No secrets or sensitive data are logged
- [x] No changes to authentication/authorization logic without review
- [x] No changes to admin/upgrade logic without review

## Checklist

- [x] I linked an issue (or explained why one is not needed)
- [x] I tested locally
- [x] I did not commit secrets
- [x] I updated docs if needed
- [x] Code follows the project's style guidelines
- [x] CI checks pass