### PR TITLE
 Add public contact/support message intake endpoint

### DIFF
--- a/backend/docs/openapi.yml
+++ b/backend/docs/openapi.yml
@@ -312,6 +312,31 @@ paths:
         default:
           $ref: "#/components/responses/Error"
 
+  /api/support/messages:
+    post:
+      summary: Submit a public support inquiry
+      description: Accepts and stores a public contact/support message for later handling.
+      operationId: createSupportMessage
+      tags:
+        - Support
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateSupportMessageRequest"
+      responses:
+        "201":
+          description: Message accepted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CreateSupportMessageResponse"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        default:
+          $ref: "#/components/responses/Error"
+
   /soroban/config:
     get:
       summary: Get Soroban configuration
@@ -2200,6 +2225,48 @@ components:
         total:
           type: integer
 
+    CreateSupportMessageRequest:
+      type: object
+      required:
+        - name
+        - email
+        - subject
+        - message
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 100
+        email:
+          type: string
+          format: email
+          maxLength: 254
+        phone:
+          type: string
+          nullable: true
+          maxLength: 32
+        subject:
+          type: string
+          minLength: 1
+          maxLength: 200
+        message:
+          type: string
+          minLength: 1
+          maxLength: 5000
+
+    CreateSupportMessageResponse:
+      type: object
+      required:
+        - success
+        - messageId
+      properties:
+        success:
+          type: boolean
+          example: true
+        messageId:
+          type: string
+          format: uuid
+
     BankAccountDetails:
       type: object
       required:
@@ -3258,3 +3325,5 @@ tags:
     description: Administrative operations including reward payouts
   - name: Staking
     description: Staking operations (stake, unstake, claim rewards)
+  - name: Support
+    description: Public support/contact message intake

--- a/backend/migrations/016_support_messages.sql
+++ b/backend/migrations/016_support_messages.sql
@@ -1,0 +1,21 @@
+-- Public support/contact form submissions
+-- Stores anonymous inbound messages for later support handling.
+
+CREATE TABLE IF NOT EXISTS support_messages (
+  message_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name TEXT NOT NULL,
+  email TEXT NOT NULL,
+  phone TEXT,
+  subject TEXT NOT NULL,
+  message TEXT NOT NULL,
+  ip TEXT,
+  user_agent TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS support_messages_created_at_idx
+  ON support_messages (created_at DESC);
+
+CREATE INDEX IF NOT EXISTS support_messages_email_idx
+  ON support_messages (email);
+

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -105,6 +105,7 @@ import { createNotificationsRouter } from "./routes/notifications.js";
 import { createSettlementAdminRouter } from "./routes/settlementAdmin.js";
 import { SettlementOutboxWorker } from "./settlement/worker.js";
 import { durableIdempotencyService } from "./services/durableIdempotencyService.js";
+import { createSupportRouter } from "./routes/support.js";
 import {
   PostgresTenantApplicationStore,
   initTenantApplicationStore,
@@ -407,6 +408,7 @@ export function createApp() {
   app.use("/", publicRouter);
   app.use("/api", createBalanceRouter(sorobanAdapter));
   app.use("/api", createReceiptsRouter(receiptRepo));
+  app.use("/api/support", createSupportRouter());
   app.use(
     "/api/wallet",
     createWalletRateLimiter(env),

--- a/backend/src/models/persistence.test.ts
+++ b/backend/src/models/persistence.test.ts
@@ -18,6 +18,7 @@ const __dirname = path.dirname(__filename)
 const migrationPaths = [
   path.resolve(__dirname, '../../migrations/006_deal_listing_reward_store.sql'),
   path.resolve(__dirname, '../../migrations/014_settlement_outbox.sql'),
+  path.resolve(__dirname, '../../migrations/016_support_messages.sql'),
 ]
 
 function loadMigrations(sql: string) {

--- a/backend/src/models/supportMessage.ts
+++ b/backend/src/models/supportMessage.ts
@@ -1,0 +1,24 @@
+export type SupportMessage = {
+  messageId: string
+  name: string
+  email: string
+  phone?: string
+  subject: string
+  message: string
+  createdAt: Date
+
+  // Optional request context (best-effort; used for abuse triage)
+  ip?: string
+  userAgent?: string
+}
+
+export type CreateSupportMessageInput = {
+  name: string
+  email: string
+  phone?: string
+  subject: string
+  message: string
+  ip?: string
+  userAgent?: string
+}
+

--- a/backend/src/models/supportMessageStore.ts
+++ b/backend/src/models/supportMessageStore.ts
@@ -1,0 +1,151 @@
+import { randomUUID } from 'node:crypto'
+import { getPool, type PgPoolLike } from '../db.js'
+import type { CreateSupportMessageInput, SupportMessage } from './supportMessage.js'
+
+interface SupportMessageStorePort {
+  create(input: CreateSupportMessageInput): Promise<SupportMessage>
+  listAll(): Promise<SupportMessage[]>
+  clear(): Promise<void>
+}
+
+class InMemorySupportMessageStore implements SupportMessageStorePort {
+  private messages: SupportMessage[] = []
+
+  async create(input: CreateSupportMessageInput): Promise<SupportMessage> {
+    const created: SupportMessage = {
+      messageId: randomUUID(),
+      name: input.name,
+      email: input.email,
+      phone: input.phone,
+      subject: input.subject,
+      message: input.message,
+      ip: input.ip,
+      userAgent: input.userAgent,
+      createdAt: new Date(),
+    }
+    this.messages.unshift(created)
+    return created
+  }
+
+  async listAll(): Promise<SupportMessage[]> {
+    return [...this.messages]
+  }
+
+  async clear(): Promise<void> {
+    this.messages = []
+  }
+}
+
+type SupportMessageRow = {
+  message_id: string
+  name: string
+  email: string
+  phone: string | null
+  subject: string
+  message: string
+  ip: string | null
+  user_agent: string | null
+  created_at: Date
+}
+
+class PostgresSupportMessageStore implements SupportMessageStorePort {
+  private async pool(): Promise<PgPoolLike> {
+    const pool = await getPool()
+    if (!pool) {
+      throw new Error('Database pool is not available (DATABASE_URL/pg not configured)')
+    }
+    return pool
+  }
+
+  async isAvailable(): Promise<boolean> {
+    return (await getPool()) !== null
+  }
+
+  async create(input: CreateSupportMessageInput): Promise<SupportMessage> {
+    const pool = await this.pool()
+    const messageId = randomUUID()
+
+    const { rows } = await pool.query(
+      `INSERT INTO support_messages (
+        message_id,
+        name,
+        email,
+        phone,
+        subject,
+        message,
+        ip,
+        user_agent
+      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+      RETURNING *`,
+      [
+        messageId,
+        input.name,
+        input.email,
+        input.phone ?? null,
+        input.subject,
+        input.message,
+        input.ip ?? null,
+        input.userAgent ?? null,
+      ],
+    )
+
+    return this.mapRow(rows[0] as SupportMessageRow)
+  }
+
+  async listAll(): Promise<SupportMessage[]> {
+    const pool = await this.pool()
+    const { rows } = await pool.query(
+      `SELECT * FROM support_messages ORDER BY created_at DESC`,
+    )
+    return rows.map((r) => this.mapRow(r as SupportMessageRow))
+  }
+
+  async clear(): Promise<void> {
+    const pool = await this.pool()
+    if (process.env.NODE_ENV !== 'test') {
+      throw new Error(
+        'supportMessageStore.clear() is only supported in test env when using Postgres',
+      )
+    }
+    await pool.query('TRUNCATE support_messages RESTART IDENTITY CASCADE')
+  }
+
+  private mapRow(row: SupportMessageRow): SupportMessage {
+    return {
+      messageId: row.message_id,
+      name: row.name,
+      email: row.email,
+      phone: row.phone ?? undefined,
+      subject: row.subject,
+      message: row.message,
+      ip: row.ip ?? undefined,
+      userAgent: row.user_agent ?? undefined,
+      createdAt: new Date(row.created_at),
+    }
+  }
+}
+
+class HybridSupportMessageStore implements SupportMessageStorePort {
+  private memory = new InMemorySupportMessageStore()
+  private postgres = new PostgresSupportMessageStore()
+
+  private async adapter(): Promise<SupportMessageStorePort> {
+    if (await this.postgres.isAvailable()) return this.postgres
+    return this.memory
+  }
+
+  async create(input: CreateSupportMessageInput): Promise<SupportMessage> {
+    return (await this.adapter()).create(input)
+  }
+
+  async listAll(): Promise<SupportMessage[]> {
+    return (await this.adapter()).listAll()
+  }
+
+  async clear(): Promise<void> {
+    return (await this.adapter()).clear()
+  }
+}
+
+export const supportMessageStore = new HybridSupportMessageStore()
+

--- a/backend/src/routes/support.test.ts
+++ b/backend/src/routes/support.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import request from 'supertest'
+import { createApp } from '../app.js'
+import { supportMessageStore } from '../models/supportMessageStore.js'
+
+describe('Support messages API', () => {
+  let app: any
+
+  beforeEach(async () => {
+    await supportMessageStore.clear()
+    app = createApp()
+  })
+
+  it('accepts a valid public support inquiry and persists it', async () => {
+    const payload = {
+      name: 'Ada Lovelace',
+      email: 'ada@example.com',
+      phone: '+2348012345678',
+      subject: 'Help needed',
+      message: 'I need help with my account.',
+    }
+
+    const res = await request(app)
+      .post('/api/support/messages')
+      .set('User-Agent', 'vitest')
+      .send(payload)
+      .expect(201)
+
+    expect(res.body.success).toBe(true)
+    expect(res.body.messageId).toBeTruthy()
+
+    const all = await supportMessageStore.listAll()
+    expect(all).toHaveLength(1)
+    expect(all[0]).toMatchObject({
+      name: payload.name,
+      email: payload.email,
+      phone: payload.phone,
+      subject: payload.subject,
+      message: payload.message,
+    })
+  })
+
+  it('returns structured validation errors for invalid submissions', async () => {
+    const res = await request(app)
+      .post('/api/support/messages')
+      .send({
+        name: '',
+        email: 'not-an-email',
+        subject: '',
+        message: '',
+      })
+      .expect(400)
+
+    expect(res.body.error.code).toBe('VALIDATION_ERROR')
+    expect(res.body.error.message).toBe('Invalid request data')
+    expect(res.body.error.details).toBeTruthy()
+    expect(typeof res.body.error.details.name).toBe('string')
+    expect(typeof res.body.error.details.email).toBe('string')
+    expect(typeof res.body.error.details.subject).toBe('string')
+    expect(typeof res.body.error.details.message).toBe('string')
+  })
+
+  it('treats empty phone as optional', async () => {
+    const res = await request(app)
+      .post('/api/support/messages')
+      .send({
+        name: 'Test User',
+        email: 'test@example.com',
+        phone: '',
+        subject: 'Subject',
+        message: 'Message',
+      })
+      .expect(201)
+
+    expect(res.body.success).toBe(true)
+    const all = await supportMessageStore.listAll()
+    expect(all[0].phone).toBeUndefined()
+  })
+})
+

--- a/backend/src/routes/support.ts
+++ b/backend/src/routes/support.ts
@@ -1,0 +1,56 @@
+import { Router, type Request, type Response } from 'express'
+import { validate } from '../middleware/validate.js'
+import { createSupportMessageSchema } from '../schemas/supportMessage.js'
+import { supportMessageStore } from '../models/supportMessageStore.js'
+
+export function createSupportRouter(): Router {
+  const router = Router()
+
+  /**
+   * POST /api/support/messages
+   * Public support inquiry intake.
+   */
+  router.post(
+    '/messages',
+    validate(createSupportMessageSchema, 'body'),
+    async (req: Request, res: Response, next) => {
+      try {
+        const { name, email, phone, subject, message } = req.body as any
+
+        const forwardedFor = req.headers['x-forwarded-for']
+        const ip =
+          typeof forwardedFor === 'string'
+            ? forwardedFor.split(',')[0]?.trim()
+            : Array.isArray(forwardedFor)
+              ? forwardedFor[0]
+              : req.ip
+
+        const userAgent =
+          typeof req.headers['user-agent'] === 'string'
+            ? req.headers['user-agent']
+            : undefined
+
+        const saved = await supportMessageStore.create({
+          name,
+          email,
+          phone,
+          subject,
+          message,
+          ip,
+          userAgent,
+        })
+
+        // Stable response (don’t echo user content back)
+        res.status(201).json({
+          success: true,
+          messageId: saved.messageId,
+        })
+      } catch (err) {
+        next(err)
+      }
+    },
+  )
+
+  return router
+}
+

--- a/backend/src/schemas/supportMessage.ts
+++ b/backend/src/schemas/supportMessage.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod'
+
+const emptyStringToUndefined = (value: unknown) => {
+  if (typeof value === 'string' && value.trim() === '') return undefined
+  return value
+}
+
+export const createSupportMessageSchema = z.object({
+  name: z.string().trim().min(1, 'Name is required').max(100, 'Name is too long'),
+  email: z
+    .string()
+    .trim()
+    .email('Email must be a valid email address')
+    .max(254, 'Email is too long'),
+  phone: z.preprocess(
+    emptyStringToUndefined,
+    z.string().trim().min(3, 'Phone is too short').max(32, 'Phone is too long').optional(),
+  ),
+  subject: z
+    .string()
+    .trim()
+    .min(1, 'Subject is required')
+    .max(200, 'Subject is too long'),
+  message: z
+    .string()
+    .trim()
+    .min(1, 'Message is required')
+    .max(5000, 'Message is too long'),
+})
+
+export type CreateSupportMessageRequest = z.infer<typeof createSupportMessageSchema>
+


### PR DESCRIPTION
## Summary
Add a real backend intake path for the public contact form by introducing a POST /api/support/messages endpoint with Zod validation, persistence (Postgres-backed when DATABASE_URL is set, in-memory fallback otherwise), and route tests. This replaces the current simulated success behavior with stored support inquiries.

Linked issue (recommended)
Closes #582 

## Changes
Added POST /api/support/messages public endpoint with stable success response.
Added request validation for required contact + message fields with structured validation errors.
Added persistence layer:
SQL migration support_messages table
Hybrid store (Postgres when configured; in-memory fallback)
Added route tests covering representative success and failure cases.
Updated OpenAPI spec to include the new endpoint and schemas.
How to test
Backend:
cd backend
npm ci
npm run lint
npm run test:ci
npm run openapi:validate
Frontend:
cd frontend
pnpm install --frozen-lockfile
pnpm run lint
pnpm run build
Security Considerations
No secrets or sensitive data are logged.
No changes to authentication/authorization logic.
No changes to admin/upgrade logic.
## Checklist

I linked an issue (or explained why one is not needed)

I tested locally

I did not commit secrets

I updated docs if needed

Code follows the project's style guidelines

CI checks pass

If UI changes: I included before/after screenshots

If images added/changed: I verified they are optimized and accessible
After saving, re-run checks (or push any commit) and the PR Validation job should pass.