### PR TITLE
Backend: Add DB connect + migration retry/backoff

### DIFF
--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -10,6 +10,9 @@ export type PgPoolLike = {
 
 let pool: PgPoolLike | null = null
 
+const DB_CONNECT_RETRIES = parseInt(process.env.DB_CONNECT_RETRIES ?? '5', 10)
+const DB_CONNECT_RETRY_MS = parseInt(process.env.DB_CONNECT_RETRY_MS ?? '2000', 10)
+
 export function setPool(newPool: PgPoolLike | null) {
   pool = newPool
 }
@@ -18,14 +21,34 @@ export async function getPool(): Promise<PgPoolLike | null> {
   if (pool) return pool
   if (!process.env.DATABASE_URL) return null
 
-  try {
-    const mod = await import('pg')
-    const PgPool = (mod as any).Pool
-    pool = new PgPool({
-      connectionString: process.env.DATABASE_URL,
-    })
-    return pool
-  } catch {
-    return null
+  for (let attempt = 1; attempt <= DB_CONNECT_RETRIES; attempt++) {
+    try {
+      const mod = await import('pg')
+      const PgPool = (mod as any).Pool
+      const candidate = new PgPool({
+        connectionString: process.env.DATABASE_URL,
+      })
+
+      // Verify the connection is actually usable
+      await candidate.query('SELECT 1')
+      pool = candidate
+      if (attempt > 1) {
+        console.log(`[db] Connected on attempt ${attempt}`)
+      }
+      return pool
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      console.error(
+        `[db] Connection attempt ${attempt}/${DB_CONNECT_RETRIES} failed: ${message}`,
+      )
+
+      if (attempt < DB_CONNECT_RETRIES) {
+        const delay = DB_CONNECT_RETRY_MS * Math.pow(2, attempt - 1)
+        await new Promise((resolve) => setTimeout(resolve, delay))
+      }
+    }
   }
+
+  console.error(`[db] All ${DB_CONNECT_RETRIES} connection attempts failed`)
+  return null
 }

--- a/backend/src/migrations/runMigrations.ts
+++ b/backend/src/migrations/runMigrations.ts
@@ -2,11 +2,44 @@ import { readFile, readdir } from 'node:fs/promises'
 import path from 'node:path'
 import { Pool } from 'pg'
 
+const DB_CONNECT_RETRIES = parseInt(process.env.DB_CONNECT_RETRIES ?? '5', 10)
+const DB_CONNECT_RETRY_MS = parseInt(process.env.DB_CONNECT_RETRY_MS ?? '2000', 10)
+
+async function connectWithRetry(databaseUrl: string): Promise<Pool> {
+  for (let attempt = 1; attempt <= DB_CONNECT_RETRIES; attempt++) {
+    try {
+      const pool = new Pool({ connectionString: databaseUrl })
+      await pool.query('SELECT 1')
+      if (attempt > 1) {
+        console.log(`[migrations] Connected on attempt ${attempt}`)
+      }
+      return pool
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      console.error(
+        `[migrations] Connection attempt ${attempt}/${DB_CONNECT_RETRIES} failed: ${message}`,
+      )
+
+      if (attempt >= DB_CONNECT_RETRIES) {
+        throw new Error(
+          `Failed to connect to database after ${DB_CONNECT_RETRIES} attempts`,
+        )
+      }
+
+      const delay = DB_CONNECT_RETRY_MS * Math.pow(2, attempt - 1)
+      await new Promise((resolve) => setTimeout(resolve, delay))
+    }
+  }
+
+  // Unreachable, but satisfies TypeScript
+  throw new Error('Exhausted retries')
+}
+
 export async function runMigrationsIfNeeded() {
   const databaseUrl = process.env.DATABASE_URL
   if (!databaseUrl) return
 
-  const pool = new Pool({ connectionString: databaseUrl })
+  const pool = await connectWithRetry(databaseUrl)
 
   const migrationsDir = path.resolve(process.cwd(), 'migrations')
 
@@ -38,6 +71,7 @@ export async function runMigrationsIfNeeded() {
         await pool.query(sql)
         await pool.query('INSERT INTO schema_migrations (filename) VALUES ($1)', [file])
         await pool.query('COMMIT')
+        console.log(`[migrations] Applied: ${file}`)
       } catch (error) {
         await pool.query('ROLLBACK')
         throw error


### PR DESCRIPTION
## Summary

Add DB connect and migration retry with exponential backoff.

Closes #304

## Changes

- Add configurable retry with exponential backoff to `db.ts` and `runMigrations.ts`
- Environment variables (with sane defaults):
  - `DB_CONNECT_RETRIES` (default: 5)
  - `DB_CONNECT_RETRY_MS` (default: 2000ms base, exponential backoff)
- Both modules verify connection with `SELECT 1` before returning the pool
- Log retry attempts without leaking connection strings or secrets
- Migration runner exits with thrown error after final failure

## How to test

- [ ] Set an invalid `DATABASE_URL` locally and confirm retries then exit
- [ ] Verify normal startup works unchanged with valid DB
- [ ] `cd backend && npm test`

## Security Considerations

- [x] No secrets or sensitive data are logged
- [x] No changes to authentication/authorization logic without review
- [x] No changes to admin/upgrade logic without review

## Checklist

- [x] I linked an issue (or explained why one is not needed)
- [x] I tested locally
- [x] I did not commit secrets
- [x] I updated docs if needed
- [x] Code follows the project's style guidelines
- [x] CI checks pass