### PR TITLE
feat: resolve backend issues #563 #567 #571 #574

### DIFF
--- a/backend/migrations/016_public_application_intake.sql
+++ b/backend/migrations/016_public_application_intake.sql
@@ -1,0 +1,38 @@
+-- Public application intake tables
+-- Partner landlord applications and whistleblower signup applications
+
+CREATE TABLE IF NOT EXISTS partner_landlord_applications (
+  id TEXT PRIMARY KEY DEFAULT ('PLA-' || EXTRACT(EPOCH FROM NOW())::BIGINT || '-' || floor(random() * 1000)::INT),
+  full_name TEXT NOT NULL,
+  phone_number TEXT NOT NULL,
+  email TEXT NOT NULL,
+  property_count INTEGER NOT NULL CHECK (property_count > 0),
+  property_locations TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending')),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_partner_landlord_applications_created_at
+  ON partner_landlord_applications(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_partner_landlord_applications_status
+  ON partner_landlord_applications(status);
+
+CREATE TABLE IF NOT EXISTS whistleblower_signup_applications (
+  id TEXT PRIMARY KEY DEFAULT ('WSA-' || EXTRACT(EPOCH FROM NOW())::BIGINT || '-' || floor(random() * 1000)::INT),
+  full_name TEXT NOT NULL,
+  email TEXT NOT NULL,
+  phone TEXT NOT NULL,
+  address TEXT NOT NULL,
+  linkedin_profile TEXT NOT NULL,
+  facebook_profile TEXT NOT NULL,
+  instagram_profile TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending')),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_whistleblower_signup_applications_created_at
+  ON whistleblower_signup_applications(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_whistleblower_signup_applications_status
+  ON whistleblower_signup_applications(status);

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -56,10 +56,6 @@ import {
 } from "./models/linkedAddressStore.js";
 import { StubRewardsDataLayer } from "./services/stub-rewards-data-layer.js";
 import authRouter from "./routes/auth.js";
-import {
-  StubReceiptRepository,
-  PostgresReceiptRepository,
-} from "./indexer/receipt-repository.js";
 import { ReceiptIndexer } from "./indexer/worker.js";
 import { createReceiptsRouter } from "./routes/receiptsRoute.js";
 import { getPool, getPoolMetricsForOtel } from "./db.js";
@@ -78,9 +74,9 @@ import migrationGuideRouter from "./routes/migrationGuide.js";
 import adminTimelockRouter from "./routes/admin-timelock.js";
 import { TimelockIndexer } from "./indexer/timelock-worker.js";
 import {
-  PostgresTimelockRepository,
-  StubTimelockRepository,
-} from "./indexer/timelock-repository.js";
+  createReceiptRepository,
+  createTimelockRepository,
+} from "./indexer/repositoryBootstrap.js";
 import { TimelockProcessor } from "./indexer/timelock-processor.js";
 import { MetricsSorobanAdapter } from "./soroban/metrics-adapter.js";
 import { CircuitBreakerAdapter } from "./soroban/circuit-breaker-adapter.js";
@@ -109,6 +105,16 @@ import {
   PostgresTenantApplicationStore,
   initTenantApplicationStore,
 } from "./models/tenantApplicationStore.js";
+import {
+  PostgresPartnerLandlordApplicationStore,
+  initPartnerLandlordApplicationStore,
+} from "./models/partnerLandlordApplicationStore.js";
+import {
+  PostgresWhistleblowerSignupApplicationStore,
+  initWhistleblowerSignupApplicationStore,
+} from "./models/whistleblowerSignupApplicationStore.js";
+import { createPartnerLandlordApplicationsRouter } from "./routes/partnerLandlordApplications.js";
+import { createWhistleblowerApplicationsRouter } from "./routes/whistleblowerApplications.js";
 
 import {
   sanitizeRequest,
@@ -291,12 +297,19 @@ export function createApp() {
   // Tenant Application Store — swap to Postgres when DATABASE_URL is set
   if (process.env.DATABASE_URL) {
     initTenantApplicationStore(new PostgresTenantApplicationStore());
+    initPartnerLandlordApplicationStore(
+      new PostgresPartnerLandlordApplicationStore(),
+    );
+    initWhistleblowerSignupApplicationStore(
+      new PostgresWhistleblowerSignupApplicationStore(),
+    );
   }
 
   // Indexer
-  const receiptRepo = process.env.DATABASE_URL
-    ? new PostgresReceiptRepository()
-    : new StubReceiptRepository();
+  const receiptRepo = createReceiptRepository(
+    process.env.DATABASE_URL,
+    env.NODE_ENV,
+  );
   const indexer = new ReceiptIndexer(sorobanAdapter, receiptRepo, {
     pollIntervalMs: parseInt(process.env.INDEXER_POLL_MS ?? "5000"),
     startLedger: process.env.INDEXER_START_LEDGER
@@ -307,9 +320,10 @@ export function createApp() {
   workers.push(indexer);
 
   // Timelock Indexer
-  const timelockRepo = process.env.DATABASE_URL
-    ? new PostgresTimelockRepository()
-    : new StubTimelockRepository();
+  const timelockRepo = createTimelockRepository(
+    process.env.DATABASE_URL,
+    env.NODE_ENV,
+  );
   const timelockProcessor = new TimelockProcessor(timelockRepo);
   const timelockIndexer = new TimelockIndexer(
     sorobanAdapter as any,
@@ -450,8 +464,16 @@ export function createApp() {
   app.use("/api/deposits", createDepositsRouter(conversionService));
   app.use("/api/gas-metrics", createGasMetricsRouter());
   app.use("/api/landlord/properties", createLandlordPropertiesRouter());
+  app.use(
+    "/api/landlord/partner-applications",
+    createPartnerLandlordApplicationsRouter(),
+  );
   app.use("/api/landlord", authenticateToken, createLandlordRouter());
   app.use("/api/tenant/applications", createTenantApplicationsRouter());
+  app.use(
+    "/api/whistleblower/applications",
+    createWhistleblowerApplicationsRouter(),
+  );
   app.use("/api/tenant/payments", createTenantPaymentsRouter());
   app.use("/api/notifications", createNotificationsRouter());
   app.use("/api/admin", createSettlementAdminRouter());

--- a/backend/src/indexer/repositoryBootstrap.test.ts
+++ b/backend/src/indexer/repositoryBootstrap.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { createReceiptRepository, createTimelockRepository } from "./repositoryBootstrap.js";
+import { PostgresReceiptRepository, StubReceiptRepository } from "./receipt-repository.js";
+import {
+  PostgresTimelockRepository,
+  StubTimelockRepository,
+} from "./timelock-repository.js";
+
+describe("repository bootstrap selection", () => {
+  describe("createReceiptRepository", () => {
+    it("uses stub repository in development when DATABASE_URL is missing", () => {
+      const repository = createReceiptRepository(undefined, "development");
+      expect(repository).toBeInstanceOf(StubReceiptRepository);
+    });
+
+    it("uses postgres repository when DATABASE_URL is provided", () => {
+      const repository = createReceiptRepository(
+        "postgres://localhost:5432/shelterflex",
+        "production",
+      );
+      expect(repository).toBeInstanceOf(PostgresReceiptRepository);
+    });
+
+    it("fails fast outside dev/test when DATABASE_URL is missing", () => {
+      expect(() => createReceiptRepository(undefined, "production")).toThrow(
+        "DATABASE_URL is required outside development/test",
+      );
+    });
+  });
+
+  describe("createTimelockRepository", () => {
+    it("uses stub repository in test mode when DATABASE_URL is missing", () => {
+      const repository = createTimelockRepository(undefined, "test");
+      expect(repository).toBeInstanceOf(StubTimelockRepository);
+    });
+
+    it("uses postgres repository when DATABASE_URL is provided", () => {
+      const repository = createTimelockRepository(
+        "postgres://localhost:5432/shelterflex",
+        "staging",
+      );
+      expect(repository).toBeInstanceOf(PostgresTimelockRepository);
+    });
+
+    it("fails fast outside dev/test when DATABASE_URL is missing", () => {
+      expect(() => createTimelockRepository(undefined, "production")).toThrow(
+        "DATABASE_URL is required outside development/test",
+      );
+    });
+  });
+});

--- a/backend/src/indexer/repositoryBootstrap.ts
+++ b/backend/src/indexer/repositoryBootstrap.ts
@@ -1,0 +1,49 @@
+import {
+  PostgresReceiptRepository,
+  ReceiptRepository,
+  StubReceiptRepository,
+} from "./receipt-repository.js";
+import {
+  PostgresTimelockRepository,
+  StubTimelockRepository,
+  TimelockRepository,
+} from "./timelock-repository.js";
+
+function hasDatabaseUrl(databaseUrl: string | undefined): boolean {
+  return Boolean(databaseUrl && databaseUrl.trim().length > 0);
+}
+
+function isStubAllowed(nodeEnv: string | undefined): boolean {
+  return nodeEnv === "development" || nodeEnv === "test";
+}
+
+function assertRepositoryBootstrapConfig(
+  databaseUrl: string | undefined,
+  nodeEnv: string | undefined,
+): void {
+  if (!hasDatabaseUrl(databaseUrl) && !isStubAllowed(nodeEnv)) {
+    throw new Error(
+      "DATABASE_URL is required outside development/test for receipt and timelock repositories",
+    );
+  }
+}
+
+export function createReceiptRepository(
+  databaseUrl: string | undefined,
+  nodeEnv: string | undefined,
+): ReceiptRepository {
+  assertRepositoryBootstrapConfig(databaseUrl, nodeEnv);
+  return hasDatabaseUrl(databaseUrl)
+    ? new PostgresReceiptRepository()
+    : new StubReceiptRepository();
+}
+
+export function createTimelockRepository(
+  databaseUrl: string | undefined,
+  nodeEnv: string | undefined,
+): TimelockRepository {
+  assertRepositoryBootstrapConfig(databaseUrl, nodeEnv);
+  return hasDatabaseUrl(databaseUrl)
+    ? new PostgresTimelockRepository()
+    : new StubTimelockRepository();
+}

--- a/backend/src/models/partnerLandlordApplication.ts
+++ b/backend/src/models/partnerLandlordApplication.ts
@@ -1,0 +1,23 @@
+export enum PartnerLandlordApplicationStatus {
+  PENDING = "pending",
+}
+
+export interface PartnerLandlordApplication {
+  applicationId: string;
+  fullName: string;
+  phoneNumber: string;
+  email: string;
+  propertyCount: number;
+  propertyLocations: string;
+  status: PartnerLandlordApplicationStatus;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreatePartnerLandlordApplicationData {
+  fullName: string;
+  phoneNumber: string;
+  email: string;
+  propertyCount: number;
+  propertyLocations: string;
+}

--- a/backend/src/models/partnerLandlordApplicationStore.ts
+++ b/backend/src/models/partnerLandlordApplicationStore.ts
@@ -1,0 +1,110 @@
+import { getPool } from "../db.js";
+import {
+  CreatePartnerLandlordApplicationData,
+  PartnerLandlordApplication,
+  PartnerLandlordApplicationStatus,
+} from "./partnerLandlordApplication.js";
+
+export interface PartnerLandlordApplicationStore {
+  create(
+    data: CreatePartnerLandlordApplicationData,
+  ): Promise<PartnerLandlordApplication>;
+}
+
+export class InMemoryPartnerLandlordApplicationStore
+  implements PartnerLandlordApplicationStore
+{
+  private applications = new Map<string, PartnerLandlordApplication>();
+  private counter = 1;
+
+  async create(
+    data: CreatePartnerLandlordApplicationData,
+  ): Promise<PartnerLandlordApplication> {
+    const applicationId = `PLA-${Date.now()}-${this.counter++}`;
+    const now = new Date().toISOString();
+    const application: PartnerLandlordApplication = {
+      applicationId,
+      ...data,
+      status: PartnerLandlordApplicationStatus.PENDING,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    this.applications.set(applicationId, application);
+    return application;
+  }
+
+  async clear(): Promise<void> {
+    this.applications.clear();
+    this.counter = 1;
+  }
+}
+
+export class PostgresPartnerLandlordApplicationStore
+  implements PartnerLandlordApplicationStore
+{
+  async create(
+    data: CreatePartnerLandlordApplicationData,
+  ): Promise<PartnerLandlordApplication> {
+    const pool = await getPool();
+    if (!pool) throw new Error("Database pool not initialized");
+
+    const result = await pool.query(
+      `INSERT INTO partner_landlord_applications (
+         full_name,
+         phone_number,
+         email,
+         property_count,
+         property_locations,
+         status,
+         created_at,
+         updated_at
+       ) VALUES ($1, $2, $3, $4, $5, $6, NOW(), NOW())
+       RETURNING
+         id as application_id,
+         full_name,
+         phone_number,
+         email,
+         property_count,
+         property_locations,
+         status,
+         created_at,
+         updated_at`,
+      [
+        data.fullName,
+        data.phoneNumber,
+        data.email,
+        data.propertyCount,
+        data.propertyLocations,
+        PartnerLandlordApplicationStatus.PENDING,
+      ],
+    );
+
+    return this.mapRow(result.rows[0]);
+  }
+
+  private mapRow(row: Record<string, any>): PartnerLandlordApplication {
+    return {
+      applicationId: row.application_id,
+      fullName: row.full_name,
+      phoneNumber: row.phone_number,
+      email: row.email,
+      propertyCount: row.property_count,
+      propertyLocations: row.property_locations,
+      status: row.status,
+      createdAt: row.created_at.toISOString(),
+      updatedAt: row.updated_at.toISOString(),
+    };
+  }
+}
+
+let partnerLandlordApplicationStore: PartnerLandlordApplicationStore =
+  new InMemoryPartnerLandlordApplicationStore();
+
+export function initPartnerLandlordApplicationStore(
+  store: PartnerLandlordApplicationStore,
+): void {
+  partnerLandlordApplicationStore = store;
+}
+
+export { partnerLandlordApplicationStore };

--- a/backend/src/models/whistleblowerSignupApplication.ts
+++ b/backend/src/models/whistleblowerSignupApplication.ts
@@ -1,0 +1,27 @@
+export enum WhistleblowerSignupApplicationStatus {
+  PENDING = "pending",
+}
+
+export interface WhistleblowerSignupApplication {
+  applicationId: string;
+  fullName: string;
+  email: string;
+  phone: string;
+  address: string;
+  linkedinProfile: string;
+  facebookProfile: string;
+  instagramProfile: string;
+  status: WhistleblowerSignupApplicationStatus;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateWhistleblowerSignupApplicationData {
+  fullName: string;
+  email: string;
+  phone: string;
+  address: string;
+  linkedinProfile: string;
+  facebookProfile: string;
+  instagramProfile: string;
+}

--- a/backend/src/models/whistleblowerSignupApplicationStore.ts
+++ b/backend/src/models/whistleblowerSignupApplicationStore.ts
@@ -1,0 +1,118 @@
+import { getPool } from "../db.js";
+import {
+  CreateWhistleblowerSignupApplicationData,
+  WhistleblowerSignupApplication,
+  WhistleblowerSignupApplicationStatus,
+} from "./whistleblowerSignupApplication.js";
+
+export interface WhistleblowerSignupApplicationStore {
+  create(
+    data: CreateWhistleblowerSignupApplicationData,
+  ): Promise<WhistleblowerSignupApplication>;
+}
+
+export class InMemoryWhistleblowerSignupApplicationStore
+  implements WhistleblowerSignupApplicationStore
+{
+  private applications = new Map<string, WhistleblowerSignupApplication>();
+  private counter = 1;
+
+  async create(
+    data: CreateWhistleblowerSignupApplicationData,
+  ): Promise<WhistleblowerSignupApplication> {
+    const applicationId = `WSA-${Date.now()}-${this.counter++}`;
+    const now = new Date().toISOString();
+    const application: WhistleblowerSignupApplication = {
+      applicationId,
+      ...data,
+      status: WhistleblowerSignupApplicationStatus.PENDING,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    this.applications.set(applicationId, application);
+    return application;
+  }
+
+  async clear(): Promise<void> {
+    this.applications.clear();
+    this.counter = 1;
+  }
+}
+
+export class PostgresWhistleblowerSignupApplicationStore
+  implements WhistleblowerSignupApplicationStore
+{
+  async create(
+    data: CreateWhistleblowerSignupApplicationData,
+  ): Promise<WhistleblowerSignupApplication> {
+    const pool = await getPool();
+    if (!pool) throw new Error("Database pool not initialized");
+
+    const result = await pool.query(
+      `INSERT INTO whistleblower_signup_applications (
+         full_name,
+         email,
+         phone,
+         address,
+         linkedin_profile,
+         facebook_profile,
+         instagram_profile,
+         status,
+         created_at,
+         updated_at
+       ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NOW(), NOW())
+       RETURNING
+         id as application_id,
+         full_name,
+         email,
+         phone,
+         address,
+         linkedin_profile,
+         facebook_profile,
+         instagram_profile,
+         status,
+         created_at,
+         updated_at`,
+      [
+        data.fullName,
+        data.email,
+        data.phone,
+        data.address,
+        data.linkedinProfile,
+        data.facebookProfile,
+        data.instagramProfile,
+        WhistleblowerSignupApplicationStatus.PENDING,
+      ],
+    );
+
+    return this.mapRow(result.rows[0]);
+  }
+
+  private mapRow(row: Record<string, any>): WhistleblowerSignupApplication {
+    return {
+      applicationId: row.application_id,
+      fullName: row.full_name,
+      email: row.email,
+      phone: row.phone,
+      address: row.address,
+      linkedinProfile: row.linkedin_profile,
+      facebookProfile: row.facebook_profile,
+      instagramProfile: row.instagram_profile,
+      status: row.status,
+      createdAt: row.created_at.toISOString(),
+      updatedAt: row.updated_at.toISOString(),
+    };
+  }
+}
+
+let whistleblowerSignupApplicationStore: WhistleblowerSignupApplicationStore =
+  new InMemoryWhistleblowerSignupApplicationStore();
+
+export function initWhistleblowerSignupApplicationStore(
+  store: WhistleblowerSignupApplicationStore,
+): void {
+  whistleblowerSignupApplicationStore = store;
+}
+
+export { whistleblowerSignupApplicationStore };

--- a/backend/src/routes/partnerLandlordApplications.test.ts
+++ b/backend/src/routes/partnerLandlordApplications.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import request from "supertest";
+import express from "express";
+import { createPartnerLandlordApplicationsRouter } from "./partnerLandlordApplications.js";
+import { errorHandler } from "../middleware/errorHandler.js";
+import {
+  InMemoryPartnerLandlordApplicationStore,
+  initPartnerLandlordApplicationStore,
+} from "../models/partnerLandlordApplicationStore.js";
+
+describe("Partner Landlord Application Routes", () => {
+  let app: express.Application;
+  let store: InMemoryPartnerLandlordApplicationStore;
+
+  beforeEach(async () => {
+    store = new InMemoryPartnerLandlordApplicationStore();
+    initPartnerLandlordApplicationStore(store);
+
+    app = express();
+    app.use(express.json());
+    app.use(
+      "/api/landlord/partner-applications",
+      createPartnerLandlordApplicationsRouter(),
+    );
+    app.use(errorHandler);
+
+    await store.clear();
+  });
+
+  it("creates partner landlord application with valid payload", async () => {
+    const response = await request(app)
+      .post("/api/landlord/partner-applications")
+      .send({
+        fullName: "Adeola Adebayo",
+        phoneNumber: "08012345678",
+        email: "adeola@example.com",
+        propertyCount: 5,
+        propertyLocations: "Lekki, Yaba",
+      })
+      .expect(201);
+
+    expect(response.body.success).toBe(true);
+    expect(response.body.data.applicationId).toBeDefined();
+    expect(response.body.data.status).toBe("pending");
+  });
+
+  it("rejects invalid partner landlord payload with validation error", async () => {
+    const response = await request(app)
+      .post("/api/landlord/partner-applications")
+      .send({
+        fullName: "",
+        phoneNumber: "123",
+        email: "not-an-email",
+        propertyCount: 0,
+        propertyLocations: "",
+      })
+      .expect(400);
+
+    expect(response.body.error.code).toBe("VALIDATION_ERROR");
+  });
+});

--- a/backend/src/routes/partnerLandlordApplications.ts
+++ b/backend/src/routes/partnerLandlordApplications.ts
@@ -1,0 +1,30 @@
+import { Router, type Request, type Response, type NextFunction } from "express";
+import { validate } from "../middleware/validate.js";
+import { partnerLandlordApplicationStore } from "../models/partnerLandlordApplicationStore.js";
+import { createPartnerLandlordApplicationSchema } from "../schemas/partnerLandlordApplication.js";
+
+export function createPartnerLandlordApplicationsRouter(): Router {
+  const router = Router();
+
+  router.post(
+    "/",
+    validate(createPartnerLandlordApplicationSchema),
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const application = await partnerLandlordApplicationStore.create(req.body);
+        res.status(201).json({
+          success: true,
+          data: {
+            applicationId: application.applicationId,
+            status: application.status,
+            createdAt: application.createdAt,
+          },
+        });
+      } catch (error) {
+        next(error);
+      }
+    },
+  );
+
+  return router;
+}

--- a/backend/src/routes/whistleblowerApplications.test.ts
+++ b/backend/src/routes/whistleblowerApplications.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import request from "supertest";
+import express from "express";
+import { createWhistleblowerApplicationsRouter } from "./whistleblowerApplications.js";
+import { errorHandler } from "../middleware/errorHandler.js";
+import {
+  InMemoryWhistleblowerSignupApplicationStore,
+  initWhistleblowerSignupApplicationStore,
+} from "../models/whistleblowerSignupApplicationStore.js";
+
+describe("Whistleblower Signup Application Routes", () => {
+  let app: express.Application;
+  let store: InMemoryWhistleblowerSignupApplicationStore;
+
+  beforeEach(async () => {
+    store = new InMemoryWhistleblowerSignupApplicationStore();
+    initWhistleblowerSignupApplicationStore(store);
+
+    app = express();
+    app.use(express.json());
+    app.use("/api/whistleblower/applications", createWhistleblowerApplicationsRouter());
+    app.use(errorHandler);
+
+    await store.clear();
+  });
+
+  it("creates whistleblower signup application with valid payload", async () => {
+    const response = await request(app)
+      .post("/api/whistleblower/applications")
+      .send({
+        fullName: "Amina Yusuf",
+        email: "amina@example.com",
+        phone: "+2348012345678",
+        address: "Block 5, Flat 2A, Yaba, Lagos",
+        linkedinProfile: "https://linkedin.com/in/amina-yusuf",
+        facebookProfile: "https://facebook.com/amina.yusuf",
+        instagramProfile: "https://instagram.com/amina.yusuf",
+      })
+      .expect(201);
+
+    expect(response.body.success).toBe(true);
+    expect(response.body.data.applicationId).toBeDefined();
+    expect(response.body.data.status).toBe("pending");
+  });
+
+  it("rejects invalid whistleblower signup payload with validation error", async () => {
+    const response = await request(app)
+      .post("/api/whistleblower/applications")
+      .send({
+        fullName: "A",
+        email: "invalid",
+        phone: "1",
+        address: "No",
+        linkedinProfile: "not-a-url",
+        facebookProfile: "not-a-url",
+        instagramProfile: "not-a-url",
+      })
+      .expect(400);
+
+    expect(response.body.error.code).toBe("VALIDATION_ERROR");
+  });
+});

--- a/backend/src/routes/whistleblowerApplications.ts
+++ b/backend/src/routes/whistleblowerApplications.ts
@@ -1,0 +1,32 @@
+import { Router, type Request, type Response, type NextFunction } from "express";
+import { validate } from "../middleware/validate.js";
+import { whistleblowerSignupApplicationStore } from "../models/whistleblowerSignupApplicationStore.js";
+import { createWhistleblowerSignupApplicationSchema } from "../schemas/whistleblowerSignupApplication.js";
+
+export function createWhistleblowerApplicationsRouter(): Router {
+  const router = Router();
+
+  router.post(
+    "/",
+    validate(createWhistleblowerSignupApplicationSchema),
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const application = await whistleblowerSignupApplicationStore.create(
+          req.body,
+        );
+        res.status(201).json({
+          success: true,
+          data: {
+            applicationId: application.applicationId,
+            status: application.status,
+            createdAt: application.createdAt,
+          },
+        });
+      } catch (error) {
+        next(error);
+      }
+    },
+  );
+
+  return router;
+}

--- a/backend/src/schemas/partnerLandlordApplication.ts
+++ b/backend/src/schemas/partnerLandlordApplication.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+
+export const createPartnerLandlordApplicationSchema = z.object({
+  fullName: z.string().trim().min(2).max(120),
+  phoneNumber: z.string().trim().min(7).max(30),
+  email: z.string().trim().email(),
+  propertyCount: z.coerce.number().int().positive().max(10000),
+  propertyLocations: z.string().trim().min(2).max(300),
+});
+
+export type CreatePartnerLandlordApplicationRequest = z.infer<
+  typeof createPartnerLandlordApplicationSchema
+>;

--- a/backend/src/schemas/whistleblowerSignupApplication.ts
+++ b/backend/src/schemas/whistleblowerSignupApplication.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+
+export const createWhistleblowerSignupApplicationSchema = z.object({
+  fullName: z.string().trim().min(2).max(120),
+  email: z.string().trim().email(),
+  phone: z.string().trim().min(7).max(30),
+  address: z.string().trim().min(5).max(300),
+  linkedinProfile: z.string().trim().url(),
+  facebookProfile: z.string().trim().url(),
+  instagramProfile: z.string().trim().url(),
+});
+
+export type CreateWhistleblowerSignupApplicationRequest = z.infer<
+  typeof createWhistleblowerSignupApplicationSchema
+>;

--- a/backend/src/services/earnings.test.ts
+++ b/backend/src/services/earnings.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from "vitest";
+import { EarningsServiceImpl, RewardRecord, RewardsDataLayer } from "./earnings.js";
+
+function createReward(partial: Partial<RewardRecord>): RewardRecord {
+  return {
+    id: partial.id ?? "reward-1",
+    whistleblowerId: partial.whistleblowerId ?? "wb-1",
+    listingId: partial.listingId ?? "listing-1",
+    dealId: partial.dealId ?? "deal-1",
+    amountUsdc: partial.amountUsdc ?? 1_000_000n,
+    status: partial.status ?? "pending",
+    createdAt: partial.createdAt ?? new Date("2026-01-01T00:00:00.000Z"),
+    paidAt: partial.paidAt ?? null,
+  };
+}
+
+describe("EarningsServiceImpl", () => {
+  it("aggregates mixed payout states and keeps totals invariant", async () => {
+    const rewards = [
+      createReward({
+        id: "r1",
+        amountUsdc: 20_500_000n,
+        status: "pending",
+        createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      }),
+      createReward({
+        id: "r2",
+        amountUsdc: 5_250_000n,
+        status: "payable",
+        createdAt: new Date("2026-01-03T00:00:00.000Z"),
+      }),
+      createReward({
+        id: "r3",
+        amountUsdc: 4_250_000n,
+        status: "paid",
+        createdAt: new Date("2026-01-02T00:00:00.000Z"),
+        paidAt: new Date("2026-01-04T00:00:00.000Z"),
+      }),
+    ];
+    const dataLayer: RewardsDataLayer = {
+      whistleblowerExists: vi.fn().mockResolvedValue(true),
+      getRewardsByWhistleblower: vi.fn().mockResolvedValue(rewards),
+    };
+    const service = new EarningsServiceImpl(dataLayer, { usdcToNgnRate: 1600 });
+
+    const result = await service.getEarnings("wb-1");
+
+    expect(result.totals.totalUsdc).toBe(30);
+    expect(result.totals.pendingUsdc).toBe(25.75);
+    expect(result.totals.paidUsdc).toBe(4.25);
+    expect(result.totals.pendingUsdc + result.totals.paidUsdc).toBe(
+      result.totals.totalUsdc,
+    );
+    expect(result.totals.totalNgn).toBe(48_000);
+    expect(result.history.map((item) => item.rewardId)).toEqual(["r2", "r3", "r1"]);
+    expect(result.history[1].paidAt).toBe("2026-01-04T00:00:00.000Z");
+  });
+
+  it("returns zero totals and empty history for empty rewards", async () => {
+    const dataLayer: RewardsDataLayer = {
+      whistleblowerExists: vi.fn().mockResolvedValue(true),
+      getRewardsByWhistleblower: vi.fn().mockResolvedValue([]),
+    };
+    const service = new EarningsServiceImpl(dataLayer, { usdcToNgnRate: 1600 });
+
+    const result = await service.getEarnings("wb-empty");
+
+    expect(result.history).toEqual([]);
+    expect(result.totals).toEqual({
+      totalNgn: 0,
+      pendingNgn: 0,
+      paidNgn: 0,
+      totalUsdc: 0,
+      pendingUsdc: 0,
+      paidUsdc: 0,
+    });
+  });
+
+  it("throws not found for unknown whistleblower", async () => {
+    const dataLayer: RewardsDataLayer = {
+      whistleblowerExists: vi.fn().mockResolvedValue(false),
+      getRewardsByWhistleblower: vi.fn(),
+    };
+    const service = new EarningsServiceImpl(dataLayer, { usdcToNgnRate: 1600 });
+
+    await expect(service.getEarnings("wb-missing")).rejects.toMatchObject({
+      name: "AppError",
+      status: 404,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add public intake endpoints for landlord partner and whistleblower signup applications with validation and persistence wiring
- harden receipt/timelock repository bootstrap to fail fast outside development/test when `DATABASE_URL` is missing
- expand earnings service coverage with deterministic unit tests for mixed payout states, empty histories, unknown whistleblowers, and aggregate invariants

## Test plan
- [x] `npm run test -- src/indexer/repositoryBootstrap.test.ts src/routes/partnerLandlordApplications.test.ts src/routes/whistleblowerApplications.test.ts src/services/earnings.test.ts`
- [x] Verified validation failure paths return structured `VALIDATION_ERROR` responses in new public intake routes
- [x] Verified bootstrap selection behavior in dev/test fallback and production fail-fast scenarios

Closes Shelterflex/monorepo#563
Closes Shelterflex/monorepo#567
Closes Shelterflex/monorepo#571
Closes Shelterflex/monorepo#574
