### PR TITLE
feat: enforce payload conflict detection for deposit idempotency key

### DIFF
--- a/backend/src/middleware/idempotency.ts
+++ b/backend/src/middleware/idempotency.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto'
 import type { Request, Response, NextFunction } from 'express'
 import { ErrorCode } from '../errors/errorCodes.js'
 import type { ErrorResponse } from '../errors/errorCodes.js'
@@ -9,6 +10,8 @@ interface CachedResponse {
   status: number
   body: unknown
   createdAt: number
+  /** SHA-256 hex digest of the request body at the time of the first call. */
+  payloadHash: string
 }
 
 /**
@@ -140,9 +143,25 @@ export function idempotency(store: IdempotencyStore = defaultStore) {
       return
     }
 
+    // Compute a hash of the incoming payload for conflict detection
+    const incomingHash = createHash('sha256')
+      .update(JSON.stringify(req.body ?? null))
+      .digest('hex')
+
     // Check for cached response
     const cached = store.get(trimmedKey)
     if (cached) {
+      if (cached.payloadHash !== incomingHash) {
+        const body: ErrorResponse = {
+          error: {
+            code: ErrorCode.CONFLICT,
+            message:
+              'This idempotency key was already used with a different request payload',
+          },
+        }
+        res.status(409).json(body)
+        return
+      }
       res.setHeader('x-idempotent-replay', 'true')
       res.status(cached.status).json(cached.body)
       return
@@ -167,6 +186,7 @@ export function idempotency(store: IdempotencyStore = defaultStore) {
         status: res.statusCode,
         body,
         createdAt: Date.now(),
+        payloadHash: incomingHash,
       })
       return originalJson(body)
     }

--- a/backend/src/routes/deposits.test.ts
+++ b/backend/src/routes/deposits.test.ts
@@ -49,4 +49,54 @@ describe('POST /api/deposits/confirm', () => {
     expect(res1.body.conversion.conversionId).toBe(res2.body.conversion.conversionId)
     expect(res1.body.conversion.amountUsdc).toBe(res2.body.conversion.amountUsdc)
   })
+
+  it('replays the original response for duplicate key + same payload', async () => {
+    const payload = {
+      depositId: 'onramp:dep_003',
+      userId: 'user_1',
+      amountNgn: 50000,
+      provider: 'onramp',
+      providerRef: 'provider-ref-003',
+    }
+
+    const res1 = await request(app)
+      .post('/api/deposits/confirm')
+      .set('x-idempotency-key', 'idem-key-003')
+      .send(payload)
+      .expect(200)
+
+    const res2 = await request(app)
+      .post('/api/deposits/confirm')
+      .set('x-idempotency-key', 'idem-key-003')
+      .send(payload)
+      .expect(200)
+
+    expect(res2.headers['x-idempotent-replay']).toBe('true')
+    expect(res2.body.conversion.conversionId).toBe(res1.body.conversion.conversionId)
+  })
+
+  it('returns 409 for same idempotency key with a different payload', async () => {
+    const payload = {
+      depositId: 'onramp:dep_004',
+      userId: 'user_1',
+      amountNgn: 50000,
+      provider: 'onramp',
+      providerRef: 'provider-ref-004',
+    }
+
+    await request(app)
+      .post('/api/deposits/confirm')
+      .set('x-idempotency-key', 'idem-key-004')
+      .send(payload)
+      .expect(200)
+
+    const conflictRes = await request(app)
+      .post('/api/deposits/confirm')
+      .set('x-idempotency-key', 'idem-key-004')
+      .send({ ...payload, amountNgn: 99999 })
+      .expect(409)
+
+    expect(conflictRes.body.error.code).toBe('CONFLICT')
+    expect(conflictRes.body.error.message).toMatch(/different request payload/)
+  })
 })


### PR DESCRIPTION
## Summary
Enforce payload conflict detection on the deposit confirmation endpoint. Duplicate requests with the same `x-idempotency-key` and identical payload are replayed from cache. Requests reusing the same key with a different payload now return a clear `409 CONFLICT` error instead of silently replaying the wrong cached response.

## Linked issue
Closes #428 

## Changes
- Added `payloadHash` field (SHA-256 of request body) to `CachedResponse` in `idempotency.ts`
- On cache hit, middleware now compares incoming payload hash against stored hash — mismatch returns `409` with `error.code: CONFLICT`
- Added `import { createHash } from 'node:crypto'` to support hashing
- Added two tests to `deposits.test.ts`:
  - Same key + same payload → `200` with `x-idempotent-replay: true` and matching `conversionId`
  - Same key + different payload → `409` with `CONFLICT` code and descriptive message

## Checklist
- [x] I tested locally
- [x] I did not commit secrets
- [x] I updated docs if needed