### PR TITLE
Backend: Re-enable skipped wallet verify success test

### DIFF
--- a/backend/src/routes/auth.test.ts
+++ b/backend/src/routes/auth.test.ts
@@ -161,8 +161,37 @@ describe('Auth Routes (Wallet)', () => {
     expect(challenge!.attempts).toBe(0)
   })
 
-  it.skip('POST /api/auth/wallet/verify should return session token on success', async () => {
-    // TODO: Implement with proper mocking of Stellar SDK
+  it('POST /api/auth/wallet/verify should return session token on success', async () => {
+    const address = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF'
+
+    const walletUtils = await getWalletUtils()
+    vi.mocked(walletUtils.verifySignedChallenge).mockReturnValue(true)
+
+    const challengeRes = await request.post('/api/auth/wallet/challenge').send({ address })
+    expect(challengeRes.status).toBe(200)
+
+    const challengeBefore = await walletChallengeStore.getByAddress(address.toLowerCase())
+    expect(challengeBefore).toBeDefined()
+
+    const verifyRes = await request.post('/api/auth/wallet/verify').send({
+      address,
+      signedChallengeXdr: 'valid-mock-xdr',
+    })
+
+    expect(verifyRes.status).toBe(200)
+
+    // Session token response presence/shape
+    expect(verifyRes.body).toHaveProperty('token')
+    expect(typeof verifyRes.body.token).toBe('string')
+    expect(verifyRes.body.token).toBe('session-token-abc')
+
+    expect(verifyRes.body).toHaveProperty('user')
+    expect(typeof verifyRes.body.user).toBe('object')
+    expect(verifyRes.body.user).not.toBeNull()
+
+    // Success should clear the one-time challenge
+    const challengeAfter = await walletChallengeStore.getByAddress(address.toLowerCase())
+    expect(challengeAfter).toBeUndefined()
   })
 
   it('POST /api/auth/wallet/verify should fail with expired challenge', async () => {
@@ -243,33 +272,6 @@ describe('Auth Routes (Wallet)', () => {
     // Verify challenge is cleared after max attempts
     const clearedChallenge = await walletChallengeStore.getByAddress(address.toLowerCase())
     expect(clearedChallenge).toBeUndefined()
-  })
-
-  it('POST /api/auth/wallet/verify should return session token and clear challenge on success', async () => {
-    const address = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF'
-
-    const walletUtils = await getWalletUtils()
-    vi.mocked(walletUtils.verifySignedChallenge).mockReturnValue(true)
-
-    // Create a challenge
-    const res = await request.post('/api/auth/wallet/challenge').send({ address })
-    expect(res.status).toBe(200)
-
-    const challengeBefore = await walletChallengeStore.getByAddress(address.toLowerCase())
-    expect(challengeBefore).toBeDefined()
-
-    const verifyRes = await request.post('/api/auth/wallet/verify').send({
-      address,
-      signedChallengeXdr: 'valid-mock-xdr',
-    })
-
-    expect(verifyRes.status).toBe(200)
-    expect(verifyRes.body).toHaveProperty('token', 'session-token-abc')
-    expect(verifyRes.body).toHaveProperty('user')
-    expect(verifyRes.body.user).toHaveProperty('email')
-
-    const challengeAfter = await walletChallengeStore.getByAddress(address.toLowerCase())
-    expect(challengeAfter).toBeUndefined()
   })
 })
 


### PR DESCRIPTION
## Summary
Re-enabled coverage for the wallet auth verify success path by mocking at the wallet-utils boundary (`verifySignedChallenge`) instead of Stellar SDK internals. The test asserts a 200 response and validates the session token response shape, ensuring this core login flow is exercised without network calls.

## Linked issue (recommended)
Closes #302 

## Changes
- Removed the skipped wallet verify success-path test in `backend/src/routes/auth.test.ts` and implemented it using the existing `getWalletUtils()` mocking pattern.
- Added assertions for HTTP status and token/user presence + basic shape.
- Ensured the wallet challenge is cleared after a successful verify.

## How to test
bash
cd backend && npx vitest run src/routes/auth.test.ts


## Security Considerations
- Test-only change; no auth/authorization logic changes
- No secrets or sensitive data are logged

## Checklist
- [x] I linked an issue (Closes #302)
- [x] I tested locally (scoped)
- [x] I did not commit secrets
- [ ] CI checks pass