### PR TITLE
Add GET /health/details returning safe operational metadata.

### DIFF
--- a/backend/src/routes/health.test.ts
+++ b/backend/src/routes/health.test.ts
@@ -1,11 +1,48 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
+import request from 'supertest'
+import express from 'express'
 import { createHealthRouter } from './health.js'
 import { CircuitBreakerAdapter } from '../soroban/circuit-breaker-adapter.js'
 import { StubSorobanAdapter } from '../soroban/stub-adapter.js'
 import { getSorobanConfigFromEnv } from '../soroban/client.js'
 import { CircuitBreakerConfig } from '../soroban/circuit-breaker-config.js'
 
+vi.mock('../db.js', () => ({
+  getPoolMetrics: () => ({ active: 1 })
+}))
+
 describe('Health Router', () => {
+  describe('GET /details', () => {
+    it('returns safe operational metadata without secrets', async () => {
+      const config = getSorobanConfigFromEnv(process.env)
+      const stubAdapter = new StubSorobanAdapter(config)
+      const router = createHealthRouter(stubAdapter)
+      
+      const app = express()
+      app.use((req, res, next) => {
+        (req as any).requestId = 'test-req-id'
+        next()
+      })
+      app.use('/health', router)
+
+      const res = await request(app).get('/health/details').expect(200)
+
+      expect(res.body).toHaveProperty('version')
+      expect(res.body).toHaveProperty('nodeEnv')
+      expect(res.body).toHaveProperty('uptimeSeconds')
+      expect(typeof res.body.uptimeSeconds).toBe('number')
+      expect(res.body).toHaveProperty('dbConnected')
+      expect(typeof res.body.dbConnected).toBe('boolean')
+      expect(res.body).toHaveProperty('requestId', 'test-req-id')
+
+      expect(res.body).not.toHaveProperty('process.env')
+      expect(res.body).not.toHaveProperty('DATABASE_URL')
+      
+      const keys = Object.keys(res.body)
+      expect(keys.length).toBe(5)
+    })
+  })
+
   describe('GET /soroban', () => {
     it('should return healthy status when circuit breaker is CLOSED', async () => {
       const config = getSorobanConfigFromEnv(process.env)


### PR DESCRIPTION
## Summary
Add GET /health/details returning safe operational metadata.

## Linked issue (recommended)
Closes #303

## Changes
Add GET /health/details returning safe operational metadata.

### Network

- [x] Testnet

