### PR TITLE
test(contracts): add reward math invariant tests for mvp staking pool

### DIFF
--- a/contracts/mvp_staking_pool/src/lib.rs
+++ b/contracts/mvp_staking_pool/src/lib.rs
@@ -881,8 +881,8 @@ mod reward_math_invariants {
     extern crate std;
 
     use super::{StakingPool, StakingPoolClient};
-    use soroban_sdk::{token::StellarAssetClient, Address, Env};
     use soroban_sdk::testutils::Address as _;
+    use soroban_sdk::{token::StellarAssetClient, Address, Env};
 
     fn setup(env: &Env) -> (StakingPoolClient<'_>, Address, Address) {
         let contract_id = env.register(StakingPool, ());


### PR DESCRIPTION
## Summary
Add invariant tests for staking pool reward math in `mvp_staking_pool`. The reward distribution formula (`global_reward_index` + per-user accrual) is money-sensitive and previously had no edge-case coverage. These tests lock in correct behaviour across small amounts, large amounts, proportional splits, and timing boundaries.

## Linked issue
Closes #429

## Changes
- Added `mod reward_math_invariants` test module to `contracts/mvp_staking_pool/src/lib.rs`
- 8 invariant tests covering:
  - Sole staker receives 100% of rewards
  - Equal stakers receive equal split
  - Unequal stakes split proportionally (2:1 ratio)
  - Late staker earns nothing from pre-join funding rounds
  - Non-staker claimable is always zero
  - Small stake (1 token) as sole staker receives full reward (no integer division loss)
  - Large amounts (10¹⁴ tokens) do not overflow index math
  - Claim is idempotent — second claim always returns zero

## Checklist
- [x] I tested locally
- [x] I did not commit secrets
- [x] I updated docs if needed
