### PR TITLE
fix: align /health/details with safe diagnostics contract

### DIFF
--- a/backend/src/routes/health.ts
+++ b/backend/src/routes/health.ts
@@ -17,18 +17,11 @@ export function createHealthRouter(adapter: SorobanAdapter): Router {
   })
 
   router.get("/details", (req: Request, res: Response) => {
-    const sorobanAdapterMode = (process.env.SOROBAN_ADAPTER_MODE ?? 'stub') === 'real'
-      ? 'real'
-      : 'stub'
-
-    const poolMetrics = getPoolMetrics()
-
     res.json({
       version: env.VERSION,
       nodeEnv: env.NODE_ENV,
-      sorobanAdapterMode,
-      databaseEnabled: !!process.env.DATABASE_URL,
-      ...(poolMetrics ? { databasePool: poolMetrics } : {}),
+      uptimeSeconds: Math.floor(process.uptime()),
+      dbConnected: getPoolMetrics() !== null,
       requestId: req.requestId,
     })
   })

--- a/backend/src/routes/integration.test.ts
+++ b/backend/src/routes/integration.test.ts
@@ -43,10 +43,10 @@ describe('Integration Tests', () => {
       expect(typeof response.body.version).toBe('string')
       expect(response.body).toHaveProperty('nodeEnv')
       expect(typeof response.body.nodeEnv).toBe('string')
-      expect(response.body).toHaveProperty('sorobanAdapterMode')
-      expect(['stub', 'real']).toContain(response.body.sorobanAdapterMode)
-      expect(response.body).toHaveProperty('databaseEnabled')
-      expect(typeof response.body.databaseEnabled).toBe('boolean')
+      expect(response.body).toHaveProperty('uptimeSeconds')
+      expect(typeof response.body.uptimeSeconds).toBe('number')
+      expect(response.body).toHaveProperty('dbConnected')
+      expect(typeof response.body.dbConnected).toBe('boolean')
       expect(response.body).toHaveProperty('requestId')
       expect(typeof response.body.requestId).toBe('string')
     })
@@ -55,6 +55,17 @@ describe('Integration Tests', () => {
       const response = await request.get('/health/details')
 
       expectRequestId(response)
+    })
+
+    it('should not expose forbidden diagnostic fields', async () => {
+      const response = await request.get('/health/details')
+
+      expect(response.status).toBe(200)
+      expect(response.body).not.toHaveProperty('process.env')
+      expect(response.body).not.toHaveProperty('DATABASE_URL')
+      expect(response.body).not.toHaveProperty('databaseEnabled')
+      expect(response.body).not.toHaveProperty('databasePool')
+      expect(response.body).not.toHaveProperty('sorobanAdapterMode')
     })
   })
 


### PR DESCRIPTION
Related to #303

## Summary
- align `GET /health/details` with the safe diagnostics response contract
- return only `version`, `nodeEnv`, `uptimeSeconds`, `requestId`, and `dbConnected`
- add integration coverage for the expected shape and forbidden fields

## Changes
- simplified `backend/src/routes/health.ts` so `/health/details` returns only the accepted safe diagnostics fields
- replaced configuration and pool detail fields with a single `dbConnected` boolean
- updated `backend/src/routes/integration.test.ts` to assert both the allowed shape and the absence of forbidden fields

## Checklist
- [x] implemented the route response changes
- [x] updated integration coverage for the new response contract
- [x] verified `Backend (lint, test)` passes for this PR
