### PR TITLE
feat: idempotent payments, settlement outbox, notifications, offline …

### DIFF
--- a/backend/migrations/012_webhook_event_dedupe.sql
+++ b/backend/migrations/012_webhook_event_dedupe.sql
@@ -1,0 +1,16 @@
+-- Deduplicate payment webhooks by provider event identity (in addition to business ref idempotency).
+-- Same provider_event_id may only be processed once per rail; replays return 200 without side effects.
+
+CREATE TABLE IF NOT EXISTS webhook_event_dedupe (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    rail TEXT NOT NULL,
+    provider_event_id TEXT NOT NULL,
+    payload_hash TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS webhook_event_dedupe_rail_event_uidx
+    ON webhook_event_dedupe (rail, provider_event_id);
+
+CREATE INDEX IF NOT EXISTS webhook_event_dedupe_created_at_idx
+    ON webhook_event_dedupe (created_at);

--- a/backend/migrations/013_api_idempotency.sql
+++ b/backend/migrations/013_api_idempotency.sql
@@ -1,0 +1,22 @@
+-- Durable idempotency for payment initiation and other mutating APIs.
+-- Replays return cached JSON; concurrent duplicate keys get 409 while processing (or reclaim after lease).
+
+CREATE TABLE IF NOT EXISTS api_idempotency (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    scope TEXT NOT NULL,
+    idempotency_key TEXT NOT NULL,
+    request_body_hash TEXT NOT NULL,
+    status TEXT NOT NULL CHECK (status IN ('processing', 'completed', 'failed')),
+    http_status INT,
+    response_body JSONB,
+    processing_started_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    completed_at TIMESTAMPTZ,
+    expires_at TIMESTAMPTZ NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS api_idempotency_scope_key_uidx
+    ON api_idempotency (scope, idempotency_key);
+
+CREATE INDEX IF NOT EXISTS api_idempotency_status_expires_idx
+    ON api_idempotency (status, expires_at);

--- a/backend/migrations/014_settlement_outbox.sql
+++ b/backend/migrations/014_settlement_outbox.sql
@@ -1,0 +1,38 @@
+-- Outbox for rent settlement side effects (receipt, notifications, audit). Emitted in same transaction as schedule updates when a period is marked paid.
+
+CREATE TABLE IF NOT EXISTS settlement_outbox (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    deal_id UUID NOT NULL,
+    period INT NOT NULL,
+    event_type TEXT NOT NULL,
+    idempotency_key TEXT NOT NULL,
+    payload JSONB NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending'
+        CHECK (status IN ('pending', 'processing', 'done', 'failed', 'dead')),
+    attempts INT NOT NULL DEFAULT 0,
+    next_retry_at TIMESTAMPTZ,
+    last_error TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS settlement_outbox_idem_uidx
+    ON settlement_outbox (idempotency_key);
+
+CREATE INDEX IF NOT EXISTS settlement_outbox_pending_idx
+    ON settlement_outbox (status, next_retry_at, created_at);
+
+CREATE TABLE IF NOT EXISTS settlement_outbox_dlq (
+    id UUID PRIMARY KEY,
+    deal_id UUID NOT NULL,
+    period INT NOT NULL,
+    event_type TEXT NOT NULL,
+    idempotency_key TEXT NOT NULL,
+    payload JSONB NOT NULL,
+    last_error TEXT,
+    failed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    replayed_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS settlement_outbox_dlq_deal_idx ON settlement_outbox_dlq (deal_id);

--- a/backend/migrations/015_notifications.sql
+++ b/backend/migrations/015_notifications.sql
@@ -1,0 +1,22 @@
+-- In-app notifications (transaction, listing, application events).
+
+CREATE TABLE IF NOT EXISTS user_notifications (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id TEXT NOT NULL,
+    category TEXT NOT NULL DEFAULT 'general',
+    title TEXT NOT NULL,
+    body TEXT NOT NULL,
+    data JSONB,
+    read_at TIMESTAMPTZ,
+    dedupe_key TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS user_notifications_user_created_idx
+    ON user_notifications (user_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS user_notifications_user_unread_idx
+    ON user_notifications (user_id) WHERE read_at IS NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS user_notifications_dedupe_uidx
+    ON user_notifications (user_id, dedupe_key) WHERE dedupe_key IS NOT NULL;

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -101,6 +101,10 @@ import { createLandlordRouter } from "./routes/landlord.js";
 import { authenticateToken } from "./middleware/auth.js";
 import { createTenantApplicationsRouter } from "./routes/tenantApplications.js";
 import { createTenantPaymentsRouter } from "./routes/tenantPayments.js";
+import { createNotificationsRouter } from "./routes/notifications.js";
+import { createSettlementAdminRouter } from "./routes/settlementAdmin.js";
+import { SettlementOutboxWorker } from "./settlement/worker.js";
+import { durableIdempotencyService } from "./services/durableIdempotencyService.js";
 import {
   PostgresTenantApplicationStore,
   initTenantApplicationStore,
@@ -257,6 +261,31 @@ export function createApp() {
   if (env.NODE_ENV !== "test") {
     jobScheduler.start();
     workers.push(jobScheduler);
+  }
+
+  const settlementOutboxWorker = new SettlementOutboxWorker();
+  if (env.NODE_ENV !== "test") {
+    settlementOutboxWorker.start(
+      parseInt(process.env.SETTLEMENT_OUTBOX_POLL_MS ?? "4000", 10),
+    );
+    workers.push({ stop: () => settlementOutboxWorker.stop() });
+  }
+
+  let idemReaper: ReturnType<typeof setInterval> | null = null;
+  if (env.NODE_ENV !== "test") {
+    const ms = parseInt(process.env.IDEMPOTENCY_RECONCILE_MS ?? "300000", 10);
+    idemReaper = setInterval(() => {
+      void durableIdempotencyService.reconcileStale();
+    }, ms);
+    if (idemReaper.unref) idemReaper.unref();
+    workers.push({
+      stop: async () => {
+        if (idemReaper) {
+          clearInterval(idemReaper);
+          idemReaper = null;
+        }
+      },
+    });
   }
 
   // Tenant Application Store — swap to Postgres when DATABASE_URL is set
@@ -424,6 +453,8 @@ export function createApp() {
   app.use("/api/landlord", authenticateToken, createLandlordRouter());
   app.use("/api/tenant/applications", createTenantApplicationsRouter());
   app.use("/api/tenant/payments", createTenantPaymentsRouter());
+  app.use("/api/notifications", createNotificationsRouter());
+  app.use("/api/admin", createSettlementAdminRouter());
   app.use("/api", migrationGuideRouter);
 
   // Interactive API documentation

--- a/backend/src/middleware/durableIdempotency.ts
+++ b/backend/src/middleware/durableIdempotency.ts
@@ -1,0 +1,78 @@
+import type { Request, Response, NextFunction } from 'express'
+import { durableIdempotencyService } from '../services/durableIdempotencyService.js'
+import { ErrorCode } from '../errors/errorCodes.js'
+import type { ErrorResponse } from '../errors/errorCodes.js'
+
+/**
+ * Durable idempotency (Postgres when DATABASE_URL is set, else in-memory).
+ * Requires `x-idempotency-key`. Replays return cached JSON with `x-idempotent-replay: true`.
+ */
+export function durableIdempotency(
+  getScope: (req: Request) => string | Promise<string>,
+) {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    const raw = req.headers['x-idempotency-key']
+    if (typeof raw !== 'string' || !raw.trim()) {
+      const body: ErrorResponse = {
+        error: {
+          code: ErrorCode.VALIDATION_ERROR,
+          message: 'Missing or empty x-idempotency-key header',
+        },
+      }
+      return res.status(400).json(body)
+    }
+    if (raw.trim().length > 256) {
+      const body: ErrorResponse = {
+        error: {
+          code: ErrorCode.VALIDATION_ERROR,
+          message: 'x-idempotency-key must not exceed 256 characters',
+        },
+      }
+      return res.status(400).json(body)
+    }
+
+    const scope = await Promise.resolve(getScope(req))
+    const h = durableIdempotencyService.payloadHash(req.body)
+    const s = await durableIdempotencyService.start({
+      scope,
+      idempotencyKey: raw,
+      requestBodyHash: h,
+    })
+
+    if (s.type === 'replay') {
+      res.setHeader('x-idempotent-replay', 'true')
+      return res.status(s.httpStatus).json(s.body)
+    }
+    if (s.type === 'conflict') {
+      const body: ErrorResponse = {
+        error: {
+          code: ErrorCode.CONFLICT,
+          message: 'Idempotency key was already used with a different request body',
+        },
+      }
+      return res.status(409).json(body)
+    }
+    if (s.type === 'in_flight') {
+      const body: ErrorResponse = {
+        error: {
+          code: ErrorCode.CONFLICT,
+          message: 'A request with this idempotency key is still being processed',
+        },
+      }
+      return res.status(409).json(body)
+    }
+
+    const idemKey = raw.trim()
+    const origJson = res.json.bind(res)
+    res.json = (b: unknown) => {
+      void durableIdempotencyService.complete({
+        scope,
+        idempotencyKey: idemKey,
+        httpStatus: res.statusCode,
+        body: b,
+      })
+      return origJson(b)
+    }
+    next()
+  }
+}

--- a/backend/src/middleware/index.ts
+++ b/backend/src/middleware/index.ts
@@ -1,6 +1,7 @@
 export { validate } from "./validate.js";
 export { errorHandler } from "./errorHandler.js";
 export { idempotency } from "./idempotency.js";
+export { durableIdempotency } from "./durableIdempotency.js";
 export { apiVersioning } from "./apiVersioning.js";
 export {
 	sanitizeRequest,

--- a/backend/src/models/dealStore.ts
+++ b/backend/src/models/dealStore.ts
@@ -16,6 +16,10 @@ import {
   ScheduleItemStatus,
 } from './deal.js'
 import { generateRepaymentSchedule } from '../utils/scheduleGenerator.js'
+import {
+  enqueueSettlementSideEffectsInTransaction,
+  enqueueSettlementSideEffectsMemory,
+} from '../settlement/enqueueSideEffects.js'
 
 export interface StoredDeal extends Deal {
   schedule: ScheduleItem[]
@@ -168,7 +172,17 @@ class InMemoryDealStore implements DealStorePort {
     const scheduleItem = deal.schedule.find((item) => item.period === period)
     if (!scheduleItem) return null
 
+    const oldStatus = scheduleItem.status
     scheduleItem.status = status
+    if (status === ScheduleItemStatus.PAID && oldStatus !== ScheduleItemStatus.PAID) {
+      enqueueSettlementSideEffectsMemory({
+        dealId,
+        period,
+        tenantId: deal.tenantId,
+        landlordId: deal.landlordId,
+        amountNgn: scheduleItem.amountNgn,
+      })
+    }
 
     return {
       ...deal,
@@ -365,15 +379,58 @@ class PostgresDealStore implements DealStorePort {
     status: ScheduleItemStatus,
   ): Promise<DealWithSchedule | null> {
     const pool = await this.pool()
-    const result = await pool.query(
-      `UPDATE tenant_deal_schedules
-       SET status = $3, updated_at = NOW()
-       WHERE deal_id = $1 AND period = $2`,
-      [dealId, period, status],
-    )
+    const client = await pool.connect()
+    try {
+      await client.query('BEGIN')
+      const { rows: cur } = await client.query(
+        `SELECT status, amount_ngn
+         FROM tenant_deal_schedules
+         WHERE deal_id = $1 AND period = $2
+         FOR UPDATE`,
+        [dealId, period],
+      )
+      if (cur.length === 0) {
+        await client.query('ROLLBACK')
+        return null
+      }
+      const row0 = cur[0] as {
+        status: string
+        amount_ngn: string | number
+      }
+      const oldStatus = row0.status
+      const amountNgn = toNumber(row0.amount_ngn)
+      const { rows: trows } = await client.query(
+        `SELECT tenant_id, landlord_id FROM tenant_deals WHERE deal_id = $1 FOR UPDATE`,
+        [dealId],
+      )
+      if (trows.length === 0) {
+        await client.query('ROLLBACK')
+        return null
+      }
+      const t0 = trows[0] as { tenant_id: string; landlord_id: string }
 
-    if (result.rowCount === 0) {
-      return null
+      await client.query(
+        `UPDATE tenant_deal_schedules
+         SET status = $3, updated_at = NOW()
+         WHERE deal_id = $1 AND period = $2`,
+        [dealId, period, status],
+      )
+
+      if (status === ScheduleItemStatus.PAID && oldStatus !== ScheduleItemStatus.PAID) {
+        await enqueueSettlementSideEffectsInTransaction(client, {
+          dealId,
+          period,
+          tenantId: t0.tenant_id,
+          landlordId: t0.landlord_id,
+          amountNgn,
+        })
+      }
+      await client.query('COMMIT')
+    } catch (e) {
+      await client.query('ROLLBACK')
+      throw e
+    } finally {
+      client.release()
     }
 
     return this.fetchDealWithSchedule(pool, dealId)

--- a/backend/src/models/persistence.test.ts
+++ b/backend/src/models/persistence.test.ts
@@ -15,7 +15,10 @@ import { RewardStatus } from './reward.js'
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 
-const migrationPath = path.resolve(__dirname, '../../migrations/006_deal_listing_reward_store.sql')
+const migrationPaths = [
+  path.resolve(__dirname, '../../migrations/006_deal_listing_reward_store.sql'),
+  path.resolve(__dirname, '../../migrations/014_settlement_outbox.sql'),
+]
 
 function loadMigrations(sql: string) {
   const db = newDb({ autoCreateForeignKeyIndices: true })
@@ -91,7 +94,7 @@ describe('Postgres-backed stores', () => {
     process.env.NODE_ENV = 'test'
     process.env.DATABASE_URL = 'pg-mem://test'
 
-    const sql = readFileSync(migrationPath, 'utf8')
+    const sql = migrationPaths.map((p) => readFileSync(p, 'utf8')).join('\n')
     const db = loadMigrations(sql)
     const { Pool } = db.adapters.createPg()
     pool = new Pool()

--- a/backend/src/models/webhookEventDedupeStore.ts
+++ b/backend/src/models/webhookEventDedupeStore.ts
@@ -1,0 +1,64 @@
+import { getPool } from '../db.js'
+import { logger } from '../utils/logger.js'
+
+class WebhookEventDedupeStore {
+  private memory = new Map<string, { payloadHash: string }>()
+
+  /**
+   * @returns 'new' if this is the first time we see (rail, providerEventId);
+   *          'duplicate' if the event was already recorded (replay).
+   */
+  async tryClaim(input: {
+    rail: string
+    providerEventId: string
+    payloadHash: string
+  }): Promise<'new' | 'duplicate'> {
+    const pool = await getPool()
+    if (!pool) {
+      const k = `${input.rail}:${input.providerEventId}`
+      const existing = this.memory.get(k)
+      if (existing) {
+        if (existing.payloadHash !== input.payloadHash) {
+          logger.warn('Webhook dedupe: same providerEventId with different payload (in-memory)', {
+            rail: input.rail,
+            providerEventId: input.providerEventId,
+          })
+        }
+        return 'duplicate'
+      }
+      this.memory.set(k, { payloadHash: input.payloadHash })
+      return 'new'
+    }
+
+    const { rows } = await pool.query(
+      `INSERT INTO webhook_event_dedupe (rail, provider_event_id, payload_hash)
+       VALUES ($1, $2, $3)
+       ON CONFLICT (rail, provider_event_id) DO NOTHING
+       RETURNING id`,
+      [input.rail, input.providerEventId, input.payloadHash],
+    )
+    if (rows.length > 0) {
+      return 'new'
+    }
+
+    const { rows: prev } = await pool.query(
+      `SELECT payload_hash FROM webhook_event_dedupe
+       WHERE rail = $1 AND provider_event_id = $2`,
+      [input.rail, input.providerEventId],
+    )
+    const ph = (prev[0] as { payload_hash: string } | undefined)?.payload_hash
+    if (ph && ph !== input.payloadHash) {
+      logger.warn('Webhook dedupe: same providerEventId with different payload (postgres)', {
+        rail: input.rail,
+        providerEventId: input.providerEventId,
+      })
+    }
+    return 'duplicate'
+  }
+
+  clear(): void {
+    this.memory.clear()
+  }
+}
+
+export const webhookEventDedupeStore = new WebhookEventDedupeStore()

--- a/backend/src/payments/flutterwaveProvider.ts
+++ b/backend/src/payments/flutterwaveProvider.ts
@@ -12,6 +12,7 @@
  *   FLUTTERWAVE_SECRET      — shared with the signature validator in webhookSignature.ts
  */
 
+import { createHash } from 'node:crypto'
 import type { Request } from 'express'
 import { AppError } from '../errors/AppError.js'
 import { ErrorCode } from '../errors/errorCodes.js'
@@ -195,8 +196,10 @@ export class FlutterwaveProvider implements PaymentProvider {
     requireValidWebhookSignature(req, 'flutterwave')
 
     const body = req.body as {
+      id?: string | number
       event?: string
       data?: {
+        id?: string | number
         tx_ref?: string
         reference?: string
         status?: string
@@ -214,11 +217,19 @@ export class FlutterwaveProvider implements PaymentProvider {
       )
     }
 
+    const providerEventId =
+      body.data?.id != null
+        ? String(body.data.id)
+        : body.id != null
+          ? String(body.id)
+          : createHash('sha256').update(`${event}:${txRef}`).digest('hex')
+
     return {
       externalRefSource: 'flutterwave',
       externalRef: txRef,
       rawStatus: event,
       providerStatus: body.data?.status,
+      providerEventId,
     }
   }
 

--- a/backend/src/payments/paystackProvider.test.ts
+++ b/backend/src/payments/paystackProvider.test.ts
@@ -258,6 +258,20 @@ describe('PaystackProvider', () => {
       expect(result.externalRef).toBe('ref-pay-001')
       expect(result.rawStatus).toBe('charge.success')
       expect(result.providerStatus).toBe('success')
+      expect(result.providerEventId).toMatch(/^[a-f0-9]{64}$/) // hash when root id omitted
+    })
+
+    it('uses root id as providerEventId when present', async () => {
+      const body = {
+        id: 99_000_000,
+        event: 'charge.success',
+        data: { reference: 'ref-pay-ida', status: 'success' },
+      }
+      const rawBody = JSON.stringify(body)
+      const sig = paystackHmac('webhook_secret', rawBody)
+      const req = makeReq({ 'x-paystack-signature': sig }, body, rawBody)
+      const result = await provider.parseAndValidateWebhook(req)
+      expect(result.providerEventId).toBe('99000000')
     })
 
     it('parses a valid charge.failed webhook', async () => {

--- a/backend/src/payments/paystackProvider.ts
+++ b/backend/src/payments/paystackProvider.ts
@@ -11,6 +11,7 @@
  *   PAYSTACK_SECRET      — shared with the signature validator in webhookSignature.ts
  */
 
+import { createHash } from 'node:crypto'
 import type { Request } from 'express'
 import { AppError } from '../errors/AppError.js'
 import { ErrorCode } from '../errors/errorCodes.js'
@@ -188,6 +189,7 @@ export class PaystackProvider implements PaymentProvider {
     requireValidWebhookSignature(req, 'paystack')
 
     const body = req.body as {
+      id?: string | number
       event?: string
       data?: {
         reference?: string
@@ -207,12 +209,19 @@ export class PaystackProvider implements PaymentProvider {
       )
     }
 
+    // Paystack may include a root `id` for the webhook; otherwise hash event + reference
+    const providerEventId =
+      body.id != null
+        ? String(body.id)
+        : createHash('sha256').update(`${event}:${reference}`).digest('hex')
+
     // rawStatus is the event name; providerStatus carries the transaction status
     return {
       externalRefSource: 'paystack',
       externalRef: reference,
       rawStatus: event,
       providerStatus: body.data?.status,
+      providerEventId,
     }
   }
 

--- a/backend/src/payments/stubPspProvider.ts
+++ b/backend/src/payments/stubPspProvider.ts
@@ -49,17 +49,25 @@ export class StubPspProvider implements PaymentProvider {
       externalRef?: string
       status?: string
       providerStatus?: string
+      /** Optional — tests can set to simulate distinct PSP deliveries for the same ref. */
+      providerEventId?: string
     }
 
     if (!body.externalRefSource || !body.externalRef || !body.status) {
       throw new AppError(ErrorCode.VALIDATION_ERROR, 400, 'Invalid webhook payload')
     }
 
+    const providerEventId =
+      body.providerEventId != null && String(body.providerEventId).trim() !== ''
+        ? String(body.providerEventId)
+        : `stub:${body.externalRef}:${body.status}`
+
     return {
       externalRefSource: body.externalRefSource,
       externalRef: body.externalRef,
       rawStatus: body.status,
       providerStatus: body.providerStatus,
+      providerEventId,
     }
   }
 

--- a/backend/src/payments/types.ts
+++ b/backend/src/payments/types.ts
@@ -26,6 +26,11 @@ export interface ParseWebhookResult {
   externalRef: string
   rawStatus: string
   providerStatus?: string
+  /**
+   * Stable per-delivery id from the PSP (or a deterministic hash when the PSP omits one).
+   * Used for deduping replays in addition to business-reference idempotency.
+   */
+  providerEventId: string
 }
 
 export interface MapStatusInput {

--- a/backend/src/routes/ngnWallet.test.ts
+++ b/backend/src/routes/ngnWallet.test.ts
@@ -5,6 +5,7 @@ import request from 'supertest'
 import express from 'express'
 import { sessionStore, userStore } from '../models/authStore.js'
 import { ngnDepositStore } from '../models/ngnDepositStore.js'
+import { _resetDurableIdempotencyMemory } from '../services/durableIdempotencyService.js'
 
 describe('NGN Wallet Routes', () => {
   let ngnWalletService: NgnWalletService
@@ -13,6 +14,7 @@ describe('NGN Wallet Routes', () => {
   let userId: string
 
   beforeEach(async () => {
+    _resetDurableIdempotencyMemory()
     ngnWalletService = new NgnWalletService()
     
     // Seed an authenticated user session for tests
@@ -131,6 +133,7 @@ describe('NGN Wallet Routes', () => {
       const response = await request(app)
         .post('/api/wallet/ngn/topup/initiate')
         .set('Authorization', `Bearer ${token}`)
+        .set('x-idempotency-key', '9a1b2c3d-4e5f-6789-abcd-ef0123456789')
         .send({ amountNgn: 1500, rail: 'paystack' })
         .expect(201)
 
@@ -156,7 +159,8 @@ describe('NGN Wallet Routes', () => {
         .set('Authorization', `Bearer ${token}`)
         .set('x-idempotency-key', key)
         .send({ amountNgn: 1500, rail: 'paystack' })
-        .expect(200)
+        .expect(201)
+      expect(second.headers['x-idempotent-replay']).toBe('true')
 
       expect(second.body.depositId).toBe(first.body.depositId)
       expect(second.body.externalRef).toBe(first.body.externalRef)

--- a/backend/src/routes/ngnWallet.ts
+++ b/backend/src/routes/ngnWallet.ts
@@ -13,9 +13,9 @@ import { AppError } from '../errors/AppError.js'
 import { ErrorCode } from '../errors/errorCodes.js'
 import { authenticateToken, type AuthenticatedRequest } from '../middleware/auth.js'
 import { requireNotFrozen } from '../middleware/risk.js'
-import { ngnTopupInitiateSchema, ngnTopupInitiateResponseSchema, type NgnTopupInitiateRequest } from '../schemas/ngnTopup.js'
-import { ngnDepositStore } from '../models/ngnDepositStore.js'
-import { getPaymentProvider } from '../payments/index.js'
+import { ngnTopupInitiateSchema, type NgnTopupInitiateRequest } from '../schemas/ngnTopup.js'
+import { durableIdempotency } from '../middleware/durableIdempotency.js'
+import { initiateNgnTopup } from '../services/ngnTopupInitiateService.js'
 
 export function createNgnWalletRouter(ngnWalletService: NgnWalletService): Router {
   const router = Router()
@@ -174,6 +174,7 @@ export function createNgnWalletRouter(ngnWalletService: NgnWalletService): Route
     '/topup/initiate',
     authenticateToken,
     validate(ngnTopupInitiateSchema, 'body'),
+    durableIdempotency((req) => `user:${(req as AuthenticatedRequest).user!.id}:ngn-topup`),
     async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
       try {
         const userId = req.user!.id
@@ -181,84 +182,13 @@ export function createNgnWalletRouter(ngnWalletService: NgnWalletService): Route
         const idempotencyKeyRaw = req.header('x-idempotency-key')
         const idempotencyKey = typeof idempotencyKeyRaw === 'string' && idempotencyKeyRaw.trim() !== '' ? idempotencyKeyRaw.trim() : null
 
-        if (idempotencyKey) {
-          const existing = await ngnDepositStore.getByUserIdAndIdempotencyKey(userId, idempotencyKey)
-          if (existing) {
-            if (!existing.externalRefSource || !existing.externalRef) {
-              throw new AppError(ErrorCode.CONFLICT, 409, 'Deposit initiation is in progress')
-            }
-            const response = {
-              success: true,
-              depositId: existing.depositId,
-              externalRefSource: existing.externalRefSource,
-              externalRef: existing.externalRef,
-              ...(existing.redirectUrl ? { redirectUrl: existing.redirectUrl } : {}),
-              ...(existing.bankDetails ? { bankDetails: existing.bankDetails } : {}),
-            }
-            res.status(200).json(ngnTopupInitiateResponseSchema.parse(response))
-            return
-          }
-        }
-
-        const deposit = await ngnDepositStore.create({
+        const { status, body: out } = await initiateNgnTopup({
           userId,
-          amountNgn: body.amountNgn,
-          rail: body.rail,
+          body,
           idempotencyKey,
-        })
-
-        let externalRefSource: string
-        let externalRef: string
-        let redirectUrl: string | undefined
-        let bankDetails: Record<string, string> | undefined
-
-        if (body.rail === 'bank_transfer') {
-          externalRefSource = 'bank'
-          externalRef = `bnk_${deposit.depositId}`
-          bankDetails = { accountNumber: '1234567890', bankName: 'Example Bank' }
-        } else {
-          const provider = getPaymentProvider(body.rail)
-          const init = await provider.initiatePayment({
-            amountNgn: body.amountNgn,
-            userId,
-            internalRef: deposit.depositId,
-            rail: body.rail,
-          })
-          externalRefSource = init.externalRefSource
-          externalRef = init.externalRef
-          redirectUrl = init.redirectUrl
-          if (init.bankDetails) {
-            bankDetails = init.bankDetails
-          }
-        }
-
-        await ngnDepositStore.attachExternalRef({
-          depositId: deposit.depositId,
-          externalRefSource,
-          externalRef,
-          redirectUrl: redirectUrl ?? null,
-          bankDetails: bankDetails ?? null,
-        })
-
-        await ngnWalletService.recordTopUpPending(deposit.depositId, body.amountNgn, externalRef)
-
-        logger.info('NGN topup initiated', {
-          userId,
-          depositId: deposit.depositId,
-          rail: body.rail,
           requestId: req.requestId,
         })
-
-        const response = {
-          success: true,
-          depositId: deposit.depositId,
-          externalRefSource,
-          externalRef,
-          ...(redirectUrl ? { redirectUrl } : {}),
-          ...(bankDetails ? { bankDetails } : {}),
-        }
-
-        res.status(201).json(ngnTopupInitiateResponseSchema.parse(response))
+        res.status(status).json(out)
       } catch (error) {
         if (error instanceof AppError) {
           res.status(error.status).json({ error: { code: error.code, message: error.message } })

--- a/backend/src/routes/notifications.ts
+++ b/backend/src/routes/notifications.ts
@@ -1,0 +1,265 @@
+import { Router, type Request, type Response, type NextFunction } from 'express'
+import { getPool } from '../db.js'
+import { env } from '../schemas/env.js'
+import { AppError } from '../errors/AppError.js'
+import { ErrorCode } from '../errors/errorCodes.js'
+import { authenticateToken, type AuthenticatedRequest } from '../middleware/auth.js'
+import { notificationService, _getNotificationMemory } from '../services/notificationService.js'
+import { z } from 'zod'
+
+function requireAdmin(req: Request) {
+  const headerSecret = req.headers['x-admin-secret']
+  if (env.MANUAL_ADMIN_SECRET && headerSecret !== env.MANUAL_ADMIN_SECRET) {
+    throw new AppError(ErrorCode.FORBIDDEN, 403, 'Invalid admin secret')
+  }
+}
+
+export function createNotificationsRouter() {
+  const r = Router()
+
+  r.get(
+    '/unread-count',
+    authenticateToken,
+    async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
+      try {
+        const userId = req.user!.id
+        const pool = await getPool()
+        if (!pool) {
+          const n = _getNotificationMemory().filter((m) => m.userId === userId && !m.readAt)
+            .length
+          return res.json({ success: true, data: { unread: n } })
+        }
+        const { rows } = await pool.query(
+          `SELECT count(*)::int AS c FROM user_notifications WHERE user_id = $1 AND read_at IS NULL`,
+          [userId],
+        )
+        return res.json({ success: true, data: { unread: rows[0].c } })
+      } catch (e) {
+        next(e)
+      }
+    },
+  )
+
+  /**
+   * GET /api/notifications — keyset cursor: pass `cursor` = base64url(JSON.stringify({ t: ISO, id })) from `nextCursor`.
+   * First page: omit `cursor`. Page size: `limit` (default 20, max 100).
+   */
+  r.get(
+    '/',
+    authenticateToken,
+    async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
+      try {
+        const userId = req.user!.id
+        const limit = Math.min(100, Math.max(1, parseInt(String(req.query.limit ?? '20'), 10) || 20))
+        const curRaw = typeof req.query.cursor === 'string' ? req.query.cursor : null
+        let tBound: string | null = null
+        let idBound: string | null = null
+        if (curRaw) {
+          try {
+            const s = JSON.parse(Buffer.from(curRaw, 'base64url').toString('utf8')) as { t: string; id: string }
+            tBound = s.t
+            idBound = s.id
+          } catch {
+            throw new AppError(ErrorCode.VALIDATION_ERROR, 400, 'Invalid cursor')
+          }
+        }
+
+        const pool = await getPool()
+        if (!pool) {
+          let items = _getNotificationMemory()
+            .filter((n) => n.userId === userId)
+            .sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1))
+          if (tBound && idBound) {
+            items = items.filter((i) => i.createdAt < tBound || (i.createdAt === tBound && i.id < idBound))
+          }
+          const page = items.slice(0, limit)
+          const last = page[page.length - 1]
+          const nextCur =
+            last
+              ? Buffer.from(JSON.stringify({ t: last.createdAt, id: last.id }), 'utf8').toString('base64url')
+              : null
+          return res.json({
+            success: true,
+            data: {
+              items: page.map((i) => ({
+                id: i.id,
+                category: i.category,
+                title: i.title,
+                body: i.body,
+                data: i.data,
+                read: !!i.readAt,
+                createdAt: i.createdAt,
+              })),
+              nextCursor: nextCur,
+            },
+          })
+        }
+
+        const take = limit + 1
+        const params: unknown[] = [userId, take]
+        let sql = `SELECT id, category, title, body, data, read_at, created_at
+          FROM user_notifications
+          WHERE user_id = $1`
+        if (tBound && idBound) {
+          params.push(tBound, idBound)
+          sql += ` AND (created_at, id) < ($3::timestamptz, $4::uuid)`
+        }
+        sql += ` ORDER BY created_at DESC, id DESC LIMIT $2`
+        const { rows } = await pool.query(sql, params)
+        const hasMore = rows.length > take - 1
+        const outRows = (hasMore ? rows.slice(0, limit) : rows) as {
+          id: string
+          category: string
+          title: string
+          body: string
+          data: unknown
+          read_at: string | null
+          created_at: string
+        }[]
+        const last = outRows[outRows.length - 1]
+        res.json({
+          success: true,
+          data: {
+            items: outRows.map((row) => ({
+              id: row.id,
+              category: row.category,
+              title: row.title,
+              body: row.body,
+              data: row.data,
+              read: row.read_at != null,
+              createdAt: new Date(row.created_at).toISOString(),
+            })),
+            nextCursor: hasMore && last
+              ? Buffer.from(
+                  JSON.stringify({ t: new Date(last.created_at).toISOString(), id: last.id }),
+                  'utf8',
+                ).toString('base64url')
+              : null,
+          },
+        })
+      } catch (e) {
+        next(e)
+      }
+    },
+  )
+
+  r.post(
+    '/:id/read',
+    authenticateToken,
+    async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
+      try {
+        const userId = req.user!.id
+        const { id } = req.params
+        const pool = await getPool()
+        if (!pool) {
+          const n = _getNotificationMemory().find((m) => m.id === id && m.userId === userId)
+          if (n && !n.readAt) n.readAt = new Date().toISOString()
+          return res.json({ success: true })
+        }
+        await pool.query(
+          `UPDATE user_notifications SET read_at = COALESCE(read_at, NOW()) WHERE id = $1 AND user_id = $2`,
+          [id, userId],
+        )
+        res.json({ success: true })
+      } catch (e) {
+        next(e)
+      }
+    },
+  )
+
+  r.post(
+    '/read-all',
+    authenticateToken,
+    async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
+      try {
+        const userId = req.user!.id
+        const pool = await getPool()
+        if (!pool) {
+          for (const n of _getNotificationMemory()) {
+            if (n.userId === userId && !n.readAt) n.readAt = new Date().toISOString()
+          }
+          return res.json({ success: true, marked: true })
+        }
+        await pool.query(
+          `UPDATE user_notifications SET read_at = COALESCE(read_at, NOW()) WHERE user_id = $1 AND read_at IS NULL`,
+          [userId],
+        )
+        res.json({ success: true })
+      } catch (e) {
+        next(e)
+      }
+    },
+  )
+
+  /** Server-Sent Events: periodic unread count + backfill signal for reconnects. */
+  r.get(
+    '/stream',
+    authenticateToken,
+    async (req: AuthenticatedRequest, res: Response) => {
+      const userId = req.user!.id
+      res.setHeader('Content-Type', 'text/event-stream; charset=utf-8')
+      res.setHeader('Cache-Control', 'no-cache, no-transform')
+      res.setHeader('Connection', 'keep-alive')
+      res.setHeader('X-Accel-Buffering', 'no')
+      res.flushHeaders()
+
+      const writeEvent = (event: string, data: unknown) => {
+        res.write(`event: ${event}\n`)
+        res.write(`data: ${JSON.stringify(data)}\n\n`)
+      }
+
+      const send = async () => {
+        const pool = await getPool()
+        if (!pool) {
+          const unread = _getNotificationMemory().filter((m) => m.userId === userId && !m.readAt)
+            .length
+          writeEvent('snapshot', { unread, ts: new Date().toISOString() })
+          return
+        }
+        const { rows } = await pool.query(`SELECT count(*)::int AS c FROM user_notifications WHERE user_id = $1 AND read_at IS NULL`, [
+          userId,
+        ])
+        writeEvent('snapshot', { unread: rows[0].c, ts: new Date().toISOString() })
+      }
+      void send()
+      const t = setInterval(() => {
+        void send()
+      }, 5000)
+      if (t.unref) t.unref()
+      req.on('close', () => {
+        clearInterval(t)
+        res.end()
+      })
+    },
+  )
+
+  const seedSchema = z.object({
+    userId: z.string(),
+    title: z.string(),
+    body: z.string(),
+    category: z.string().optional(),
+  })
+
+  r.post(
+    '/test-seed',
+    async (req, res, next) => {
+      try {
+        requireAdmin(req)
+        if (env.NODE_ENV === 'production' && !process.env.ALLOW_NOTIFICATION_TEST_SEED) {
+          throw new AppError(ErrorCode.FORBIDDEN, 403, 'Disabled')
+        }
+        const p = seedSchema.parse(req.body)
+        const id = await notificationService.create(p.userId, {
+          title: p.title,
+          body: p.body,
+          category: p.category ?? 'general',
+        })
+        res.json({ success: true, id })
+      } catch (e) {
+        next(e)
+      }
+    },
+  )
+
+  return r
+}

--- a/backend/src/routes/settlementAdmin.ts
+++ b/backend/src/routes/settlementAdmin.ts
@@ -1,0 +1,101 @@
+import { Router, type Request, type Response, type NextFunction } from 'express'
+import { getPool } from '../db.js'
+import { env } from '../schemas/env.js'
+import { AppError } from '../errors/AppError.js'
+import { ErrorCode } from '../errors/errorCodes.js'
+import { generateId } from '../utils/tokens.js'
+import { logger } from '../utils/logger.js'
+
+function requireAdmin(req: Request) {
+  const headerSecret = req.headers['x-admin-secret']
+  if (env.MANUAL_ADMIN_SECRET && headerSecret !== env.MANUAL_ADMIN_SECRET) {
+    throw new AppError(ErrorCode.FORBIDDEN, 403, 'Invalid admin secret')
+  }
+}
+
+/**
+ * Admin tools for dead-letter queue replay (settlement outbox).
+ * POST /api/admin/settlement-dlq/:id/replay — requeues a row from `settlement_outbox_dlq` into `settlement_outbox`.
+ */
+export function createSettlementAdminRouter() {
+  const r = Router()
+
+  r.post(
+    '/settlement-dlq/:id/replay',
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        requireAdmin(req)
+        const pool = await getPool()
+        if (!pool) {
+          return res.status(501).json({ error: { message: 'Database required for DLQ replay' } })
+        }
+        const id = String(req.params.id)
+        const { rows } = await pool.query(
+          `SELECT * FROM settlement_outbox_dlq WHERE id = $1`,
+          [id],
+        )
+        if (rows.length === 0) {
+          throw new AppError(ErrorCode.NOT_FOUND, 404, 'DLQ entry not found')
+        }
+        const row = rows[0] as {
+          deal_id: string
+          period: number
+          event_type: string
+          idempotency_key: string
+          payload: unknown
+        }
+        const newId = generateId()
+        const payload = typeof row.payload === 'string' ? row.payload : JSON.stringify(row.payload)
+        try {
+          await pool.query(
+            `INSERT INTO settlement_outbox (id, deal_id, period, event_type, idempotency_key, payload, status, attempts, next_retry_at, last_error)
+             VALUES ($1, $2, $3, $4, $5, $6::jsonb, 'pending', 0, NULL, NULL)`,
+            [newId, row.deal_id, row.period, row.event_type, row.idempotency_key, payload],
+          )
+        } catch (e: unknown) {
+          const err = e as { code?: string }
+          if (err.code === '23505') {
+            await pool.query(
+              `UPDATE settlement_outbox
+               SET status = 'pending', attempts = 0, next_retry_at = NULL, last_error = NULL, updated_at = NOW()
+               WHERE idempotency_key = $1`,
+              [row.idempotency_key],
+            )
+          } else {
+            throw e
+          }
+        }
+        await pool.query(
+          `UPDATE settlement_outbox_dlq SET replayed_at = NOW() WHERE id = $1`,
+          [id],
+        )
+        logger.info('DLQ entry replayed to settlement outbox', { oldId: id, newId })
+        res.json({ success: true, newOutboxId: newId })
+      } catch (e) {
+        next(e)
+      }
+    },
+  )
+
+  r.get(
+    '/settlement-dlq',
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        requireAdmin(req)
+        const pool = await getPool()
+        if (!pool) {
+          return res.json({ items: [] })
+        }
+        const { rows } = await pool.query(
+          `SELECT id, deal_id, period, event_type, idempotency_key, last_error, failed_at, replayed_at
+           FROM settlement_outbox_dlq ORDER BY failed_at DESC LIMIT 100`,
+        )
+        res.json({ success: true, data: { items: rows } })
+      } catch (e) {
+        next(e)
+      }
+    },
+  )
+
+  return r
+}

--- a/backend/src/routes/tenantPayments.ts
+++ b/backend/src/routes/tenantPayments.ts
@@ -1,39 +1,33 @@
 /**
  * Tenant Payments Routes
- * Handles tenant payment schedules, history, and wallet operations
+ * Uses durable idempotency for quick-pay and wallet top-up initiation.
  */
 
-import { Router, Request, Response } from "express";
-import { authenticateToken } from "../middleware/auth.js";
+import { Router, type Response } from "express";
+import { z } from "zod";
+import { authenticateToken, type AuthenticatedRequest } from "../middleware/auth.js";
 import { AppError } from "../errors/AppError.js";
 import { ErrorCode } from "../errors/errorCodes.js";
 import { NgnWalletService } from "../services/ngnWalletService.js";
-import { z } from "zod";
+import { durableIdempotency } from "../middleware/durableIdempotency.js";
+import { validate } from "../middleware/validate.js";
+import { ngnTopupInitiateSchema, ngnTopupInitiateResponseSchema } from "../schemas/ngnTopup.js";
+import type { NgnTopupInitiateRequest } from "../schemas/ngnTopup.js";
+import { initiateNgnTopup } from "../services/ngnTopupInitiateService.js";
+import { generateId } from "../utils/tokens.js";
 
 const router = Router();
 const ngnWalletService = new NgnWalletService();
 
-/**
- * GET /api/tenant/payments/schedule
- * Get payment schedule for authenticated tenant
- *
- * @authenticated
- */
 router.get(
   "/schedule",
   authenticateToken,
-  async (req: Request, res: Response, next) => {
+  async (req: AuthenticatedRequest, res: Response, next) => {
     try {
-      const userId = (req as any).user?.userId;
+      const userId = req.user?.id;
       if (!userId) {
-        throw new AppError(
-          ErrorCode.UNAUTHORIZED,
-          401,
-          "User not authenticated",
-        );
+        throw new AppError(ErrorCode.UNAUTHORIZED, 401, "User not authenticated");
       }
-
-      // Return empty schedule for now - to be implemented with real deal data
       res.json({
         success: true,
         data: {
@@ -47,27 +41,14 @@ router.get(
   },
 );
 
-/**
- * GET /api/tenant/payments/history
- * Get payment history for authenticated tenant
- *
- * @authenticated
- */
 router.get(
   "/history",
   authenticateToken,
-  async (req: Request, res: Response, next) => {
+  async (req: AuthenticatedRequest, res: Response, next) => {
     try {
-      const userId = (req as any).user?.userId;
-      if (!userId) {
-        throw new AppError(
-          ErrorCode.UNAUTHORIZED,
-          401,
-          "User not authenticated",
-        );
+      if (!req.user?.id) {
+        throw new AppError(ErrorCode.UNAUTHORIZED, 401, "User not authenticated");
       }
-
-      // Return empty history for now
       res.json({
         success: true,
         data: {
@@ -80,28 +61,16 @@ router.get(
   },
 );
 
-/**
- * GET /api/tenant/payments/wallet
- * Get wallet balance for authenticated tenant
- *
- * @authenticated
- */
 router.get(
   "/wallet",
   authenticateToken,
-  async (req: Request, res: Response, next) => {
+  async (req: AuthenticatedRequest, res: Response, next) => {
     try {
-      const userId = (req as any).user?.userId;
+      const userId = req.user?.id;
       if (!userId) {
-        throw new AppError(
-          ErrorCode.UNAUTHORIZED,
-          401,
-          "User not authenticated",
-        );
+        throw new AppError(ErrorCode.UNAUTHORIZED, 401, "User not authenticated");
       }
-
       const balance = await ngnWalletService.getBalance(userId);
-
       res.json({
         success: true,
         data: {
@@ -119,12 +88,6 @@ router.get(
   },
 );
 
-/**
- * POST /api/tenant/payments/quick-pay
- * Initiate a quick payment from wallet or card
- *
- * @authenticated
- */
 const quickPaySchema = z.object({
   dealId: z.string().describe("Deal ID to pay for"),
   amount: z.number().positive().describe("Amount to pay in NGN"),
@@ -134,89 +97,82 @@ const quickPaySchema = z.object({
 router.post(
   "/quick-pay",
   authenticateToken,
-  async (req: Request, res: Response, next) => {
+  durableIdempotency((req) => `tenant:${(req as AuthenticatedRequest).user!.id}:quick-pay`),
+  async (req: AuthenticatedRequest, res: Response, next) => {
     try {
-      const userId = (req as any).user?.userId;
+      const userId = req.user?.id;
       if (!userId) {
-        throw new AppError(
-          ErrorCode.UNAUTHORIZED,
-          401,
-          "User not authenticated",
-        );
+        throw new AppError(ErrorCode.UNAUTHORIZED, 401, "User not authenticated");
       }
-
-      const validatedData = quickPaySchema.parse(req.body);
-
-      // Return pending status for now
+      const validated = quickPaySchema.parse(req.body);
+      const paymentId = generateId();
       res.json({
         success: true,
         data: {
-          paymentId: `PAY-${Date.now()}`,
-          status: "pending",
-          amount: validatedData.amount,
-          method: validatedData.paymentMethod,
+          paymentId,
+          status: "pending" as const,
+          amount: validated.amount,
+          method: validated.paymentMethod,
+          dealId: validated.dealId,
           message: "Payment initiated",
         },
       });
     } catch (error) {
       if (error instanceof Error && error.name === "ZodError") {
-        return next(
-          new AppError(ErrorCode.VALIDATION_ERROR, 400, error.message),
-        );
+        return next(new AppError(ErrorCode.VALIDATION_ERROR, 400, error.message));
       }
       next(error);
     }
   },
 );
 
-/**
- * POST /api/tenant/payments/wallet/topup
- * Initiate wallet top-up
- *
- * @authenticated
- */
-const topUpSchema = z.object({
-  amount: z.number().positive().min(1000).describe("Amount to top up in NGN"),
-  paymentMethod: z
-    .enum(["card", "bank_transfer"])
-    .default("card")
-    .describe("Top-up method"),
-});
+const topUpBodySchema = z
+  .object({
+    amount: z.number().positive().min(1000).describe("Amount to top up in NGN"),
+    paymentMethod: z.enum(["card", "bank_transfer"]).default("card").describe("Top-up method"),
+  })
+  .transform(
+    (v): NgnTopupInitiateRequest => ({
+      amountNgn: v.amount,
+      rail: v.paymentMethod === "bank_transfer" ? "bank_transfer" : "paystack",
+    }),
+  );
 
 router.post(
   "/wallet/topup",
   authenticateToken,
-  async (req: Request, res: Response, next) => {
+  validate(topUpBodySchema, "body"),
+  durableIdempotency((req) => `tenant:${(req as AuthenticatedRequest).user!.id}:wallet-topup`),
+  async (req: AuthenticatedRequest, res: Response, next) => {
     try {
-      const userId = (req as any).user?.userId;
+      const userId = req.user?.id;
       if (!userId) {
+        throw new AppError(ErrorCode.UNAUTHORIZED, 401, "User not authenticated");
+      }
+      const body = req.body as NgnTopupInitiateRequest;
+      const idempotencyKeyRaw = req.header("x-idempotency-key");
+      const idempotencyKey =
+        typeof idempotencyKeyRaw === "string" && idempotencyKeyRaw.trim() !== ""
+          ? idempotencyKeyRaw.trim()
+          : null;
+      if (!idempotencyKey) {
         throw new AppError(
-          ErrorCode.UNAUTHORIZED,
-          401,
-          "User not authenticated",
+          ErrorCode.VALIDATION_ERROR,
+          400,
+          "Missing x-idempotency-key for top-up (required with durable idempotency)",
         );
       }
-
-      const validatedData = topUpSchema.parse(req.body);
-
-      // Return mock response for now - to be implemented with real NGN wallet integration
-      res.json({
-        success: true,
-        data: {
-          topUpId: `TOPUP-${Date.now()}`,
-          amount: validatedData.amount,
-          status: "pending",
-          reference: `REF-${Date.now()}`,
-          redirectUrl: null,
-          bankTransfer: null,
-          expiresAt: null,
-        },
+      const ngnBody = ngnTopupInitiateSchema.parse(body);
+      const { status, body: out } = await initiateNgnTopup({
+        userId,
+        body: ngnBody,
+        idempotencyKey,
+        requestId: req.requestId,
       });
+      res.status(status).json(ngnTopupInitiateResponseSchema.parse(out));
     } catch (error) {
-      if (error instanceof Error && error.name === "ZodError") {
-        return next(
-          new AppError(ErrorCode.VALIDATION_ERROR, 400, error.message),
-        );
+      if (error instanceof AppError) {
+        return res.status(error.status).json({ error: { code: error.code, message: error.message } });
       }
       next(error);
     }

--- a/backend/src/routes/webhooks.test.ts
+++ b/backend/src/routes/webhooks.test.ts
@@ -3,7 +3,9 @@ import request from 'supertest'
 import { createApp } from '../app.js'
 import { depositStore } from '../models/depositStore.js'
 import { outboxStore } from '../outbox/store.js'
+import { TxType } from '../outbox/types.js'
 import { quoteStore } from '../models/quoteStore.js'
+import { webhookEventDedupeStore } from '../models/webhookEventDedupeStore.js'
 import { NgnWalletService } from '../services/ngnWalletService.js'
 
 describe('Payments webhook', () => {
@@ -13,6 +15,7 @@ describe('Payments webhook', () => {
     await depositStore.clear()
     await outboxStore.clear()
     await quoteStore.clear()
+    webhookEventDedupeStore.clear()
     delete process.env.WEBHOOK_SIGNATURE_ENABLED
     delete process.env.WEBHOOK_SECRET
     delete process.env.PAYSTACK_SECRET
@@ -25,7 +28,7 @@ describe('Payments webhook', () => {
     await outboxStore.clear()
   })
 
-  it('is idempotent on replay (rail, externalRef)', async () => {
+  it('is idempotent on replay (rail, externalRef) and second delivery is provider-event deduped', async () => {
     const quote = await quoteStore.create({
       userId: 'user-001',
       amountNgn: 160000,
@@ -50,12 +53,22 @@ describe('Payments webhook', () => {
       status: 'confirmed',
     }
 
-    await request(app).post('/api/webhooks/payments/paystack').send(payload).expect(200)
-    await request(app).post('/api/webhooks/payments/paystack').send(payload).expect(200)
+    const r1 = await request(app)
+      .post('/api/webhooks/payments/paystack')
+      .send(payload)
+      .expect(200)
+    expect(r1.body.deduped).toBeFalsy()
+    const r2 = await request(app)
+      .post('/api/webhooks/payments/paystack')
+      .send(payload)
+      .expect(200)
+    expect(r2.body.deduped).toBe(true)
+    expect(r2.body.success).toBe(true)
 
     const items = await outboxStore.listAll(10)
-    expect(items.length).toBe(1)
-    expect(items[0].payload.txType).toBe('stake')
+    const stakeOutbox = items.filter((i) => i.txType === TxType.STAKE)
+    expect(stakeOutbox.length).toBe(1)
+    expect(stakeOutbox[0].payload.txType).toBe('stake')
   })
 
   it('rejects invalid signature when enabled', async () => {

--- a/backend/src/routes/webhooks.ts
+++ b/backend/src/routes/webhooks.ts
@@ -9,7 +9,9 @@ import { paymentsWebhookSchema } from "../schemas/deposit.js";
 import { depositReversalWebhookSchema } from "../schemas/risk.js";
 import { depositStore } from "../models/depositStore.js";
 import { ngnDepositStore } from "../models/ngnDepositStore.js";
+import { webhookEventDedupeStore } from "../models/webhookEventDedupeStore.js";
 import { logger } from "../utils/logger.js";
+import { recordKPI } from "../utils/appMetrics.js";
 import { AppError } from "../errors/AppError.js";
 import { ErrorCode } from "../errors/errorCodes.js";
 import { outboxStore, OutboxSender, TxType } from "../outbox/index.js";
@@ -18,6 +20,7 @@ import { getSorobanConfigFromEnv } from "../soroban/client.js";
 import { NgnWalletService } from "../services/ngnWalletService.js";
 import { getPaymentProvider } from "../payments/index.js";
 import { requireValidWebhookSignature } from "../payments/webhookSignature.js";
+import { jsonPayloadSha256Hex } from "../utils/sha256.js";
 
 export function createWebhooksRouter(ngnWalletService: NgnWalletService) {
   const router = Router();
@@ -52,6 +55,25 @@ export function createWebhooksRouter(ngnWalletService: NgnWalletService) {
         // Validate rail matches externalRefSource
         if (externalRefSource !== rail) {
           throw new AppError(ErrorCode.VALIDATION_ERROR, 400, "Rail mismatch");
+        }
+
+        // Persisted idempotency on provider event id (after signature validation) — replays short-circuit here.
+        const payloadHash = jsonPayloadSha256Hex(req.body);
+        const claim = await webhookEventDedupeStore.tryClaim({
+          rail,
+          providerEventId: parsed.providerEventId,
+          payloadHash,
+        });
+        if (claim === "duplicate") {
+          recordKPI("webhookEventDeduped");
+          logger.info("Webhook event deduplicated (provider event id)", {
+            rail,
+            providerEventId: parsed.providerEventId,
+            requestId: req.requestId,
+          });
+          return res
+            .status(200)
+            .json({ success: true, deduped: true, providerEventId: parsed.providerEventId });
         }
 
         const existingStakingDeposit = await depositStore.getByCanonical(

--- a/backend/src/services/durableIdempotencyService.ts
+++ b/backend/src/services/durableIdempotencyService.ts
@@ -1,0 +1,213 @@
+import { createHash } from 'node:crypto'
+import { getPool } from '../db.js'
+import { logger } from '../utils/logger.js'
+import { recordKPI } from '../utils/appMetrics.js'
+
+const DEFAULT_TTL_MS = parseInt(process.env.API_IDEMPOTENCY_TTL_MS ?? String(24 * 60 * 60 * 1000), 10)
+const PROCESSING_LEASE_MS = parseInt(process.env.API_IDEMPOTENCY_LEASE_MS ?? '120000', 10)
+const STALE_AGE_MS = parseInt(process.env.API_IDEMPOTENCY_STALE_MS ?? String(15 * 60 * 1000), 10)
+
+type StartResult =
+  | { type: 'proceed' }
+  | { type: 'replay'; httpStatus: number; body: unknown }
+  | { type: 'conflict' }
+  | { type: 'in_flight' }
+
+type MemRow = {
+  status: 'processing' | 'completed' | 'failed'
+  requestBodyHash: string
+  httpStatus: number | null
+  responseBody: unknown
+  processingStartedAt: number
+}
+
+const memory = new Map<string, MemRow>()
+
+function memKey(scope: string, k: string) {
+  return `${scope}::${k}`
+}
+
+function sha256(s: string): string {
+  return createHash('sha256').update(s).digest('hex')
+}
+
+function startMemory(scope: string, idempotencyKey: string, requestBodyHash: string): StartResult {
+  const k = memKey(scope, idempotencyKey)
+  const existing = memory.get(k)
+  if (existing) {
+    if (existing.requestBodyHash !== requestBodyHash) {
+      return { type: 'conflict' }
+    }
+    if (existing.status === 'completed') {
+      recordKPI('idempotencyCacheHit')
+      return { type: 'replay', httpStatus: existing.httpStatus ?? 200, body: existing.responseBody }
+    }
+    if (existing.status === 'failed') {
+      memory.delete(k)
+    } else if (existing.status === 'processing') {
+      if (Date.now() - existing.processingStartedAt < PROCESSING_LEASE_MS) {
+        return { type: 'in_flight' }
+      }
+      recordKPI('idempotencyLeaseReclaimed')
+      existing.processingStartedAt = Date.now()
+      return { type: 'proceed' }
+    }
+  }
+  memory.set(k, {
+    status: 'processing',
+    requestBodyHash,
+    httpStatus: null,
+    responseBody: null,
+    processingStartedAt: Date.now(),
+  })
+  return { type: 'proceed' }
+}
+
+export const durableIdempotencyService = {
+  payloadHash(reqBody: unknown): string {
+    return sha256(JSON.stringify(reqBody ?? null))
+  },
+
+  async start(input: { scope: string; idempotencyKey: string; requestBodyHash: string }): Promise<StartResult> {
+    const { scope, idempotencyKey, requestBodyHash } = input
+    const key = idempotencyKey.trim()
+    if (!key || key.length > 256) {
+      return { type: 'conflict' }
+    }
+
+    const pool = await getPool()
+    if (!pool) {
+      return startMemory(scope, key, requestBodyHash)
+    }
+
+    const expires = new Date(Date.now() + DEFAULT_TTL_MS).toISOString()
+    const ins = await pool.query(
+      `INSERT INTO api_idempotency (
+          scope, idempotency_key, request_body_hash, status, processing_started_at, expires_at
+        ) VALUES ($1, $2, $3, 'processing', NOW(), $4::timestamptz)
+        ON CONFLICT (scope, idempotency_key) DO NOTHING
+        RETURNING id`,
+      [scope, key, requestBodyHash, expires],
+    )
+    if (ins.rows.length > 0) {
+      return { type: 'proceed' }
+    }
+
+    const { rows } = await pool.query(
+      `SELECT status, request_body_hash, http_status, response_body, processing_started_at
+       FROM api_idempotency WHERE scope = $1 AND idempotency_key = $2`,
+      [scope, key],
+    )
+    const row = rows[0] as
+      | {
+          status: string
+          request_body_hash: string
+          http_status: number | null
+          response_body: unknown
+          processing_started_at: string
+        }
+      | undefined
+    if (!row) {
+      return { type: 'proceed' }
+    }
+    if (row.request_body_hash !== requestBodyHash) {
+      return { type: 'conflict' }
+    }
+    if (row.status === 'completed' && row.response_body !== null && row.response_body !== undefined) {
+      recordKPI('idempotencyCacheHit')
+      return {
+        type: 'replay',
+        httpStatus: row.http_status ?? 200,
+        body: row.response_body,
+      }
+    }
+    if (row.status === 'failed') {
+      await pool.query(
+        `UPDATE api_idempotency
+         SET status = 'processing', processing_started_at = NOW(), request_body_hash = $3, expires_at = $4::timestamptz, completed_at = NULL, http_status = NULL, response_body = NULL
+         WHERE scope = $1 AND idempotency_key = $2`,
+        [scope, key, requestBodyHash, expires],
+      )
+      return { type: 'proceed' }
+    }
+    if (row.status === 'processing') {
+      const age = Date.now() - new Date(row.processing_started_at).getTime()
+      if (age < PROCESSING_LEASE_MS) {
+        return { type: 'in_flight' }
+      }
+      await pool.query(
+        `UPDATE api_idempotency SET processing_started_at = NOW() WHERE scope = $1 AND idempotency_key = $2`,
+        [scope, key],
+      )
+      recordKPI('idempotencyLeaseReclaimed')
+    }
+    return { type: 'proceed' }
+  },
+
+  async complete(input: { scope: string; idempotencyKey: string; httpStatus: number; body: unknown }): Promise<void> {
+    const k = memKey(input.scope, input.idempotencyKey.trim())
+    const pool = await getPool()
+    if (!pool) {
+      const row = memory.get(k)
+      if (row) {
+        row.status = 'completed'
+        row.httpStatus = input.httpStatus
+        row.responseBody = input.body
+      }
+      return
+    }
+    await pool.query(
+      `UPDATE api_idempotency
+       SET status = 'completed', http_status = $3, response_body = $4::jsonb, completed_at = NOW()
+       WHERE scope = $1 AND idempotency_key = $2`,
+      [input.scope, input.idempotencyKey.trim(), input.httpStatus, JSON.stringify(input.body ?? null)],
+    )
+  },
+
+  async fail(input: { scope: string; idempotencyKey: string; message?: string }): Promise<void> {
+    const k = memKey(input.scope, input.idempotencyKey.trim())
+    const pool = await getPool()
+    if (!pool) {
+      memory.delete(k)
+      return
+    }
+    await pool.query(
+      `UPDATE api_idempotency SET status = 'failed', completed_at = NOW()
+       WHERE scope = $1 AND idempotency_key = $2`,
+      [input.scope, input.idempotencyKey.trim()],
+    )
+    if (input.message) {
+      logger.warn('idempotency request failed', { message: input.message, scope: input.scope })
+    }
+  },
+
+  async reconcileStale(): Promise<{ reclaimed: number }> {
+    const pool = await getPool()
+    if (!pool) {
+      const cutoff = Date.now() - STALE_AGE_MS
+      let reclaimed = 0
+      for (const [k, row] of memory) {
+        if (row.status === 'processing' && row.processingStartedAt < cutoff) {
+          memory.delete(k)
+          reclaimed++
+        }
+      }
+      if (reclaimed) recordKPI('idempotencyStaleReclaimed')
+      return { reclaimed }
+    }
+    const r = await pool.query(
+      `DELETE FROM api_idempotency
+       WHERE status = 'processing'
+         AND processing_started_at < NOW() - ($1::numeric * INTERVAL '1 millisecond')
+       RETURNING id`,
+      [STALE_AGE_MS],
+    )
+    const reclaimed = r.rowCount ?? 0
+    if (reclaimed) recordKPI('idempotencyStaleReclaimed')
+    return { reclaimed }
+  },
+}
+
+export function _resetDurableIdempotencyMemory() {
+  memory.clear()
+}

--- a/backend/src/services/ngnTopupInitiateService.ts
+++ b/backend/src/services/ngnTopupInitiateService.ts
@@ -1,0 +1,99 @@
+import { AppError } from '../errors/AppError.js'
+import { ErrorCode } from '../errors/errorCodes.js'
+import { ngnDepositStore } from '../models/ngnDepositStore.js'
+import { NgnWalletService } from './ngnWalletService.js'
+import { getPaymentProvider } from '../payments/index.js'
+import { logger } from '../utils/logger.js'
+import {
+  ngnTopupInitiateResponseSchema,
+  type NgnTopupInitiateRequest,
+  type NgnTopupInitiateResponse,
+} from '../schemas/ngnTopup.js'
+
+const ngnWallet = new NgnWalletService()
+
+/**
+ * Shared NGN top-up initiation for `/api/wallet/ngn/topup/initiate` and tenant routes.
+ * Deposit-level idempotency: when `idempotencyKey` is set, reuses the same `ngn_deposits` row.
+ */
+export async function initiateNgnTopup(params: {
+  userId: string
+  body: NgnTopupInitiateRequest
+  idempotencyKey: string | null
+  requestId?: string
+}): Promise<{ status: 200 | 201; body: NgnTopupInitiateResponse }> {
+  const { userId, body, idempotencyKey, requestId } = params
+
+  if (idempotencyKey) {
+    const existing = await ngnDepositStore.getByUserIdAndIdempotencyKey(userId, idempotencyKey)
+    if (existing) {
+      if (!existing.externalRefSource || !existing.externalRef) {
+        throw new AppError(ErrorCode.CONFLICT, 409, 'Deposit initiation is in progress')
+      }
+      const response = {
+        success: true,
+        depositId: existing.depositId,
+        externalRefSource: existing.externalRefSource,
+        externalRef: existing.externalRef,
+        ...(existing.redirectUrl ? { redirectUrl: existing.redirectUrl } : {}),
+        ...(existing.bankDetails ? { bankDetails: existing.bankDetails } : {}),
+      }
+      return { status: 200, body: ngnTopupInitiateResponseSchema.parse(response) }
+    }
+  }
+
+  const deposit = await ngnDepositStore.create({
+    userId,
+    amountNgn: body.amountNgn,
+    rail: body.rail,
+    idempotencyKey,
+  })
+
+  let externalRefSource: string
+  let externalRef: string
+  let redirectUrl: string | undefined
+  let bankDetails: Record<string, string> | undefined
+
+  if (body.rail === 'bank_transfer') {
+    externalRefSource = 'bank'
+    externalRef = `bnk_${deposit.depositId}`
+    bankDetails = { accountNumber: '1234567890', bankName: 'Example Bank' }
+  } else {
+    const provider = getPaymentProvider(body.rail)
+    const init = await provider.initiatePayment({
+      amountNgn: body.amountNgn,
+      userId,
+      internalRef: deposit.depositId,
+      rail: body.rail,
+    })
+    externalRefSource = init.externalRefSource
+    externalRef = init.externalRef
+    redirectUrl = init.redirectUrl
+    if (init.bankDetails) {
+      bankDetails = init.bankDetails
+    }
+  }
+
+  await ngnDepositStore.attachExternalRef({
+    depositId: deposit.depositId,
+    externalRefSource,
+    externalRef,
+    redirectUrl: redirectUrl ?? null,
+    bankDetails: bankDetails ?? null,
+  })
+
+  await ngnWallet.recordTopUpPending(deposit.depositId, body.amountNgn, externalRef)
+
+  logger.info('NGN topup initiated', { userId, depositId: deposit.depositId, rail: body.rail, requestId })
+
+  const response = {
+    success: true,
+    depositId: deposit.depositId,
+    externalRefSource,
+    externalRef,
+    ...(redirectUrl ? { redirectUrl } : {}),
+    ...(bankDetails ? { bankDetails } : {}),
+  }
+
+  return { status: 201, body: ngnTopupInitiateResponseSchema.parse(response) }
+}

--- a/backend/src/services/notificationService.ts
+++ b/backend/src/services/notificationService.ts
@@ -1,0 +1,80 @@
+import { randomUUID } from 'node:crypto'
+import { getPool } from '../db.js'
+import { recordKPI } from '../utils/appMetrics.js'
+
+export type CreateNotificationInput = {
+  category: string
+  title: string
+  body: string
+  data?: Record<string, unknown>
+  dedupeKey?: string
+}
+
+const mem: {
+  id: string
+  userId: string
+  category: string
+  title: string
+  body: string
+  data: Record<string, unknown> | null
+  readAt: string | null
+  createdAt: string
+  dedupeKey: string | null
+}[] = []
+
+export const notificationService = {
+  async create(userId: string, input: CreateNotificationInput): Promise<string> {
+    const pool = await getPool()
+    if (!pool) {
+      if (input.dedupeKey) {
+        const d = mem.find((m) => m.userId === userId && m.dedupeKey === input.dedupeKey)
+        if (d) return d.id
+      }
+      const id = randomUUID()
+      const now = new Date().toISOString()
+      mem.push({
+        id,
+        userId,
+        category: input.category,
+        title: input.title,
+        body: input.body,
+        data: input.data ?? null,
+        readAt: null,
+        createdAt: now,
+        dedupeKey: input.dedupeKey ?? null,
+      })
+      recordKPI('notificationCreated')
+      return id
+    }
+    if (input.dedupeKey) {
+      const { rows: ex } = await pool.query(
+        `SELECT id FROM user_notifications WHERE user_id = $1 AND dedupe_key = $2 LIMIT 1`,
+        [userId, input.dedupeKey],
+      )
+      if (ex.length) return (ex[0] as { id: string }).id
+    }
+    const { rows } = await pool.query(
+      `INSERT INTO user_notifications (user_id, category, title, body, data, dedupe_key)
+       VALUES ($1, $2, $3, $4, $5::jsonb, $6)
+       RETURNING id`,
+      [
+        userId,
+        input.category,
+        input.title,
+        input.body,
+        input.data ? JSON.stringify(input.data) : null,
+        input.dedupeKey ?? null,
+      ],
+    )
+    recordKPI('notificationCreated')
+    return (rows[0] as { id: string }).id
+  },
+}
+
+export function _resetNotificationMemory() {
+  mem.length = 0
+}
+
+export function _getNotificationMemory() {
+  return mem
+}

--- a/backend/src/settlement/enqueueSideEffects.ts
+++ b/backend/src/settlement/enqueueSideEffects.ts
@@ -1,0 +1,132 @@
+import { randomUUID } from 'node:crypto'
+
+type SqlClient = {
+  query: (text: string, params?: unknown[]) => Promise<unknown>
+}
+import { recordKPI } from '../utils/appMetrics.js'
+import { logger } from '../utils/logger.js'
+import { notificationService } from '../services/notificationService.js'
+
+export type SettlementEventType = 'receipt_recorded' | 'notification_fanout' | 'audit_publish'
+
+export interface EnqueueContext {
+  dealId: string
+  period: number
+  tenantId: string
+  landlordId: string
+  amountNgn: number
+}
+
+const memQueue: {
+  id: string
+  dealId: string
+  period: number
+  eventType: SettlementEventType
+  idempotencyKey: string
+  payload: Record<string, unknown>
+  status: 'pending' | 'processing' | 'done' | 'failed' | 'dead'
+  attempts: number
+}[] = []
+
+let memId = 0
+
+function buildRows(ctx: EnqueueContext) {
+  const { dealId, period, tenantId, landlordId, amountNgn } = ctx
+  const base = { dealId, period, tenantId, landlordId, amountNgn }
+  return [
+    {
+      eventType: 'receipt_recorded' as const,
+      idempotencyKey: `deal:${dealId}:p${period}:receipt_recorded`,
+      payload: { ...base, event: 'receipt_recorded' },
+    },
+    {
+      eventType: 'notification_fanout' as const,
+      idempotencyKey: `deal:${dealId}:p${period}:notification_fanout`,
+      payload: { ...base, event: 'notification_fanout' },
+    },
+    {
+      eventType: 'audit_publish' as const,
+      idempotencyKey: `deal:${dealId}:p${period}:audit_publish`,
+      payload: { ...base, event: 'audit_publish' },
+    },
+  ]
+}
+
+export async function enqueueSettlementSideEffectsInTransaction(
+  client: SqlClient,
+  ctx: EnqueueContext,
+): Promise<void> {
+  for (const row of buildRows(ctx)) {
+    const id = randomUUID()
+    await client.query(
+      `INSERT INTO settlement_outbox (id, deal_id, period, event_type, idempotency_key, payload, status)
+       VALUES ($1, $2, $3, $4, $5, $6, 'pending')
+       ON CONFLICT (idempotency_key) DO NOTHING`,
+      [id, ctx.dealId, ctx.period, row.eventType, row.idempotencyKey, JSON.stringify(row.payload)],
+    )
+  }
+  logger.info('Enqueued settlement side effects', { dealId: ctx.dealId, period: ctx.period })
+}
+
+export function enqueueSettlementSideEffectsMemory(ctx: EnqueueContext): void {
+  for (const row of buildRows(ctx)) {
+    if (memQueue.some((m) => m.idempotencyKey === row.idempotencyKey)) continue
+    memId += 1
+    memQueue.push({
+      id: `mem-${memId}`,
+      dealId: ctx.dealId,
+      period: ctx.period,
+      eventType: row.eventType,
+      idempotencyKey: row.idempotencyKey,
+      payload: row.payload,
+      status: 'pending',
+      attempts: 0,
+    })
+  }
+}
+
+export function getSettlementMemoryQueue() {
+  return memQueue
+}
+
+export function _clearSettlementMemoryQueue() {
+  memQueue.length = 0
+  memId = 0
+}
+
+export type SettlementOutboxRow = {
+  id: string
+  dealId: string
+  period: number
+  eventType: string
+  idempotencyKey: string
+  payload: Record<string, unknown>
+  status: string
+  attempts: number
+  nextRetryAt: Date | null
+  lastError: string | null
+}
+
+/**
+ * Idempotent side-effect execution (at-least-once safe via notification dedupe and stable idempotency_key).
+ */
+export async function executeSettlementEvent(row: SettlementOutboxRow): Promise<void> {
+  if (row.eventType === 'receipt_recorded') {
+    // Stub: official receipt record would upsert with idempotency_key; metrics only here
+    recordKPI('settlementOutboxDone')
+  } else if (row.eventType === 'notification_fanout') {
+    const tenantId = String(row.payload.tenantId ?? '')
+    const dedupe = `settlement:${row.dealId}:p${row.period}:rent_paid`
+    await notificationService.create(tenantId, {
+      category: 'transaction',
+      title: 'Rent payment received',
+      body: `Period ${row.period} for deal ${row.dealId} was marked paid.`,
+      data: { dealId: row.dealId, period: row.period },
+      dedupeKey: dedupe,
+    })
+    recordKPI('settlementOutboxDone')
+  } else if (row.eventType === 'audit_publish') {
+    logger.info('settlement.audit', { idempotencyKey: row.idempotencyKey, dealId: row.dealId, period: row.period })
+    recordKPI('settlementOutboxDone')
+  }
+}

--- a/backend/src/settlement/worker.ts
+++ b/backend/src/settlement/worker.ts
@@ -1,0 +1,149 @@
+import { getPool } from '../db.js'
+import { logger } from '../utils/logger.js'
+import { executeSettlementEvent, getSettlementMemoryQueue, type SettlementOutboxRow } from './enqueueSideEffects.js'
+import { recordKPI } from '../utils/appMetrics.js'
+
+const MAX_ATTEMPTS = 5
+const BASE_BACKOFF_MS = 2000
+
+export class SettlementOutboxWorker {
+  private timer: ReturnType<typeof setInterval> | null = null
+
+  start(intervalMs = 4000) {
+    if (this.timer) return
+    this.timer = setInterval(() => {
+      void this.tick()
+    }, intervalMs)
+    if (this.timer.unref) this.timer.unref()
+    logger.info('SettlementOutboxWorker started', { intervalMs })
+  }
+
+  async stop() {
+    if (this.timer) {
+      clearInterval(this.timer)
+      this.timer = null
+    }
+  }
+
+  async tick() {
+    const pool = await getPool()
+    if (pool) {
+      for (let i = 0; i < 8; i++) {
+        const done = await this.claimAndProcessOne(pool)
+        if (!done) break
+      }
+    } else {
+      const q = getSettlementMemoryQueue()
+      for (const row of q.filter((r) => r.status === 'pending')) {
+        try {
+          await executeSettlementEvent(mapMemRow(row))
+          row.status = 'done'
+        } catch (e) {
+          row.attempts += 1
+          row.status = row.attempts >= MAX_ATTEMPTS ? 'dead' : 'pending'
+          if (row.status === 'dead') recordKPI('settlementOutboxDead')
+        }
+      }
+    }
+  }
+
+  private async claimAndProcessOne(pool: NonNullable<Awaited<ReturnType<typeof getPool>>>): Promise<boolean> {
+    const client = await pool.connect()
+    let row: SettlementOutboxRow | null = null
+    try {
+      await client.query('BEGIN')
+      const { rows } = await client.query(
+        `SELECT id, deal_id AS "dealId", period, event_type AS "eventType", idempotency_key AS "idempotencyKey",
+                payload, status, attempts, next_retry_at AS "nextRetryAt", last_error AS "lastError"
+         FROM settlement_outbox
+         WHERE status = 'pending' AND (next_retry_at IS NULL OR next_retry_at <= NOW())
+         ORDER BY created_at
+         FOR UPDATE SKIP LOCKED
+         LIMIT 1`,
+      )
+      if (rows.length === 0) {
+        await client.query('COMMIT')
+        return false
+      }
+      row = mapRow(rows[0]!)
+      await client.query(
+        `UPDATE settlement_outbox SET status = 'processing', updated_at = NOW() WHERE id = $1`,
+        [row.id],
+      )
+      await client.query('COMMIT')
+    } catch (e) {
+      await client.query('ROLLBACK').catch(() => {})
+      throw e
+    } finally {
+      client.release()
+    }
+
+    if (!row) return false
+
+    try {
+      await executeSettlementEvent(row)
+      await pool.query(`UPDATE settlement_outbox SET status = 'done', updated_at = NOW() WHERE id = $1`, [row.id])
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e)
+      const attempts = row.attempts + 1
+      if (attempts >= MAX_ATTEMPTS) {
+        await pool.query(
+          `INSERT INTO settlement_outbox_dlq (id, deal_id, period, event_type, idempotency_key, payload, last_error, failed_at)
+           VALUES ($1, $2, $3, $4, $5, $6, $7, NOW())`,
+          [row.id, row.dealId, row.period, row.eventType, row.idempotencyKey, JSON.stringify(row.payload), msg],
+        )
+        await pool.query(`DELETE FROM settlement_outbox WHERE id = $1`, [row.id])
+        recordKPI('settlementOutboxDead')
+        logger.error('settlement outbox dead', { id: row.id, idempotencyKey: row.idempotencyKey, msg })
+      } else {
+        const next = new Date(Date.now() + BASE_BACKOFF_MS * Math.pow(2, attempts - 1))
+        await pool.query(
+          `UPDATE settlement_outbox
+           SET status = 'pending', attempts = $2, last_error = $3, next_retry_at = $4, updated_at = NOW()
+           WHERE id = $1`,
+          [row.id, attempts, msg, next.toISOString()],
+        )
+      }
+    }
+    return true
+  }
+}
+
+function mapRow(raw: Record<string, unknown>): SettlementOutboxRow {
+  return {
+    id: String(raw.id),
+    dealId: String(raw.dealId),
+    period: Number(raw.period),
+    eventType: String(raw.eventType),
+    idempotencyKey: String(raw.idempotencyKey),
+    payload: (raw.payload as Record<string, unknown>) ?? {},
+    status: String(raw.status),
+    attempts: Number(raw.attempts),
+    nextRetryAt: raw.nextRetryAt ? new Date(String(raw.nextRetryAt)) : null,
+    lastError: raw.lastError ? String(raw.lastError) : null,
+  }
+}
+
+function mapMemRow(row: {
+  id: string
+  dealId: string
+  period: number
+  eventType: string
+  idempotencyKey: string
+  payload: Record<string, unknown>
+  status: string
+  attempts: number
+}): SettlementOutboxRow {
+  return {
+    id: row.id,
+    dealId: row.dealId,
+    period: row.period,
+    eventType: row.eventType,
+    idempotencyKey: row.idempotencyKey,
+    payload: row.payload,
+    status: row.status,
+    attempts: row.attempts,
+    nextRetryAt: null,
+    lastError: null,
+  }
+}

--- a/backend/src/utils/appMetrics.test.ts
+++ b/backend/src/utils/appMetrics.test.ts
@@ -66,6 +66,17 @@ describe('appMetrics', () => {
       const after = getMetricsSnapshot().kpis.paymentsInitiated
       expect(after).toBe(before + 2)
     })
+
+    it('increments webhookEventDeduped and idempotencyCacheHit', () => {
+      const s = getMetricsSnapshot().kpis
+      const beforeD = s.webhookEventDeduped
+      const beforeC = s.idempotencyCacheHit
+      recordKPI('webhookEventDeduped')
+      recordKPI('idempotencyCacheHit')
+      const after = getMetricsSnapshot().kpis
+      expect(after.webhookEventDeduped).toBe(beforeD + 1)
+      expect(after.idempotencyCacheHit).toBe(beforeC + 1)
+    })
   })
 
   describe('metricsMiddleware', () => {

--- a/backend/src/utils/appMetrics.ts
+++ b/backend/src/utils/appMetrics.ts
@@ -39,6 +39,14 @@ interface BusinessKPIs {
   paymentsCompleted: number
   paymentsFailed: number
   stakingDeposits: number
+  /** Replayed PSP webhooks skipped after provider event id deduplication */
+  webhookEventDeduped: number
+  idempotencyCacheHit: number
+  idempotencyLeaseReclaimed: number
+  idempotencyStaleReclaimed: number
+  settlementOutboxDone: number
+  settlementOutboxDead: number
+  notificationCreated: number
 }
 
 interface AlertThresholds {
@@ -56,6 +64,13 @@ const kpis: BusinessKPIs = {
   paymentsCompleted: 0,
   paymentsFailed: 0,
   stakingDeposits: 0,
+  webhookEventDeduped: 0,
+  idempotencyCacheHit: 0,
+  idempotencyLeaseReclaimed: 0,
+  idempotencyStaleReclaimed: 0,
+  settlementOutboxDone: 0,
+  settlementOutboxDead: 0,
+  notificationCreated: 0,
 }
 const startedAt = Date.now()
 

--- a/backend/src/utils/sha256.ts
+++ b/backend/src/utils/sha256.ts
@@ -1,0 +1,10 @@
+import { createHash } from 'node:crypto'
+
+export function sha256Hex(s: string): string {
+  return createHash('sha256').update(s).digest('hex')
+}
+
+/** Stable JSON + SHA-256 (body hashing for idempotency / webhooks). */
+export function jsonPayloadSha256Hex(value: unknown): string {
+  return sha256Hex(JSON.stringify(value ?? null))
+}

--- a/frontend/app/dashboard/notifications/page.tsx
+++ b/frontend/app/dashboard/notifications/page.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import Link from "next/link";
+import { ArrowLeft, CheckCheck } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { DashboardHeader } from "@/components/dashboard-header";
+import {
+  fetchNotifications,
+  markAllNotificationsRead,
+  markNotificationRead,
+  type NotificationItem,
+} from "@/lib/notificationsApi";
+import { cn } from "@/lib/utils";
+
+export default function NotificationsPage() {
+  const [items, setItems] = useState<NotificationItem[]>([]);
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [err, setErr] = useState<string | null>(null);
+  const [optimistic, setOptimistic] = useState<Set<string>>(new Set());
+
+  const load = useCallback(async (cursor?: string) => {
+    setLoading(true);
+    setErr(null);
+    try {
+      const r = await fetchNotifications({ cursor, limit: 20 });
+      setItems((prev) => (cursor ? [...prev, ...r.data.items] : r.data.items));
+      setNextCursor(r.data.nextCursor);
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : "Error");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const onRead = async (id: string) => {
+    setOptimistic((o) => new Set(o).add(id));
+    setItems((prev) =>
+      prev.map((i) => (i.id === id ? { ...i, read: true } : i)),
+    );
+    try {
+      await markNotificationRead(id);
+    } catch {
+      setItems((prev) =>
+        prev.map((i) => (i.id === id ? { ...i, read: false } : i)),
+      );
+      setOptimistic((o) => {
+        const n = new Set(o);
+        n.delete(id);
+        return n;
+      });
+    }
+  };
+
+  const onReadAll = async () => {
+    setItems((prev) => prev.map((i) => ({ ...i, read: true })));
+    try {
+      await markAllNotificationsRead();
+    } catch {
+      void load();
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-background">
+      <DashboardHeader />
+      <main className="container mx-auto max-w-2xl px-4 pt-24 pb-12">
+        <div className="mb-6 flex items-center justify-between">
+          <Link
+            href="/dashboard/tenant"
+            className="inline-flex items-center text-sm font-medium text-muted-foreground hover:text-foreground"
+          >
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            Back
+          </Link>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="gap-2"
+            onClick={() => void onReadAll()}
+          >
+            <CheckCheck className="h-4 w-4" />
+            Mark all read
+          </Button>
+        </div>
+        <h1 className="mb-6 font-mono text-2xl font-black">Notifications</h1>
+        {err && (
+          <p className="mb-4 text-sm text-destructive" role="alert">
+            {err}
+          </p>
+        )}
+        <ul className="space-y-2">
+          {items.map((n) => (
+            <li
+              key={n.id}
+              className={cn(
+                "rounded border-2 border-foreground p-4 shadow-[2px_2px_0_0_#1a1a1a] transition-opacity",
+                !n.read && !optimistic.has(n.id) && "bg-primary/5",
+              )}
+            >
+              <div className="flex justify-between gap-2">
+                <div>
+                  <p className="text-xs font-mono uppercase text-muted-foreground">
+                    {n.category}
+                  </p>
+                  <h2 className="font-bold">{n.title}</h2>
+                  <p className="mt-1 text-sm text-muted-foreground">{n.body}</p>
+                  <p className="mt-2 text-xs text-muted-foreground">
+                    {new Date(n.createdAt).toLocaleString()}
+                  </p>
+                </div>
+                {!n.read && (
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="secondary"
+                    onClick={() => void onRead(n.id)}
+                  >
+                    Mark read
+                  </Button>
+                )}
+              </div>
+            </li>
+          ))}
+        </ul>
+        {nextCursor && (
+          <div className="mt-6 flex justify-center">
+            <Button
+              type="button"
+              variant="outline"
+              disabled={loading}
+              onClick={() => void load(nextCursor)}
+            >
+              {loading ? "Loading…" : "Load more"}
+            </Button>
+          </div>
+        )}
+        {!loading && items.length === 0 && !err && (
+          <p className="text-center text-muted-foreground">No notifications yet.</p>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/frontend/components/dashboard-header.tsx
+++ b/frontend/components/dashboard-header.tsx
@@ -1,12 +1,14 @@
 "use client"
 
 import Link from "next/link"
-import { Home, Building2, Calculator, Menu, X } from "lucide-react"
+import { Home, Building2, Calculator, Menu, X, Bell } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { useState } from "react"
+import { useNotificationUnread } from "@/hooks/use-notification-unread"
 
 export function DashboardHeader() {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
+  const { unread } = useNotificationUnread()
 
   return (
     <header className="fixed top-0 left-0 right-0 z-50 border-b-3 border-foreground bg-card">
@@ -21,6 +23,21 @@ export function DashboardHeader() {
 
         {/* Desktop Navigation */}
         <nav className="hidden md:flex items-center gap-4">
+          <Link href="/dashboard/notifications" className="relative">
+            <Button
+              type="button"
+              variant="outline"
+              className="border-2 border-foreground bg-transparent font-bold shadow-[2px_2px_0px_0px_rgba(26,26,26,1)]"
+              aria-label="Notifications"
+            >
+              <Bell className="h-4 w-4" />
+              {unread > 0 && (
+                <span className="absolute -right-1 -top-1 flex h-4 min-w-[1rem] items-center justify-center rounded-full bg-destructive px-1 text-[10px] font-bold text-destructive-foreground">
+                  {unread > 9 ? "9+" : unread}
+                </span>
+              )}
+            </Button>
+          </Link>
           <Link href="/">
             <Button
               variant="outline"

--- a/frontend/hooks/use-notification-unread.ts
+++ b/frontend/hooks/use-notification-unread.ts
@@ -1,0 +1,32 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { fetchUnreadCount } from "@/lib/notificationsApi";
+
+const POLL_MS = 8000;
+
+export function useNotificationUnread() {
+  const [unread, setUnread] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      const r = await fetchUnreadCount();
+      setUnread(r.data.unread);
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load");
+    }
+  }, []);
+
+  useEffect(() => {
+    const t0 = setTimeout(() => void refresh(), 0);
+    const t = setInterval(() => void refresh(), POLL_MS);
+    return () => {
+      clearTimeout(t0);
+      clearInterval(t);
+    };
+  }, [refresh]);
+
+  return { unread, error, refresh };
+}

--- a/frontend/lib/notificationsApi.ts
+++ b/frontend/lib/notificationsApi.ts
@@ -1,0 +1,34 @@
+import { apiGet, apiPost } from "./apiClient";
+
+export type NotificationItem = {
+  id: string;
+  category: string;
+  title: string;
+  body: string;
+  data: unknown;
+  read: boolean;
+  createdAt: string;
+};
+
+export async function fetchNotifications(params?: { cursor?: string; limit?: number }) {
+  const sp = new URLSearchParams();
+  if (params?.cursor) sp.set("cursor", params.cursor);
+  if (params?.limit) sp.set("limit", String(params.limit));
+  const q = sp.toString();
+  return apiGet<{
+    success: boolean;
+    data: { items: NotificationItem[]; nextCursor: string | null };
+  }>(`/api/notifications${q ? `?${q}` : ""}`);
+}
+
+export function markNotificationRead(id: string) {
+  return apiPost<{ success: boolean }>(`/api/notifications/${id}/read`, {});
+}
+
+export function markAllNotificationsRead() {
+  return apiPost<{ success: boolean }>(`/api/notifications/read-all`, {});
+}
+
+export async function fetchUnreadCount() {
+  return apiGet<{ success: boolean; data: { unread: number } }>("/api/notifications/unread-count");
+}

--- a/frontend/lib/paymentOffline.ts
+++ b/frontend/lib/paymentOffline.ts
@@ -1,0 +1,32 @@
+/**
+ * Tenant payment actions (quick pay, top-up) use the shared `offline-queue` in `api.ts`
+ * when the browser is offline. Send a stable `x-idempotency-key` (UUID) on POSTs
+ * so the backend durable idempotency layer can merge retries safely.
+ */
+import {
+  flushOfflineQueue,
+  enqueueOfflineRequest,
+} from "./offline-queue";
+
+const baseUrl = process.env.NEXT_PUBLIC_BACKEND_URL || "http://localhost:4000";
+
+export { flushOfflineQueue, enqueueOfflineRequest };
+
+export async function flushPaymentQueue() {
+  return flushOfflineQueue(baseUrl);
+}
+
+/** Fingerprint to detect duplicate queued payment intents in the UI. */
+export function paymentActionFingerprint(
+  op: "tenant-quick-pay" | "tenant-topup" | "ngn-topup",
+  body: unknown,
+) {
+  return `${op}:${JSON.stringify(body)}`;
+}
+
+export function newIdempotencyKey() {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID();
+  }
+  return `idem_${Date.now()}_${Math.random().toString(36).slice(2)}`;
+}


### PR DESCRIPTION
## Summary

Implements end-to-end payment idempotency (durable API keys + webhook deduplication by provider event), a durable **settlement outbox** with a worker, metrics, and admin DLQ replay; an in-app **notification center** (list, read state, unread count, SSE) with dashboard UI; and **offline-oriented client helpers** for payment actions. Applies DB migrations 012–015 and aligns with repo lint/tests/OpenAPI/frontend/contract checks.

Closes #601
Closes #602
Closes #603
Closes #604

## Changes

- **Backend:** Migrations for webhook dedupe, API idempotency store, `settlement_outbox` + DLQ, notifications table; `durableIdempotency` middleware; webhook payload hashing + `webhookEventDedupeStore`; NGN/tenant top-up idempotency integration; deal schedule → `enqueueSideEffects` + `SettlementOutboxWorker` + `settlementAdmin` routes; `notifications` routes (pagination, read, unread count, stream); `app` wiring, metrics, tests.
- **Frontend:** Notifications page, API client, unread hook (polling) with header bell, `paymentOffline` helpers.
- **CI hardening:** Route-friendly hashing helper; explicit outbox `INSERT` row ids; persistence test includes settlement schema; hook lint fix for React’s `set-state-in-effect` rule.

## Checklist

- [x] Migrations 012–015 applied (or noted for deploy — run in order in your environment)
- [x] Backend: `npm run lint`, `npm run test:ci`, `npm run openapi:validate`
- [x] Frontend: `pnpm run lint`, `pnpm run build`
- [x] Contracts: `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets --all-features`, `cargo test --workspace`
- [ ] PR targets `main` and branch is pushed to the remote