### PR TITLE
feat(451): add read-replica pool with circuit breaker failover

### DIFF
--- a/backend/src/db.test.ts
+++ b/backend/src/db.test.ts
@@ -1,9 +1,27 @@
-import { describe, it, expect, beforeEach } from 'vitest'
-import { setPool, getPoolMetrics, type PgPoolLike } from './db.js'
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+import { setPool, setReadPool, getPool, getReadPool, getPoolMetrics, type PgPoolLike } from './db.js'
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function makeMockPool(queryResult: any = { rows: [], rowCount: 0 }): PgPoolLike & Record<string, any> {
+  return {
+    query: vi.fn().mockResolvedValue(queryResult),
+    connect: vi.fn().mockResolvedValue({ query: vi.fn(), release: vi.fn() }),
+  } as any
+}
+
+// ── existing pool metrics tests ───────────────────────────────────────────────
 
 describe('db pool metrics', () => {
   beforeEach(() => {
     setPool(null)
+    setReadPool(null)
+    delete process.env.READ_REPLICA_URL
+  })
+
+  afterEach(() => {
+    setPool(null)
+    setReadPool(null)
   })
 
   it('returns null when no pool is set', () => {
@@ -49,5 +67,100 @@ describe('db pool metrics', () => {
     expect(metrics!.totalCount).toBe(0)
     expect(metrics!.idleCount).toBe(0)
     expect(metrics!.activeCount).toBe(0)
+  })
+
+  it('includes circuitBreaker state in metrics', () => {
+    const mockPool = makeMockPool()
+    setPool(mockPool)
+
+    const metrics = getPoolMetrics()
+    expect(metrics!.circuitBreaker.primary).toBe('closed')
+    expect(metrics!.circuitBreaker.replica).toBe('none')
+    expect(metrics!.replicaEnabled).toBe(false)
+  })
+
+  it('reports replicaEnabled and replica circuit state when readPool is set', () => {
+    const primary = makeMockPool()
+    setPool(primary)
+    const replica = makeMockPool()
+    setReadPool(replica)
+
+    const metrics = getPoolMetrics()
+    expect(metrics!.replicaEnabled).toBe(true)
+    expect(metrics!.circuitBreaker.replica).toBe('closed')
+  })
+})
+
+// ── getPool() ─────────────────────────────────────────────────────────────────
+
+describe('getPool()', () => {
+  beforeEach(() => {
+    setPool(null)
+    setReadPool(null)
+    delete process.env.DATABASE_URL
+  })
+
+  afterEach(() => {
+    setPool(null)
+    vi.restoreAllMocks()
+  })
+
+  it('returns null when DATABASE_URL is not set', async () => {
+    expect(await getPool()).toBeNull()
+  })
+
+  it('returns the injected pool immediately without hitting pg', async () => {
+    const mock = makeMockPool()
+    setPool(mock)
+    expect(await getPool()).toBe(mock)
+  })
+})
+
+// ── getReadPool() ─────────────────────────────────────────────────────────────
+
+describe('getReadPool()', () => {
+  beforeEach(() => {
+    setPool(null)
+    setReadPool(null)
+    delete process.env.DATABASE_URL
+    delete process.env.READ_REPLICA_URL
+  })
+
+  afterEach(() => {
+    setPool(null)
+    setReadPool(null)
+    vi.restoreAllMocks()
+  })
+
+  it('falls back to primary when READ_REPLICA_URL is not set', async () => {
+    const primary = makeMockPool()
+    setPool(primary)
+    const result = await getReadPool()
+    expect(result).toBe(primary)
+  })
+
+  it('uses the injected read pool when READ_REPLICA_URL is set', async () => {
+    process.env.READ_REPLICA_URL = 'postgres://replica/db'
+    const replica = makeMockPool({ rows: [{ val: 1 }], rowCount: 1 })
+    setReadPool(replica)
+
+    const result = await getReadPool()
+    expect(result).not.toBeNull()
+
+    const rows = await result!.query('SELECT 1')
+    expect(rows.rows).toEqual([{ val: 1 }])
+    expect((replica.query as ReturnType<typeof vi.fn>)).toHaveBeenCalledWith('SELECT 1', undefined)
+  })
+
+  it('propagates errors from the replica pool query', async () => {
+    process.env.READ_REPLICA_URL = 'postgres://replica/db'
+    const replica: PgPoolLike = {
+      query: vi.fn().mockRejectedValue(new Error('replica unavailable')),
+      connect: vi.fn(),
+    }
+    setReadPool(replica)
+
+    const result = await getReadPool()
+    await expect(result!.query('SELECT 1')).rejects.toThrow('replica unavailable')
   })
 })

--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -9,6 +9,7 @@ export type PgPoolLike = {
 }
 
 let pool: PgPoolLike | null = null
+let readPool: PgPoolLike | null = null
 
 // Connection retry settings
 const DB_CONNECT_RETRIES = parseInt(process.env.DB_CONNECT_RETRIES ?? '5', 10)
@@ -22,13 +23,61 @@ const DB_POOL_CONNECTION_TIMEOUT_MS = parseInt(process.env.DB_POOL_CONNECTION_TI
 const DB_STATEMENT_TIMEOUT_MS = parseInt(process.env.DB_STATEMENT_TIMEOUT_MS ?? '30000', 10)
 const DB_SLOW_QUERY_THRESHOLD_MS = parseInt(process.env.DB_SLOW_QUERY_THRESHOLD_MS ?? '200', 10)
 
-// Pool metrics
+// Circuit breaker settings
+const CB_FAILURE_THRESHOLD = parseInt(process.env.DB_CB_FAILURE_THRESHOLD ?? '5', 10)
+const CB_RECOVERY_MS = parseInt(process.env.DB_CB_RECOVERY_MS ?? '30000', 10)
+
+// ── Circuit Breaker ───────────────────────────────────────────────────────────
+
+type CircuitState = 'closed' | 'open' | 'half-open'
+
+interface CircuitBreaker {
+  state: CircuitState
+  failures: number
+  openedAt: number | null
+}
+
+const primaryCircuit: CircuitBreaker = { state: 'closed', failures: 0, openedAt: null }
+const replicaCircuit: CircuitBreaker = { state: 'closed', failures: 0, openedAt: null }
+
+function recordSuccess(cb: CircuitBreaker): void {
+  cb.failures = 0
+  cb.state = 'closed'
+  cb.openedAt = null
+}
+
+function recordFailure(cb: CircuitBreaker): void {
+  cb.failures++
+  if (cb.failures >= CB_FAILURE_THRESHOLD) {
+    cb.state = 'open'
+    cb.openedAt = Date.now()
+    console.error(JSON.stringify({ level: 'error', message: 'DB circuit breaker OPEN', failures: cb.failures, timestamp: new Date().toISOString() }))
+  }
+}
+
+function isAvailable(cb: CircuitBreaker): boolean {
+  if (cb.state === 'closed') return true
+  if (cb.state === 'open' && cb.openedAt !== null && Date.now() - cb.openedAt >= CB_RECOVERY_MS) {
+    cb.state = 'half-open'
+    console.log(JSON.stringify({ level: 'info', message: 'DB circuit breaker HALF-OPEN (probing)', timestamp: new Date().toISOString() }))
+    return true
+  }
+  return cb.state === 'half-open'
+}
+
+// ── Pool metrics ──────────────────────────────────────────────────────────────
+
 export interface PoolMetrics {
   totalCount: number
   idleCount: number
   waitingCount: number
   activeCount: number
   slowQueryCount: number
+  circuitBreaker: {
+    primary: CircuitState
+    replica: CircuitState | 'none'
+  }
+  replicaEnabled: boolean
 }
 
 let slowQueryCount = 0
@@ -45,11 +94,101 @@ export function getPoolMetrics(): PoolMetrics | null {
         ? p.totalCount - p.idleCount
         : 0,
     slowQueryCount,
+    circuitBreaker: {
+      primary: primaryCircuit.state,
+      replica: readPool ? replicaCircuit.state : 'none',
+    },
+    replicaEnabled: !!readPool,
   }
 }
 
 export function setPool(newPool: PgPoolLike | null) {
   pool = newPool
+}
+
+export function setReadPool(newPool: PgPoolLike | null) {
+  readPool = newPool
+}
+
+/**
+ * Returns a pool for read queries. Prefers the read replica when available and
+ * its circuit breaker is closed/half-open; falls back to the primary pool.
+ */
+export async function getReadPool(): Promise<PgPoolLike | null> {
+  const replicaUrl = process.env.READ_REPLICA_URL
+
+  if (replicaUrl && isAvailable(replicaCircuit)) {
+    if (!readPool) {
+      for (let attempt = 1; attempt <= DB_CONNECT_RETRIES; attempt++) {
+        try {
+          const mod = await import('pg')
+          const PgPool = (mod as any).Pool
+          const candidate = new PgPool({
+            connectionString: replicaUrl,
+            max: DB_POOL_MAX,
+            min: DB_POOL_MIN,
+            idleTimeoutMillis: DB_POOL_IDLE_TIMEOUT_MS,
+            connectionTimeoutMillis: DB_POOL_CONNECTION_TIMEOUT_MS,
+            statement_timeout: DB_STATEMENT_TIMEOUT_MS,
+          })
+
+          await candidate.query('SELECT 1')
+
+          candidate.on('error', (err: Error) => {
+            console.error(
+              JSON.stringify({
+                level: 'error',
+                message: 'Unexpected replica pool client error',
+                errorMessage: err.message,
+                timestamp: new Date().toISOString(),
+              }),
+            )
+          })
+
+          readPool = wrapPoolWithQueryLogging(candidate)
+
+          console.log(
+            JSON.stringify({
+              level: 'info',
+              message: 'Read replica pool initialized',
+              ...(attempt > 1 ? { connectedOnAttempt: attempt } : {}),
+            }),
+          )
+          break
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err)
+          console.error(`[db] Replica connection attempt ${attempt}/${DB_CONNECT_RETRIES} failed: ${message}`)
+          recordFailure(replicaCircuit)
+
+          if (attempt < DB_CONNECT_RETRIES) {
+            const delay = DB_CONNECT_RETRY_MS * Math.pow(2, attempt - 1)
+            await new Promise((resolve) => setTimeout(resolve, delay))
+          }
+        }
+      }
+    }
+
+    if (readPool) {
+      // Wrap the replica pool query to track circuit breaker state
+      const originalQuery = readPool.query.bind(readPool)
+      return {
+        query: async (text: string, params?: unknown[]) => {
+          try {
+            const result = await originalQuery(text, params)
+            recordSuccess(replicaCircuit)
+            return result
+          } catch (err) {
+            recordFailure(replicaCircuit)
+            throw err
+          }
+        },
+        connect: readPool.connect.bind(readPool),
+      }
+    }
+  }
+
+  // Fall back to primary
+  return getPool()
 }
 
 /**
@@ -98,6 +237,17 @@ export async function getPool(): Promise<PgPoolLike | null> {
   if (pool) return pool
   if (!process.env.DATABASE_URL) return null
 
+  if (!isAvailable(primaryCircuit)) {
+    console.error(
+      JSON.stringify({
+        level: 'error',
+        message: 'DB primary circuit breaker is OPEN — refusing connection',
+        timestamp: new Date().toISOString(),
+      }),
+    )
+    return null
+  }
+
   for (let attempt = 1; attempt <= DB_CONNECT_RETRIES; attempt++) {
     try {
       const mod = await import('pg')
@@ -113,6 +263,7 @@ export async function getPool(): Promise<PgPoolLike | null> {
 
       // Verify the connection is actually usable
       await candidate.query('SELECT 1')
+      recordSuccess(primaryCircuit)
 
       // Log pool error events to prevent silent failures
       candidate.on('error', (err: Error) => {
@@ -148,6 +299,7 @@ export async function getPool(): Promise<PgPoolLike | null> {
       console.error(
         `[db] Connection attempt ${attempt}/${DB_CONNECT_RETRIES} failed: ${message}`,
       )
+      recordFailure(primaryCircuit)
 
       if (attempt < DB_CONNECT_RETRIES) {
         const delay = DB_CONNECT_RETRY_MS * Math.pow(2, attempt - 1)


### PR DESCRIPTION
## Summary
Adds read-replica pool support with a per-pool circuit breaker state machine. Reads are routed to `READ_REPLICA_URL` when available; the circuit opens after `DB_CB_FAILURE_THRESHOLD` consecutive failures and probes recovery after `DB_CB_RECOVERY_MS`. Falls back to the primary pool transparently.

Closes #451

## Changes
- `backend/src/db.ts` — adds `readPool` variable, `CircuitBreaker` interface with `closed/open/half-open` states, `recordSuccess/recordFailure/isAvailable` helpers, `setReadPool()` for test injection, and `getReadPool()` which routes to replica with circuit-breaker tracking and falls back to primary; integrates `primaryCircuit` checks into `getPool()`; extends `PoolMetrics` with `circuitBreaker` and `replicaEnabled` fields
- `backend/src/db.test.ts` — 10 vitest tests covering pool injection, getPool/getReadPool fallback, replica query routing, error propagation, and metrics reflection

## How to test
- [x] All automated tests pass (`vitest run src/db.test.ts` — 10 tests)
- [x] Integration tests pass (if applicable)
- [x] Manual testing completed

## Security Considerations
- [x] No secrets or sensitive data are logged
- [x] No changes to authentication/authorization logic
- [x] No admin/upgrade logic changes

## Checklist
- [x] I linked an issue (Closes #451)
- [x] I tested locally (10 tests passing)
- [x] I did not commit secrets
- [x] I updated docs if needed
- [x] Code follows the project's style guidelines
- [x] CI checks pass