### PR TITLE
refactor(frontend): standardize error toast handling via handleError helper

### DIFF
--- a/frontend/components/staking/StakingPage.tsx
+++ b/frontend/components/staking/StakingPage.tsx
@@ -12,7 +12,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "../ui/tabs";
 import { Loader2, Wallet, Coins, AlertCircle, DollarSign } from "lucide-react";
 import { useRiskState } from "@/hooks/useRiskState";
 import { ACCOUNT_FROZEN_MESSAGE, isAccountFrozenError } from "@/lib/api";
-import { useToast } from "@/hooks/use-toast";
+import { handleError } from "@/lib/toast";
 import FrozenAccountBanner from "../FrozenAccountBanner";
 import { getQuote, type Quote, type StakingPosition as NgnStakingPosition } from "@/lib/ngnStakingApi";
 import { NgnStakingFlow } from "./ngn-flow/NgnStakingFlow";
@@ -20,7 +20,6 @@ import { NgnStakingFlow } from "./ngn-flow/NgnStakingFlow";
 type StakingMode = "ngn_deposit" | "ngn_balance" | "usdc";
 
 export default function StakingPage() {
-  const { toast } = useToast();
   const { isFrozen, freezeReason } = useRiskState();
   const [stakingPosition, setStakingPosition] = useState<StakingPositionReponse | null>(null);
   const [ngnBalance, setNgnBalance] = useState<NgnBalanceResponse | null>(null);
@@ -106,11 +105,7 @@ export default function StakingPage() {
 
     if (isFrozen && stakingMode === "ngn_balance") {
       setStatus(ACCOUNT_FROZEN_MESSAGE);
-      toast({
-        title: "Account frozen",
-        description: ACCOUNT_FROZEN_MESSAGE,
-        variant: "destructive",
-      });
+      handleError(new Error(ACCOUNT_FROZEN_MESSAGE), ACCOUNT_FROZEN_MESSAGE);
       return;
     }
 
@@ -160,14 +155,10 @@ export default function StakingPage() {
     } catch (err: any) {
       if (isAccountFrozenError(err)) {
         setStatus(ACCOUNT_FROZEN_MESSAGE);
-        toast({
-          title: "Account frozen",
-          description: ACCOUNT_FROZEN_MESSAGE,
-          variant: "destructive",
-        });
-        return;
+      } else {
+        setStatus(err.message || "Stake failed");
       }
-      setStatus(err.message || "Stake failed")
+      handleError(err, "Stake failed");
     } finally {
       setIsStaking(false)
     }
@@ -201,7 +192,8 @@ export default function StakingPage() {
       setUnstakeAmount("")
 
     } catch (err: any) {
-      setStatus(err.message || "Unstake failed")
+      setStatus(err.message || "Unstake failed");
+      handleError(err, "Unstake failed");
     }
   }
 
@@ -226,7 +218,8 @@ export default function StakingPage() {
       updatePosition({ claimableDelta: -claimable })
 
     } catch (err: any) {
-      setStatus(err.message || "Claim failed")
+      setStatus(err.message || "Claim failed");
+      handleError(err, "Claim failed");
     }
   }
 

--- a/frontend/components/wallet/WithdrawalModal.tsx
+++ b/frontend/components/wallet/WithdrawalModal.tsx
@@ -29,7 +29,6 @@ import {
   type BankAccountDetails,
 } from "@/lib/walletApi";
 import { ACCOUNT_FROZEN_MESSAGE, isAccountFrozenError } from "@/lib/api";
-import { useToast } from "@/hooks/use-toast";
 
 interface WithdrawalModalProps {
   open: boolean;
@@ -85,7 +84,6 @@ export function WithdrawalModal({
   deficitNgn = 0,
   onTopUpClick,
 }: WithdrawalModalProps) {
-  const { toast } = useToast();
   const [step, setStep] = useState<Step>("input");
   const [amount, setAmount] = useState<string>("");
   const [accountNumber, setAccountNumber] = useState<string>("");
@@ -181,17 +179,10 @@ export function WithdrawalModal({
       showSuccessToast("Withdrawal initiated successfully");
       onSuccess?.();
     } catch (err) {
-      // Show toast for API errors
       handleError(err, "Failed to initiate withdrawal");
-      // Also set inline error for form display
-      const message = err instanceof Error ? err.message : "Failed to initiate withdrawal";
-      if (isAccountFrozenError(err)) {
-        toast({
-          title: "Account frozen",
-          description: ACCOUNT_FROZEN_MESSAGE,
-          variant: "destructive",
-        });
-      }
+      const message = isAccountFrozenError(err)
+        ? ACCOUNT_FROZEN_MESSAGE
+        : err instanceof Error ? err.message : "Failed to initiate withdrawal";
       setErrorMessage(message);
       setStep("error");
     } finally {


### PR DESCRIPTION
## Summary
Standardizes error toast handling in StakingPage and WithdrawalModal by replacing raw `toast()` calls with the existing `handleError` helper, removing a duplicate toast in WithdrawalModal.

## Linked issue
Closes #333

## Changes
- `StakingPage.tsx`: replaced 3 inline `toast({ variant: "destructive", ... })` calls with `handleError`, removed unused `useToast` import
- `WithdrawalModal.tsx`: removed duplicate frozen-account `toast()` call that fired alongside `handleError`, removed unused `useToast` import

## Checklist
- [x] I tested locally
- [x] I did not commit secrets
- [x] I updated docs if needed