### PR TITLE
feat(452): add date range and address filters to receipt search API

### DIFF
--- a/backend/src/indexer/receipt-repository.test.ts
+++ b/backend/src/indexer/receipt-repository.test.ts
@@ -104,4 +104,33 @@ describe('PostgresReceiptRepository', () => {
       ['deal1', 10, 10], // offset = (2-1)*10 = 10
     )
   })
+
+  it('builds SQL conditions for fromAddress, toAddress, fromDate, and toDate', async () => {
+    mockPool.query
+      .mockResolvedValueOnce({ rows: [{ count: '5' }] })
+      .mockResolvedValueOnce({ rows: [] })
+
+    const fromDate = new Date('2024-01-01T00:00:00Z')
+    const toDate = new Date('2024-12-31T00:00:00Z')
+
+    await repo.query({ fromAddress: 'SENDER_A', toAddress: 'RCVR_B', fromDate, toDate })
+
+    const [countSql, countParams] = mockPool.query.mock.calls[0] as [string, unknown[]]
+    expect(countSql).toContain('sender = $1')
+    expect(countSql).toContain('receiver = $2')
+    expect(countSql).toContain('indexed_at >= $3')
+    expect(countSql).toContain('indexed_at <= $4')
+    expect(countParams).toEqual(['SENDER_A', 'RCVR_B', fromDate, toDate])
+  })
+
+  it('omits WHERE clause when no filters are given', async () => {
+    mockPool.query
+      .mockResolvedValueOnce({ rows: [{ count: '0' }] })
+      .mockResolvedValueOnce({ rows: [] })
+
+    await repo.query({})
+
+    const [countSql] = mockPool.query.mock.calls[0] as [string, unknown[]]
+    expect(countSql).not.toContain('WHERE')
+  })
 })

--- a/backend/src/indexer/receipt-repository.ts
+++ b/backend/src/indexer/receipt-repository.ts
@@ -7,7 +7,16 @@ export interface IndexedReceipt {
   from?: string; to?: string; externalRefHash: string; metadataHash?: string
   ledger: number; indexedAt: Date
 }
-export interface ReceiptQuery { dealId?: string; txType?: TxType; page?: number; pageSize?: number }
+export interface ReceiptQuery {
+  dealId?: string
+  txType?: TxType
+  fromAddress?: string
+  toAddress?: string
+  fromDate?: Date
+  toDate?: Date
+  page?: number
+  pageSize?: number
+}
 export interface PagedReceipts { data: IndexedReceipt[]; total: number; page: number; pageSize: number }
 
 export interface ReceiptRepository {
@@ -26,10 +35,14 @@ export class StubReceiptRepository implements ReceiptRepository {
   async upsertMany(receipts: IndexedReceipt[]) { for (const r of receipts) this.store.set(r.txId, r) }
   async findByDealId(dealId: string) { return [...this.store.values()].filter(r => r.dealId === dealId) }
   async findByTxId(txId: string) { return this.store.get(txId) || null }
-  async query({ dealId, txType, page = 1, pageSize = 20 }: ReceiptQuery): Promise<PagedReceipts> {
+  async query({ dealId, txType, fromAddress, toAddress, fromDate, toDate, page = 1, pageSize = 20 }: ReceiptQuery): Promise<PagedReceipts> {
     let r = [...this.store.values()]
     if (dealId) r = r.filter(x => x.dealId === dealId)
     if (txType) r = r.filter(x => x.txType === txType)
+    if (fromAddress) r = r.filter(x => x.from === fromAddress)
+    if (toAddress) r = r.filter(x => x.to === toAddress)
+    if (fromDate) r = r.filter(x => x.indexedAt >= fromDate)
+    if (toDate) r = r.filter(x => x.indexedAt <= toDate)
     return { data: r.slice((page - 1) * pageSize, page * pageSize), total: r.length, page, pageSize }
   }
   async getCheckpoint() { return this.checkpoint }
@@ -112,15 +125,19 @@ export class PostgresReceiptRepository implements ReceiptRepository {
     return rows.length ? this.mapRow(rows[0]) : null
   }
 
-  async query({ dealId, txType, page = 1, pageSize = 20 }: ReceiptQuery): Promise<PagedReceipts> {
+  async query({ dealId, txType, fromAddress, toAddress, fromDate, toDate, page = 1, pageSize = 20 }: ReceiptQuery): Promise<PagedReceipts> {
     const pool = await this.pool()
     const offset = (page - 1) * pageSize
 
     const conditions: string[] = []
     const params: unknown[] = []
 
-    if (dealId) { params.push(dealId); conditions.push(`deal_id = $${params.length}`) }
-    if (txType) { params.push(txType); conditions.push(`tx_type = $${params.length}`) }
+    if (dealId)      { params.push(dealId);      conditions.push(`deal_id = $${params.length}`) }
+    if (txType)      { params.push(txType);      conditions.push(`tx_type = $${params.length}`) }
+    if (fromAddress) { params.push(fromAddress); conditions.push(`sender = $${params.length}`) }
+    if (toAddress)   { params.push(toAddress);   conditions.push(`receiver = $${params.length}`) }
+    if (fromDate)    { params.push(fromDate);    conditions.push(`indexed_at >= $${params.length}`) }
+    if (toDate)      { params.push(toDate);      conditions.push(`indexed_at <= $${params.length}`) }
 
     const where = conditions.length ? `WHERE ${conditions.join(' AND ')}` : ''
 

--- a/backend/src/routes/receiptsRoute.test.ts
+++ b/backend/src/routes/receiptsRoute.test.ts
@@ -109,6 +109,83 @@ describe('GET /api/admin/receipts', () => {
     expect(res.body.error.message).toContain('Invalid txType')
   })
 
+  it('filters by fromAddress', async () => {
+    await repo.upsertMany([
+      makeReceipt({ from: 'ADDR_A' }),
+      makeReceipt({ from: 'ADDR_B' }),
+      makeReceipt({ from: 'ADDR_A' }),
+    ])
+    const app = buildApp(repo)
+
+    const res = await supertest(app)
+      .get('/api/admin/receipts?fromAddress=ADDR_A')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200)
+
+    expect(res.body.total).toBe(2)
+    expect(res.body.data.every((r: IndexedReceipt) => r.from === 'ADDR_A')).toBe(true)
+  })
+
+  it('filters by toAddress', async () => {
+    await repo.upsertMany([
+      makeReceipt({ to: 'RCVR_X' }),
+      makeReceipt({ to: 'RCVR_Y' }),
+    ])
+    const app = buildApp(repo)
+
+    const res = await supertest(app)
+      .get('/api/admin/receipts?toAddress=RCVR_X')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200)
+
+    expect(res.body.total).toBe(1)
+    expect(res.body.data[0].to).toBe('RCVR_X')
+  })
+
+  it('filters by fromDate and toDate', async () => {
+    await repo.upsertMany([
+      makeReceipt({ txId: 'tx-old', indexedAt: new Date('2024-01-01T00:00:00Z') }),
+      makeReceipt({ txId: 'tx-mid', indexedAt: new Date('2024-06-15T00:00:00Z') }),
+      makeReceipt({ txId: 'tx-new', indexedAt: new Date('2024-12-31T00:00:00Z') }),
+    ])
+    const app = buildApp(repo)
+
+    const res = await supertest(app)
+      .get('/api/admin/receipts?fromDate=2024-03-01T00:00:00Z&toDate=2024-09-01T00:00:00Z')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200)
+
+    expect(res.body.total).toBe(1)
+    expect(res.body.data[0].txId).toBe('tx-mid')
+  })
+
+  it('rejects invalid fromDate with 400', async () => {
+    const app = buildApp(repo)
+    const res = await supertest(app)
+      .get('/api/admin/receipts?fromDate=not-a-date')
+      .set('Authorization', `Bearer ${token}`)
+    expect(res.status).toBe(400)
+    expect(res.body.error.message).toContain('Invalid fromDate')
+  })
+
+  it('rejects invalid toDate with 400', async () => {
+    const app = buildApp(repo)
+    const res = await supertest(app)
+      .get('/api/admin/receipts?toDate=not-a-date')
+      .set('Authorization', `Bearer ${token}`)
+    expect(res.status).toBe(400)
+    expect(res.body.error.message).toContain('Invalid toDate')
+  })
+
+  it('rejects fromDate after toDate with 400', async () => {
+    const app = buildApp(repo)
+    const res = await supertest(app)
+      .get('/api/admin/receipts?fromDate=2024-12-01T00:00:00Z&toDate=2024-01-01T00:00:00Z')
+      .set('Authorization', `Bearer ${token}`)
+    expect(res.status).toBe(400)
+    expect(res.body.error.message).toContain('fromDate must not be after toDate')
+  })
+
   it('clamps pageSize to max 100', async () => {
     const receipts = Array.from({ length: 5 }, () => makeReceipt())
     await repo.upsertMany(receipts)

--- a/backend/src/routes/receiptsRoute.ts
+++ b/backend/src/routes/receiptsRoute.ts
@@ -15,12 +15,17 @@ const VALID_TX_TYPES = new Set(Object.values(TxType))
  *     tags: [Admin]
  *     security: [{ bearerAuth: [] }]
  *     parameters:
- *       - { in: query, name: dealId,   schema: { type: string } }
- *       - { in: query, name: txType,   schema: { type: string } }
- *       - { in: query, name: page,     schema: { type: integer, default: 1 } }
- *       - { in: query, name: pageSize, schema: { type: integer, default: 20, maximum: 100 } }
+ *       - { in: query, name: dealId,      schema: { type: string } }
+ *       - { in: query, name: txType,      schema: { type: string } }
+ *       - { in: query, name: fromAddress, schema: { type: string } }
+ *       - { in: query, name: toAddress,   schema: { type: string } }
+ *       - { in: query, name: fromDate,    schema: { type: string, format: date-time } }
+ *       - { in: query, name: toDate,      schema: { type: string, format: date-time } }
+ *       - { in: query, name: page,        schema: { type: integer, default: 1 } }
+ *       - { in: query, name: pageSize,    schema: { type: integer, default: 20, maximum: 100 } }
  *     responses:
  *       200: { description: Paged receipts }
+ *       400: { description: Invalid query parameter }
  *       401: { description: Unauthorized }
  * /api/deals/{dealId}/receipts:
  *   get:
@@ -43,6 +48,10 @@ export function createReceiptsRouter(repo: ReceiptRepository): Router {
         const pageSize = Math.min(100, Math.max(1, parseInt(String(req.query.pageSize ?? '20'), 10) || 20))
         const dealId = req.query.dealId as string | undefined
         const rawTxType = req.query.txType as string | undefined
+        const fromAddress = req.query.fromAddress as string | undefined
+        const toAddress = req.query.toAddress as string | undefined
+        const rawFromDate = req.query.fromDate as string | undefined
+        const rawToDate = req.query.toDate as string | undefined
 
         if (rawTxType !== undefined && !VALID_TX_TYPES.has(rawTxType as TxType)) {
           return next(
@@ -54,8 +63,28 @@ export function createReceiptsRouter(repo: ReceiptRepository): Router {
           )
         }
 
+        let fromDate: Date | undefined
+        if (rawFromDate !== undefined) {
+          fromDate = new Date(rawFromDate)
+          if (isNaN(fromDate.getTime())) {
+            return next(new AppError(ErrorCode.VALIDATION_ERROR, 400, 'Invalid fromDate — must be ISO 8601'))
+          }
+        }
+
+        let toDate: Date | undefined
+        if (rawToDate !== undefined) {
+          toDate = new Date(rawToDate)
+          if (isNaN(toDate.getTime())) {
+            return next(new AppError(ErrorCode.VALIDATION_ERROR, 400, 'Invalid toDate — must be ISO 8601'))
+          }
+        }
+
+        if (fromDate && toDate && fromDate > toDate) {
+          return next(new AppError(ErrorCode.VALIDATION_ERROR, 400, 'fromDate must not be after toDate'))
+        }
+
         const txType = rawTxType as TxType | undefined
-        res.json(await repo.query({ dealId, txType, page, pageSize }))
+        res.json(await repo.query({ dealId, txType, fromAddress, toAddress, fromDate, toDate, page, pageSize }))
       } catch (err) {
         next(err)
       }


### PR DESCRIPTION
## Summary
Extends the receipt search API with date range and address filters. Callers can now filter indexed receipts by `fromDate`/`toDate` (ISO 8601) and `fromAddress`/`toAddress`, enabling frontend analytics and per-user event queries.

Closes #452

## Changes
- `backend/src/indexer/receipt-repository.ts` — adds `fromAddress`, `toAddress`, `fromDate`, `toDate` to `ReceiptQuery`; `StubReceiptRepository.query()` filters in-memory; `PostgresReceiptRepository.query()` emits parameterised SQL conditions (`sender =`, `receiver =`, `indexed_at >=`, `indexed_at <=`)
- `backend/src/indexer/receipt-repository.test.ts` — 2 new tests: SQL conditions built correctly for all 4 new filters; WHERE clause omitted when no filters given
- `backend/src/routes/receiptsRoute.ts` — parses and validates the 4 new query params; rejects malformed ISO dates and inverted date ranges with HTTP 400; updated OpenAPI doc comments
- `backend/src/routes/receiptsRoute.test.ts` — 6 new route-level tests: fromAddress/toAddress filtering, date range filtering, and 3 validation error cases

## How to test
- [x] All automated tests pass (`vitest run` — 24 tests across 2 files)
- [x] Integration tests pass (if applicable)
- [x] Manual testing completed

## Security Considerations
- [x] No secrets or sensitive data are logged
- [x] No changes to authentication/authorization logic
- [x] No admin/upgrade logic changes

## Checklist
- [x] I linked an issue (Closes #452)
- [x] I tested locally (24 tests passing)
- [x] I did not commit secrets
- [x] I updated docs if needed
- [x] Code follows the project's style guidelines
- [x] CI checks pass