### PR TITLE
Feat/add property issue report

### DIFF
--- a/backend/docs/openapi.yml
+++ b/backend/docs/openapi.yml
@@ -337,6 +337,106 @@ paths:
         default:
           $ref: "#/components/responses/Error"
 
+  /api/whistleblower/ratings:
+    post:
+      summary: Submit a whistleblower rating (tenant)
+      description: Authenticated tenant submits a rating (1-5) and optional review text.
+      operationId: createWhistleblowerRating
+      tags:
+        - Whistleblower
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateWhistleblowerRatingRequest"
+      responses:
+        "201":
+          description: Rating created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CreateWhistleblowerRatingResponse"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "409":
+          $ref: "#/components/responses/Error"
+        default:
+          $ref: "#/components/responses/Error"
+
+  /api/whistleblower/{id}/ratings:
+    get:
+      summary: List whistleblower ratings
+      description: Public list of ratings for profile/dashboard display.
+      operationId: listWhistleblowerRatings
+      tags:
+        - Whistleblower
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+      responses:
+        "200":
+          description: Ratings list
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [success, ratings]
+                properties:
+                  success:
+                    type: boolean
+                  ratings:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/WhistleblowerRating"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        default:
+          $ref: "#/components/responses/Error"
+
+  /api/whistleblower/{id}/ratings/aggregate:
+    get:
+      summary: Get whistleblower rating aggregate
+      description: Public aggregate trust metrics (count, average, breakdown).
+      operationId: getWhistleblowerRatingAggregate
+      tags:
+        - Whistleblower
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Aggregate metrics
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [success, aggregate]
+                properties:
+                  success:
+                    type: boolean
+                  aggregate:
+                    $ref: "#/components/schemas/WhistleblowerRatingAggregate"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        default:
+          $ref: "#/components/responses/Error"
+
   /soroban/config:
     get:
       summary: Get Soroban configuration
@@ -2266,6 +2366,79 @@ components:
         messageId:
           type: string
           format: uuid
+
+    CreateWhistleblowerRatingRequest:
+      type: object
+      required: [whistleblowerId, dealId, rating]
+      properties:
+        whistleblowerId:
+          type: string
+          minLength: 1
+        dealId:
+          type: string
+          minLength: 1
+        rating:
+          type: integer
+          minimum: 1
+          maximum: 5
+        reviewText:
+          type: string
+          nullable: true
+          maxLength: 2000
+
+    WhistleblowerRating:
+      type: object
+      required:
+        - ratingId
+        - whistleblowerId
+        - tenantId
+        - dealId
+        - rating
+        - createdAt
+      properties:
+        ratingId:
+          type: string
+          format: uuid
+        whistleblowerId:
+          type: string
+        tenantId:
+          type: string
+        dealId:
+          type: string
+        rating:
+          type: integer
+          minimum: 1
+          maximum: 5
+        reviewText:
+          type: string
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+
+    CreateWhistleblowerRatingResponse:
+      type: object
+      required: [success, rating]
+      properties:
+        success:
+          type: boolean
+        rating:
+          $ref: "#/components/schemas/WhistleblowerRating"
+
+    WhistleblowerRatingAggregate:
+      type: object
+      required: [whistleblowerId, count, average, breakdown]
+      properties:
+        whistleblowerId:
+          type: string
+        count:
+          type: integer
+        average:
+          type: number
+        breakdown:
+          type: object
+          additionalProperties:
+            type: integer
 
     BankAccountDetails:
       type: object

--- a/backend/docs/openapi.yml
+++ b/backend/docs/openapi.yml
@@ -437,6 +437,31 @@ paths:
         default:
           $ref: "#/components/responses/Error"
 
+  /api/property-issue-reports:
+    post:
+      summary: Submit a property issue report
+      description: Accepts and stores an issue report from the property detail report dialog.
+      operationId: createPropertyIssueReport
+      tags:
+        - Risk
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreatePropertyIssueReportRequest"
+      responses:
+        "201":
+          description: Report accepted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CreatePropertyIssueReportResponse"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        default:
+          $ref: "#/components/responses/Error"
+
   /soroban/config:
     get:
       summary: Get Soroban configuration
@@ -2439,6 +2464,38 @@ components:
           type: object
           additionalProperties:
             type: integer
+
+    CreatePropertyIssueReportRequest:
+      type: object
+      required:
+        - propertyId
+        - reportCategory
+        - reportDetails
+      properties:
+        propertyId:
+          type: string
+          minLength: 1
+        reportCategory:
+          type: string
+          minLength: 1
+          maxLength: 64
+          description: Category selected in the dialog (frontend field name).
+        reportDetails:
+          type: string
+          minLength: 1
+          maxLength: 2000
+          description: Free-text details entered in the dialog (frontend field name).
+
+    CreatePropertyIssueReportResponse:
+      type: object
+      required: [success, reportId]
+      properties:
+        success:
+          type: boolean
+          example: true
+        reportId:
+          type: string
+          format: uuid
 
     BankAccountDetails:
       type: object

--- a/backend/docs/openapi.yml
+++ b/backend/docs/openapi.yml
@@ -312,6 +312,31 @@ paths:
         default:
           $ref: "#/components/responses/Error"
 
+  /api/support/messages:
+    post:
+      summary: Submit a public support inquiry
+      description: Accepts and stores a public contact/support message for later handling.
+      operationId: createSupportMessage
+      tags:
+        - Support
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateSupportMessageRequest"
+      responses:
+        "201":
+          description: Message accepted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CreateSupportMessageResponse"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        default:
+          $ref: "#/components/responses/Error"
+
   /soroban/config:
     get:
       summary: Get Soroban configuration
@@ -2200,6 +2225,48 @@ components:
         total:
           type: integer
 
+    CreateSupportMessageRequest:
+      type: object
+      required:
+        - name
+        - email
+        - subject
+        - message
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 100
+        email:
+          type: string
+          format: email
+          maxLength: 254
+        phone:
+          type: string
+          nullable: true
+          maxLength: 32
+        subject:
+          type: string
+          minLength: 1
+          maxLength: 200
+        message:
+          type: string
+          minLength: 1
+          maxLength: 5000
+
+    CreateSupportMessageResponse:
+      type: object
+      required:
+        - success
+        - messageId
+      properties:
+        success:
+          type: boolean
+          example: true
+        messageId:
+          type: string
+          format: uuid
+
     BankAccountDetails:
       type: object
       required:
@@ -3258,3 +3325,5 @@ tags:
     description: Administrative operations including reward payouts
   - name: Staking
     description: Staking operations (stake, unstake, claim rewards)
+  - name: Support
+    description: Public support/contact message intake

--- a/backend/migrations/016_support_messages.sql
+++ b/backend/migrations/016_support_messages.sql
@@ -1,0 +1,21 @@
+-- Public support/contact form submissions
+-- Stores anonymous inbound messages for later support handling.
+
+CREATE TABLE IF NOT EXISTS support_messages (
+  message_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name TEXT NOT NULL,
+  email TEXT NOT NULL,
+  phone TEXT,
+  subject TEXT NOT NULL,
+  message TEXT NOT NULL,
+  ip TEXT,
+  user_agent TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS support_messages_created_at_idx
+  ON support_messages (created_at DESC);
+
+CREATE INDEX IF NOT EXISTS support_messages_email_idx
+  ON support_messages (email);
+

--- a/backend/migrations/017_whistleblower_ratings.sql
+++ b/backend/migrations/017_whistleblower_ratings.sql
@@ -1,0 +1,21 @@
+-- Tenant → Whistleblower ratings and review text (public trust signal)
+
+CREATE TABLE IF NOT EXISTS whistleblower_ratings (
+  rating_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  whistleblower_id TEXT NOT NULL,
+  tenant_id TEXT NOT NULL,
+  deal_id UUID NOT NULL REFERENCES tenant_deals(deal_id) ON DELETE CASCADE,
+  rating INTEGER NOT NULL CHECK (rating >= 1 AND rating <= 5),
+  review_text TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  -- Prevent duplicate submissions per completed rental
+  CONSTRAINT whistleblower_ratings_unique_per_deal UNIQUE (deal_id, tenant_id)
+);
+
+CREATE INDEX IF NOT EXISTS whistleblower_ratings_whistleblower_id_idx
+  ON whistleblower_ratings (whistleblower_id);
+
+CREATE INDEX IF NOT EXISTS whistleblower_ratings_created_at_idx
+  ON whistleblower_ratings (created_at DESC);
+

--- a/backend/migrations/018_property_issue_reports.sql
+++ b/backend/migrations/018_property_issue_reports.sql
@@ -1,0 +1,18 @@
+-- Property issue reports (from property detail report dialog)
+
+CREATE TABLE IF NOT EXISTS property_issue_reports (
+  report_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  property_id TEXT NOT NULL,
+  category TEXT NOT NULL,
+  details TEXT NOT NULL,
+  ip TEXT,
+  user_agent TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS property_issue_reports_property_id_idx
+  ON property_issue_reports (property_id);
+
+CREATE INDEX IF NOT EXISTS property_issue_reports_created_at_idx
+  ON property_issue_reports (created_at DESC);
+

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -106,6 +106,7 @@ import { createSettlementAdminRouter } from "./routes/settlementAdmin.js";
 import { SettlementOutboxWorker } from "./settlement/worker.js";
 import { durableIdempotencyService } from "./services/durableIdempotencyService.js";
 import { createSupportRouter } from "./routes/support.js";
+import { createPropertyIssueReportsRouter } from "./routes/propertyIssueReports.js";
 import {
   PostgresTenantApplicationStore,
   initTenantApplicationStore,
@@ -409,6 +410,7 @@ export function createApp() {
   app.use("/api", createBalanceRouter(sorobanAdapter));
   app.use("/api", createReceiptsRouter(receiptRepo));
   app.use("/api/support", createSupportRouter());
+  app.use("/api/property-issue-reports", createPropertyIssueReportsRouter());
   app.use(
     "/api/wallet",
     createWalletRateLimiter(env),

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -105,6 +105,7 @@ import { createNotificationsRouter } from "./routes/notifications.js";
 import { createSettlementAdminRouter } from "./routes/settlementAdmin.js";
 import { SettlementOutboxWorker } from "./settlement/worker.js";
 import { durableIdempotencyService } from "./services/durableIdempotencyService.js";
+import { createSupportRouter } from "./routes/support.js";
 import {
   PostgresTenantApplicationStore,
   initTenantApplicationStore,
@@ -407,6 +408,7 @@ export function createApp() {
   app.use("/", publicRouter);
   app.use("/api", createBalanceRouter(sorobanAdapter));
   app.use("/api", createReceiptsRouter(receiptRepo));
+  app.use("/api/support", createSupportRouter());
   app.use(
     "/api/wallet",
     createWalletRateLimiter(env),

--- a/backend/src/models/persistence.test.ts
+++ b/backend/src/models/persistence.test.ts
@@ -19,6 +19,7 @@ const migrationPaths = [
   path.resolve(__dirname, '../../migrations/006_deal_listing_reward_store.sql'),
   path.resolve(__dirname, '../../migrations/014_settlement_outbox.sql'),
   path.resolve(__dirname, '../../migrations/016_support_messages.sql'),
+  path.resolve(__dirname, '../../migrations/017_whistleblower_ratings.sql'),
 ]
 
 function loadMigrations(sql: string) {

--- a/backend/src/models/persistence.test.ts
+++ b/backend/src/models/persistence.test.ts
@@ -18,6 +18,7 @@ const __dirname = path.dirname(__filename)
 const migrationPaths = [
   path.resolve(__dirname, '../../migrations/006_deal_listing_reward_store.sql'),
   path.resolve(__dirname, '../../migrations/014_settlement_outbox.sql'),
+  path.resolve(__dirname, '../../migrations/016_support_messages.sql'),
 ]
 
 function loadMigrations(sql: string) {

--- a/backend/src/models/persistence.test.ts
+++ b/backend/src/models/persistence.test.ts
@@ -20,6 +20,7 @@ const migrationPaths = [
   path.resolve(__dirname, '../../migrations/014_settlement_outbox.sql'),
   path.resolve(__dirname, '../../migrations/016_support_messages.sql'),
   path.resolve(__dirname, '../../migrations/017_whistleblower_ratings.sql'),
+  path.resolve(__dirname, '../../migrations/018_property_issue_reports.sql'),
 ]
 
 function loadMigrations(sql: string) {

--- a/backend/src/models/propertyIssueReport.ts
+++ b/backend/src/models/propertyIssueReport.ts
@@ -1,0 +1,18 @@
+export type PropertyIssueReport = {
+  reportId: string
+  propertyId: string
+  category: string
+  details: string
+  ip?: string
+  userAgent?: string
+  createdAt: Date
+}
+
+export type CreatePropertyIssueReportInput = {
+  propertyId: string
+  category: string
+  details: string
+  ip?: string
+  userAgent?: string
+}
+

--- a/backend/src/models/propertyIssueReportStore.ts
+++ b/backend/src/models/propertyIssueReportStore.ts
@@ -1,0 +1,142 @@
+import { randomUUID } from 'node:crypto'
+import { getPool, type PgPoolLike } from '../db.js'
+import type {
+  CreatePropertyIssueReportInput,
+  PropertyIssueReport,
+} from './propertyIssueReport.js'
+
+interface PropertyIssueReportStorePort {
+  create(input: CreatePropertyIssueReportInput): Promise<PropertyIssueReport>
+  listAll(): Promise<PropertyIssueReport[]>
+  clear(): Promise<void>
+}
+
+class InMemoryPropertyIssueReportStore implements PropertyIssueReportStorePort {
+  private reports: PropertyIssueReport[] = []
+
+  async create(input: CreatePropertyIssueReportInput): Promise<PropertyIssueReport> {
+    const created: PropertyIssueReport = {
+      reportId: randomUUID(),
+      propertyId: input.propertyId,
+      category: input.category,
+      details: input.details,
+      ip: input.ip,
+      userAgent: input.userAgent,
+      createdAt: new Date(),
+    }
+    this.reports.unshift(created)
+    return created
+  }
+
+  async listAll(): Promise<PropertyIssueReport[]> {
+    return [...this.reports]
+  }
+
+  async clear(): Promise<void> {
+    this.reports = []
+  }
+}
+
+type ReportRow = {
+  report_id: string
+  property_id: string
+  category: string
+  details: string
+  ip: string | null
+  user_agent: string | null
+  created_at: Date
+}
+
+class PostgresPropertyIssueReportStore implements PropertyIssueReportStorePort {
+  private async pool(): Promise<PgPoolLike> {
+    const pool = await getPool()
+    if (!pool) {
+      throw new Error('Database pool is not available (DATABASE_URL/pg not configured)')
+    }
+    return pool
+  }
+
+  async isAvailable(): Promise<boolean> {
+    return (await getPool()) !== null
+  }
+
+  async create(input: CreatePropertyIssueReportInput): Promise<PropertyIssueReport> {
+    const pool = await this.pool()
+    const reportId = randomUUID()
+    const { rows } = await pool.query(
+      `INSERT INTO property_issue_reports (
+        report_id,
+        property_id,
+        category,
+        details,
+        ip,
+        user_agent
+      ) VALUES ($1, $2, $3, $4, $5, $6)
+      RETURNING *`,
+      [
+        reportId,
+        input.propertyId,
+        input.category,
+        input.details,
+        input.ip ?? null,
+        input.userAgent ?? null,
+      ],
+    )
+    return this.mapRow(rows[0] as ReportRow)
+  }
+
+  async listAll(): Promise<PropertyIssueReport[]> {
+    const pool = await this.pool()
+    const { rows } = await pool.query(
+      `SELECT * FROM property_issue_reports ORDER BY created_at DESC`,
+    )
+    return rows.map((r) => this.mapRow(r as ReportRow))
+  }
+
+  async clear(): Promise<void> {
+    const pool = await this.pool()
+    if (process.env.NODE_ENV !== 'test') {
+      throw new Error(
+        'propertyIssueReportStore.clear() is only supported in test env when using Postgres',
+      )
+    }
+    await pool.query('TRUNCATE property_issue_reports RESTART IDENTITY CASCADE')
+  }
+
+  private mapRow(row: ReportRow): PropertyIssueReport {
+    return {
+      reportId: row.report_id,
+      propertyId: row.property_id,
+      category: row.category,
+      details: row.details,
+      ip: row.ip ?? undefined,
+      userAgent: row.user_agent ?? undefined,
+      createdAt: new Date(row.created_at),
+    }
+  }
+}
+
+class HybridPropertyIssueReportStore implements PropertyIssueReportStorePort {
+  private memory = new InMemoryPropertyIssueReportStore()
+  private postgres = new PostgresPropertyIssueReportStore()
+
+  private async adapter(): Promise<PropertyIssueReportStorePort> {
+    if (await this.postgres.isAvailable()) return this.postgres
+    return this.memory
+  }
+
+  async create(input: CreatePropertyIssueReportInput): Promise<PropertyIssueReport> {
+    return (await this.adapter()).create(input)
+  }
+
+  async listAll(): Promise<PropertyIssueReport[]> {
+    return (await this.adapter()).listAll()
+  }
+
+  async clear(): Promise<void> {
+    return (await this.adapter()).clear()
+  }
+}
+
+export const propertyIssueReportStore = new HybridPropertyIssueReportStore()
+

--- a/backend/src/models/supportMessage.ts
+++ b/backend/src/models/supportMessage.ts
@@ -1,0 +1,24 @@
+export type SupportMessage = {
+  messageId: string
+  name: string
+  email: string
+  phone?: string
+  subject: string
+  message: string
+  createdAt: Date
+
+  // Optional request context (best-effort; used for abuse triage)
+  ip?: string
+  userAgent?: string
+}
+
+export type CreateSupportMessageInput = {
+  name: string
+  email: string
+  phone?: string
+  subject: string
+  message: string
+  ip?: string
+  userAgent?: string
+}
+

--- a/backend/src/models/supportMessageStore.ts
+++ b/backend/src/models/supportMessageStore.ts
@@ -1,0 +1,151 @@
+import { randomUUID } from 'node:crypto'
+import { getPool, type PgPoolLike } from '../db.js'
+import type { CreateSupportMessageInput, SupportMessage } from './supportMessage.js'
+
+interface SupportMessageStorePort {
+  create(input: CreateSupportMessageInput): Promise<SupportMessage>
+  listAll(): Promise<SupportMessage[]>
+  clear(): Promise<void>
+}
+
+class InMemorySupportMessageStore implements SupportMessageStorePort {
+  private messages: SupportMessage[] = []
+
+  async create(input: CreateSupportMessageInput): Promise<SupportMessage> {
+    const created: SupportMessage = {
+      messageId: randomUUID(),
+      name: input.name,
+      email: input.email,
+      phone: input.phone,
+      subject: input.subject,
+      message: input.message,
+      ip: input.ip,
+      userAgent: input.userAgent,
+      createdAt: new Date(),
+    }
+    this.messages.unshift(created)
+    return created
+  }
+
+  async listAll(): Promise<SupportMessage[]> {
+    return [...this.messages]
+  }
+
+  async clear(): Promise<void> {
+    this.messages = []
+  }
+}
+
+type SupportMessageRow = {
+  message_id: string
+  name: string
+  email: string
+  phone: string | null
+  subject: string
+  message: string
+  ip: string | null
+  user_agent: string | null
+  created_at: Date
+}
+
+class PostgresSupportMessageStore implements SupportMessageStorePort {
+  private async pool(): Promise<PgPoolLike> {
+    const pool = await getPool()
+    if (!pool) {
+      throw new Error('Database pool is not available (DATABASE_URL/pg not configured)')
+    }
+    return pool
+  }
+
+  async isAvailable(): Promise<boolean> {
+    return (await getPool()) !== null
+  }
+
+  async create(input: CreateSupportMessageInput): Promise<SupportMessage> {
+    const pool = await this.pool()
+    const messageId = randomUUID()
+
+    const { rows } = await pool.query(
+      `INSERT INTO support_messages (
+        message_id,
+        name,
+        email,
+        phone,
+        subject,
+        message,
+        ip,
+        user_agent
+      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+      RETURNING *`,
+      [
+        messageId,
+        input.name,
+        input.email,
+        input.phone ?? null,
+        input.subject,
+        input.message,
+        input.ip ?? null,
+        input.userAgent ?? null,
+      ],
+    )
+
+    return this.mapRow(rows[0] as SupportMessageRow)
+  }
+
+  async listAll(): Promise<SupportMessage[]> {
+    const pool = await this.pool()
+    const { rows } = await pool.query(
+      `SELECT * FROM support_messages ORDER BY created_at DESC`,
+    )
+    return rows.map((r) => this.mapRow(r as SupportMessageRow))
+  }
+
+  async clear(): Promise<void> {
+    const pool = await this.pool()
+    if (process.env.NODE_ENV !== 'test') {
+      throw new Error(
+        'supportMessageStore.clear() is only supported in test env when using Postgres',
+      )
+    }
+    await pool.query('TRUNCATE support_messages RESTART IDENTITY CASCADE')
+  }
+
+  private mapRow(row: SupportMessageRow): SupportMessage {
+    return {
+      messageId: row.message_id,
+      name: row.name,
+      email: row.email,
+      phone: row.phone ?? undefined,
+      subject: row.subject,
+      message: row.message,
+      ip: row.ip ?? undefined,
+      userAgent: row.user_agent ?? undefined,
+      createdAt: new Date(row.created_at),
+    }
+  }
+}
+
+class HybridSupportMessageStore implements SupportMessageStorePort {
+  private memory = new InMemorySupportMessageStore()
+  private postgres = new PostgresSupportMessageStore()
+
+  private async adapter(): Promise<SupportMessageStorePort> {
+    if (await this.postgres.isAvailable()) return this.postgres
+    return this.memory
+  }
+
+  async create(input: CreateSupportMessageInput): Promise<SupportMessage> {
+    return (await this.adapter()).create(input)
+  }
+
+  async listAll(): Promise<SupportMessage[]> {
+    return (await this.adapter()).listAll()
+  }
+
+  async clear(): Promise<void> {
+    return (await this.adapter()).clear()
+  }
+}
+
+export const supportMessageStore = new HybridSupportMessageStore()
+

--- a/backend/src/models/whistleblowerRating.ts
+++ b/backend/src/models/whistleblowerRating.ts
@@ -1,0 +1,25 @@
+export type WhistleblowerRating = {
+  ratingId: string
+  whistleblowerId: string
+  tenantId: string
+  dealId: string
+  rating: number
+  reviewText?: string
+  createdAt: Date
+}
+
+export type CreateWhistleblowerRatingInput = {
+  whistleblowerId: string
+  tenantId: string
+  dealId: string
+  rating: number
+  reviewText?: string
+}
+
+export type WhistleblowerRatingAggregate = {
+  whistleblowerId: string
+  count: number
+  average: number
+  breakdown: Record<1 | 2 | 3 | 4 | 5, number>
+}
+

--- a/backend/src/models/whistleblowerRatingStore.ts
+++ b/backend/src/models/whistleblowerRatingStore.ts
@@ -1,0 +1,238 @@
+import { randomUUID } from 'node:crypto'
+import { getPool, type PgPoolLike } from '../db.js'
+import type {
+  CreateWhistleblowerRatingInput,
+  WhistleblowerRating,
+  WhistleblowerRatingAggregate,
+} from './whistleblowerRating.js'
+
+interface WhistleblowerRatingStorePort {
+  create(input: CreateWhistleblowerRatingInput): Promise<WhistleblowerRating>
+  listByWhistleblower(
+    whistleblowerId: string,
+    opts?: { limit?: number },
+  ): Promise<WhistleblowerRating[]>
+  getAggregate(whistleblowerId: string): Promise<WhistleblowerRatingAggregate>
+  hasTenantRatedDeal(dealId: string, tenantId: string): Promise<boolean>
+  clear(): Promise<void>
+}
+
+class InMemoryWhistleblowerRatingStore implements WhistleblowerRatingStorePort {
+  private ratings: WhistleblowerRating[] = []
+
+  async create(input: CreateWhistleblowerRatingInput): Promise<WhistleblowerRating> {
+    const created: WhistleblowerRating = {
+      ratingId: randomUUID(),
+      whistleblowerId: input.whistleblowerId,
+      tenantId: input.tenantId,
+      dealId: input.dealId,
+      rating: input.rating,
+      reviewText: input.reviewText,
+      createdAt: new Date(),
+    }
+    this.ratings.unshift(created)
+    return created
+  }
+
+  async listByWhistleblower(
+    whistleblowerId: string,
+    opts: { limit?: number } = {},
+  ): Promise<WhistleblowerRating[]> {
+    const limit = opts.limit && opts.limit > 0 ? opts.limit : 20
+    return this.ratings
+      .filter((r) => r.whistleblowerId === whistleblowerId)
+      .slice(0, limit)
+      .map((r) => ({ ...r }))
+  }
+
+  async getAggregate(whistleblowerId: string): Promise<WhistleblowerRatingAggregate> {
+    const items = this.ratings.filter((r) => r.whistleblowerId === whistleblowerId)
+    const count = items.length
+    const sum = items.reduce((acc, r) => acc + r.rating, 0)
+    const avg = count === 0 ? 0 : sum / count
+    const breakdown: Record<1 | 2 | 3 | 4 | 5, number> = {
+      1: 0,
+      2: 0,
+      3: 0,
+      4: 0,
+      5: 0,
+    }
+    for (const r of items) {
+      const key = r.rating as 1 | 2 | 3 | 4 | 5
+      breakdown[key] = (breakdown[key] ?? 0) + 1
+    }
+    return { whistleblowerId, count, average: avg, breakdown }
+  }
+
+  async hasTenantRatedDeal(dealId: string, tenantId: string): Promise<boolean> {
+    return this.ratings.some((r) => r.dealId === dealId && r.tenantId === tenantId)
+  }
+
+  async clear(): Promise<void> {
+    this.ratings = []
+  }
+}
+
+type RatingRow = {
+  rating_id: string
+  whistleblower_id: string
+  tenant_id: string
+  deal_id: string
+  rating: number
+  review_text: string | null
+  created_at: Date
+}
+
+class PostgresWhistleblowerRatingStore implements WhistleblowerRatingStorePort {
+  private async pool(): Promise<PgPoolLike> {
+    const pool = await getPool()
+    if (!pool) {
+      throw new Error('Database pool is not available (DATABASE_URL/pg not configured)')
+    }
+    return pool
+  }
+
+  async isAvailable(): Promise<boolean> {
+    return (await getPool()) !== null
+  }
+
+  async hasTenantRatedDeal(dealId: string, tenantId: string): Promise<boolean> {
+    const pool = await this.pool()
+    const { rows } = await pool.query(
+      `SELECT 1 FROM whistleblower_ratings WHERE deal_id = $1 AND tenant_id = $2 LIMIT 1`,
+      [dealId, tenantId],
+    )
+    return rows.length > 0
+  }
+
+  async create(input: CreateWhistleblowerRatingInput): Promise<WhistleblowerRating> {
+    const pool = await this.pool()
+    const ratingId = randomUUID()
+
+    const { rows } = await pool.query(
+      `INSERT INTO whistleblower_ratings (
+        rating_id,
+        whistleblower_id,
+        tenant_id,
+        deal_id,
+        rating,
+        review_text
+      ) VALUES ($1, $2, $3, $4::uuid, $5, $6)
+      RETURNING *`,
+      [
+        ratingId,
+        input.whistleblowerId,
+        input.tenantId,
+        input.dealId,
+        input.rating,
+        input.reviewText ?? null,
+      ],
+    )
+
+    return this.mapRow(rows[0] as RatingRow)
+  }
+
+  async listByWhistleblower(
+    whistleblowerId: string,
+    opts: { limit?: number } = {},
+  ): Promise<WhistleblowerRating[]> {
+    const pool = await this.pool()
+    const limit = opts.limit && opts.limit > 0 ? Math.min(opts.limit, 100) : 20
+    const { rows } = await pool.query(
+      `SELECT * FROM whistleblower_ratings
+       WHERE whistleblower_id = $1
+       ORDER BY created_at DESC
+       LIMIT $2`,
+      [whistleblowerId, limit],
+    )
+    return rows.map((r) => this.mapRow(r as RatingRow))
+  }
+
+  async getAggregate(whistleblowerId: string): Promise<WhistleblowerRatingAggregate> {
+    const pool = await this.pool()
+    const { rows } = await pool.query(
+      `SELECT
+        COUNT(*)::int AS count,
+        COALESCE(AVG(rating), 0)::float AS average,
+        SUM(CASE WHEN rating = 1 THEN 1 ELSE 0 END)::int AS c1,
+        SUM(CASE WHEN rating = 2 THEN 1 ELSE 0 END)::int AS c2,
+        SUM(CASE WHEN rating = 3 THEN 1 ELSE 0 END)::int AS c3,
+        SUM(CASE WHEN rating = 4 THEN 1 ELSE 0 END)::int AS c4,
+        SUM(CASE WHEN rating = 5 THEN 1 ELSE 0 END)::int AS c5
+      FROM whistleblower_ratings
+      WHERE whistleblower_id = $1`,
+      [whistleblowerId],
+    )
+    const row = rows[0] as any
+    return {
+      whistleblowerId,
+      count: Number(row?.count ?? 0),
+      average: Number(row?.average ?? 0),
+      breakdown: {
+        1: Number(row?.c1 ?? 0),
+        2: Number(row?.c2 ?? 0),
+        3: Number(row?.c3 ?? 0),
+        4: Number(row?.c4 ?? 0),
+        5: Number(row?.c5 ?? 0),
+      },
+    }
+  }
+
+  async clear(): Promise<void> {
+    const pool = await this.pool()
+    if (process.env.NODE_ENV !== 'test') {
+      throw new Error(
+        'whistleblowerRatingStore.clear() is only supported in test env when using Postgres',
+      )
+    }
+    await pool.query('TRUNCATE whistleblower_ratings RESTART IDENTITY CASCADE')
+  }
+
+  private mapRow(row: RatingRow): WhistleblowerRating {
+    return {
+      ratingId: row.rating_id,
+      whistleblowerId: row.whistleblower_id,
+      tenantId: row.tenant_id,
+      dealId: row.deal_id,
+      rating: row.rating,
+      reviewText: row.review_text ?? undefined,
+      createdAt: new Date(row.created_at),
+    }
+  }
+}
+
+class HybridWhistleblowerRatingStore implements WhistleblowerRatingStorePort {
+  private memory = new InMemoryWhistleblowerRatingStore()
+  private postgres = new PostgresWhistleblowerRatingStore()
+
+  private async adapter(): Promise<WhistleblowerRatingStorePort> {
+    if (await this.postgres.isAvailable()) return this.postgres
+    return this.memory
+  }
+
+  async create(input: CreateWhistleblowerRatingInput): Promise<WhistleblowerRating> {
+    return (await this.adapter()).create(input)
+  }
+
+  async listByWhistleblower(
+    whistleblowerId: string,
+    opts?: { limit?: number },
+  ): Promise<WhistleblowerRating[]> {
+    return (await this.adapter()).listByWhistleblower(whistleblowerId, opts)
+  }
+
+  async getAggregate(whistleblowerId: string): Promise<WhistleblowerRatingAggregate> {
+    return (await this.adapter()).getAggregate(whistleblowerId)
+  }
+
+  async hasTenantRatedDeal(dealId: string, tenantId: string): Promise<boolean> {
+    return (await this.adapter()).hasTenantRatedDeal(dealId, tenantId)
+  }
+
+  async clear(): Promise<void> {
+    return (await this.adapter()).clear()
+  }
+}
+
+export const whistleblowerRatingStore = new HybridWhistleblowerRatingStore()
+

--- a/backend/src/routes/propertyIssueReports.test.ts
+++ b/backend/src/routes/propertyIssueReports.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import request from 'supertest'
+import { createApp } from '../app.js'
+import { propertyIssueReportStore } from '../models/propertyIssueReportStore.js'
+
+describe('Property issue reports API', () => {
+  let app: any
+
+  beforeEach(async () => {
+    await propertyIssueReportStore.clear()
+    app = createApp()
+  })
+
+  it('accepts a valid report payload matching the frontend dialog shape', async () => {
+    const res = await request(app)
+      .post('/api/property-issue-reports')
+      .send({
+        propertyId: '123',
+        reportCategory: 'scam',
+        reportDetails: 'The photos appear stolen from another listing.',
+      })
+      .expect(201)
+
+    expect(res.body.success).toBe(true)
+    expect(res.body.reportId).toBeTruthy()
+
+    const all = await propertyIssueReportStore.listAll()
+    expect(all).toHaveLength(1)
+    expect(all[0]).toMatchObject({
+      propertyId: '123',
+      category: 'scam',
+      details: 'The photos appear stolen from another listing.',
+    })
+  })
+
+  it('returns structured validation errors for invalid payloads', async () => {
+    const res = await request(app)
+      .post('/api/property-issue-reports')
+      .send({ propertyId: '', reportCategory: '', reportDetails: '' })
+      .expect(400)
+
+    expect(res.body.error.code).toBe('VALIDATION_ERROR')
+    expect(res.body.error.message).toBe('Invalid request data')
+    expect(res.body.error.details).toBeTruthy()
+  })
+
+  it('returns a validation error for malformed JSON', async () => {
+    const res = await request(app)
+      .post('/api/property-issue-reports')
+      .set('Content-Type', 'application/json')
+      .send('{"propertyId":"123",') // malformed
+      .expect(400)
+
+    expect(res.body.error.code).toBe('VALIDATION_ERROR')
+    expect(res.body.error.message).toContain('Malformed JSON')
+  })
+})
+

--- a/backend/src/routes/propertyIssueReports.ts
+++ b/backend/src/routes/propertyIssueReports.ts
@@ -1,0 +1,53 @@
+import { Router, type Request, type Response, type NextFunction } from 'express'
+import { validate } from '../middleware/validate.js'
+import { createPropertyIssueReportSchema } from '../schemas/propertyIssueReport.js'
+import { propertyIssueReportStore } from '../models/propertyIssueReportStore.js'
+
+export function createPropertyIssueReportsRouter(): Router {
+  const router = Router()
+
+  /**
+   * POST /api/property-issue-reports
+   * Public issue reporting intake from property detail page.
+   */
+  router.post(
+    '/',
+    validate(createPropertyIssueReportSchema, 'body'),
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const { propertyId, category, details } = req.body as any
+
+        const forwardedFor = req.headers['x-forwarded-for']
+        const ip =
+          typeof forwardedFor === 'string'
+            ? forwardedFor.split(',')[0]?.trim()
+            : Array.isArray(forwardedFor)
+              ? forwardedFor[0]
+              : req.ip
+
+        const userAgent =
+          typeof req.headers['user-agent'] === 'string'
+            ? req.headers['user-agent']
+            : undefined
+
+        const saved = await propertyIssueReportStore.create({
+          propertyId,
+          category,
+          details,
+          ip,
+          userAgent,
+        })
+
+        res.status(201).json({
+          success: true,
+          reportId: saved.reportId,
+        })
+      } catch (error) {
+        next(error)
+      }
+    },
+  )
+
+  return router
+}
+

--- a/backend/src/routes/support.test.ts
+++ b/backend/src/routes/support.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import request from 'supertest'
+import { createApp } from '../app.js'
+import { supportMessageStore } from '../models/supportMessageStore.js'
+
+describe('Support messages API', () => {
+  let app: any
+
+  beforeEach(async () => {
+    await supportMessageStore.clear()
+    app = createApp()
+  })
+
+  it('accepts a valid public support inquiry and persists it', async () => {
+    const payload = {
+      name: 'Ada Lovelace',
+      email: 'ada@example.com',
+      phone: '+2348012345678',
+      subject: 'Help needed',
+      message: 'I need help with my account.',
+    }
+
+    const res = await request(app)
+      .post('/api/support/messages')
+      .set('User-Agent', 'vitest')
+      .send(payload)
+      .expect(201)
+
+    expect(res.body.success).toBe(true)
+    expect(res.body.messageId).toBeTruthy()
+
+    const all = await supportMessageStore.listAll()
+    expect(all).toHaveLength(1)
+    expect(all[0]).toMatchObject({
+      name: payload.name,
+      email: payload.email,
+      phone: payload.phone,
+      subject: payload.subject,
+      message: payload.message,
+    })
+  })
+
+  it('returns structured validation errors for invalid submissions', async () => {
+    const res = await request(app)
+      .post('/api/support/messages')
+      .send({
+        name: '',
+        email: 'not-an-email',
+        subject: '',
+        message: '',
+      })
+      .expect(400)
+
+    expect(res.body.error.code).toBe('VALIDATION_ERROR')
+    expect(res.body.error.message).toBe('Invalid request data')
+    expect(res.body.error.details).toBeTruthy()
+    expect(typeof res.body.error.details.name).toBe('string')
+    expect(typeof res.body.error.details.email).toBe('string')
+    expect(typeof res.body.error.details.subject).toBe('string')
+    expect(typeof res.body.error.details.message).toBe('string')
+  })
+
+  it('treats empty phone as optional', async () => {
+    const res = await request(app)
+      .post('/api/support/messages')
+      .send({
+        name: 'Test User',
+        email: 'test@example.com',
+        phone: '',
+        subject: 'Subject',
+        message: 'Message',
+      })
+      .expect(201)
+
+    expect(res.body.success).toBe(true)
+    const all = await supportMessageStore.listAll()
+    expect(all[0].phone).toBeUndefined()
+  })
+})
+

--- a/backend/src/routes/support.ts
+++ b/backend/src/routes/support.ts
@@ -1,0 +1,56 @@
+import { Router, type Request, type Response } from 'express'
+import { validate } from '../middleware/validate.js'
+import { createSupportMessageSchema } from '../schemas/supportMessage.js'
+import { supportMessageStore } from '../models/supportMessageStore.js'
+
+export function createSupportRouter(): Router {
+  const router = Router()
+
+  /**
+   * POST /api/support/messages
+   * Public support inquiry intake.
+   */
+  router.post(
+    '/messages',
+    validate(createSupportMessageSchema, 'body'),
+    async (req: Request, res: Response, next) => {
+      try {
+        const { name, email, phone, subject, message } = req.body as any
+
+        const forwardedFor = req.headers['x-forwarded-for']
+        const ip =
+          typeof forwardedFor === 'string'
+            ? forwardedFor.split(',')[0]?.trim()
+            : Array.isArray(forwardedFor)
+              ? forwardedFor[0]
+              : req.ip
+
+        const userAgent =
+          typeof req.headers['user-agent'] === 'string'
+            ? req.headers['user-agent']
+            : undefined
+
+        const saved = await supportMessageStore.create({
+          name,
+          email,
+          phone,
+          subject,
+          message,
+          ip,
+          userAgent,
+        })
+
+        // Stable response (don’t echo user content back)
+        res.status(201).json({
+          success: true,
+          messageId: saved.messageId,
+        })
+      } catch (err) {
+        next(err)
+      }
+    },
+  )
+
+  return router
+}
+

--- a/backend/src/routes/whistleblower.ts
+++ b/backend/src/routes/whistleblower.ts
@@ -7,6 +7,12 @@ import { listingStore } from '../models/listingStore.js'
 import { logger } from '../utils/logger.js'
 import { AppError } from '../errors/AppError.js'
 import { ErrorCode } from '../errors/errorCodes.js'
+import { authenticateToken, type AuthenticatedRequest } from '../middleware/auth.js'
+import { whistleblowerRatingStore } from '../models/whistleblowerRatingStore.js'
+import {
+  createWhistleblowerRatingSchema,
+  listWhistleblowerRatingsQuerySchema,
+} from '../schemas/whistleblowerRating.js'
 
 /**
  * Factory function to create the whistleblower router.
@@ -14,6 +20,108 @@ import { ErrorCode } from '../errors/errorCodes.js'
  */
 export function createWhistleblowerRouter(earningsService: EarningsService): Router {
   const router = Router()
+
+  /**
+   * POST /api/whistleblower/ratings
+   * Tenant-submitted whistleblower rating for a completed rental/deal.
+   */
+  router.post(
+    '/ratings',
+    authenticateToken,
+    validate(createWhistleblowerRatingSchema, 'body'),
+    async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
+      try {
+        const tenantId = req.user?.id
+        if (!tenantId) {
+          throw new AppError(ErrorCode.UNAUTHORIZED, 401, 'User not authenticated')
+        }
+
+        const { whistleblowerId, dealId, rating, reviewText } = req.body as any
+
+        const already = await whistleblowerRatingStore.hasTenantRatedDeal(dealId, tenantId)
+        if (already) {
+          throw new AppError(
+            ErrorCode.DUPLICATE_REQUEST,
+            409,
+            'Duplicate rating submission for this deal',
+            { dealId },
+          )
+        }
+
+        const created = await whistleblowerRatingStore.create({
+          whistleblowerId,
+          tenantId,
+          dealId,
+          rating,
+          reviewText,
+        })
+
+        res.status(201).json({
+          success: true,
+          rating: {
+            ratingId: created.ratingId,
+            whistleblowerId: created.whistleblowerId,
+            tenantId: created.tenantId,
+            dealId: created.dealId,
+            rating: created.rating,
+            reviewText: created.reviewText,
+            createdAt: created.createdAt.toISOString(),
+          },
+        })
+      } catch (error) {
+        next(error)
+      }
+    },
+  )
+
+  /**
+   * GET /api/whistleblower/:id/ratings
+   * Public list of ratings (for profile/dashboard display).
+   */
+  router.get(
+    '/:id/ratings',
+    validate(whistleblowerIdParamSchema, 'params'),
+    validate(listWhistleblowerRatingsQuerySchema, 'query'),
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const { id } = req.params
+        const { limit } = req.query as any
+        const ratings = await whistleblowerRatingStore.listByWhistleblower(id, { limit })
+        res.json({
+          success: true,
+          ratings: ratings.map((r) => ({
+            ratingId: r.ratingId,
+            whistleblowerId: r.whistleblowerId,
+            tenantId: r.tenantId,
+            dealId: r.dealId,
+            rating: r.rating,
+            reviewText: r.reviewText,
+            createdAt: r.createdAt.toISOString(),
+          })),
+        })
+      } catch (error) {
+        next(error)
+      }
+    },
+  )
+
+  /**
+   * GET /api/whistleblower/:id/ratings/aggregate
+   * Public aggregate trust metrics for display.
+   */
+  router.get(
+    '/:id/ratings/aggregate',
+    validate(whistleblowerIdParamSchema, 'params'),
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const { id } = req.params
+        const agg = await whistleblowerRatingStore.getAggregate(id)
+        res.json({ success: true, aggregate: agg })
+      } catch (error) {
+        next(error)
+      }
+    },
+  )
 
   /**
    * GET /api/whistleblower/:id/earnings

--- a/backend/src/routes/whistleblowerRatings.test.ts
+++ b/backend/src/routes/whistleblowerRatings.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import request from 'supertest'
+import { createApp } from '../app.js'
+import { sessionStore, userStore } from '../models/authStore.js'
+import { generateToken } from '../utils/tokens.js'
+import { whistleblowerRatingStore } from '../models/whistleblowerRatingStore.js'
+
+describe('Whistleblower ratings API', () => {
+  let app: any
+  let token: string
+
+  beforeEach(async () => {
+    await whistleblowerRatingStore.clear()
+    sessionStore.clear()
+    userStore.clear()
+
+    const tenant = await userStore.getOrCreateByEmail('tenant@test.com')
+    token = generateToken()
+    await sessionStore.create(tenant.email, token)
+
+    app = createApp()
+  })
+
+  it('creates a rating and shows up in aggregate', async () => {
+    const createRes = await request(app)
+      .post('/api/whistleblower/ratings')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        whistleblowerId: 'wb-001',
+        dealId: '550e8400-e29b-41d4-a716-446655440000',
+        rating: 5,
+        reviewText: 'Great experience',
+      })
+      .expect(201)
+
+    expect(createRes.body.success).toBe(true)
+    expect(createRes.body.rating.rating).toBe(5)
+
+    const aggRes = await request(app)
+      .get('/api/whistleblower/wb-001/ratings/aggregate')
+      .expect(200)
+
+    expect(aggRes.body.success).toBe(true)
+    expect(aggRes.body.aggregate.whistleblowerId).toBe('wb-001')
+    expect(aggRes.body.aggregate.count).toBe(1)
+    expect(aggRes.body.aggregate.average).toBe(5)
+    expect(aggRes.body.aggregate.breakdown['5']).toBe(1)
+  })
+
+  it('rejects invalid rating values with structured validation errors', async () => {
+    const res = await request(app)
+      .post('/api/whistleblower/ratings')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        whistleblowerId: 'wb-001',
+        dealId: 'deal-1',
+        rating: 6,
+      })
+      .expect(400)
+
+    expect(res.body.error.code).toBe('VALIDATION_ERROR')
+    expect(res.body.error.message).toBe('Invalid request data')
+    expect(typeof res.body.error.details.rating).toBe('string')
+  })
+
+  it('prevents duplicate submissions for same deal by same tenant', async () => {
+    const payload = {
+      whistleblowerId: 'wb-001',
+      dealId: 'deal-dup',
+      rating: 4,
+      reviewText: 'Solid',
+    }
+
+    await request(app)
+      .post('/api/whistleblower/ratings')
+      .set('Authorization', `Bearer ${token}`)
+      .send(payload)
+      .expect(201)
+
+    const res2 = await request(app)
+      .post('/api/whistleblower/ratings')
+      .set('Authorization', `Bearer ${token}`)
+      .send(payload)
+      .expect(409)
+
+    expect(res2.body.error.code).toBe('DUPLICATE_REQUEST')
+  })
+})
+

--- a/backend/src/schemas/propertyIssueReport.ts
+++ b/backend/src/schemas/propertyIssueReport.ts
@@ -1,0 +1,50 @@
+import { z } from 'zod'
+
+type Normalized = {
+  propertyId: string
+  category: string
+  details: string
+}
+
+export const createPropertyIssueReportSchema = z
+  .object({
+    propertyId: z.string().trim().min(1, 'Property ID is required').max(128),
+
+    // Frontend currently uses these names
+    reportCategory: z.string().trim().min(1).max(64).optional(),
+    reportDetails: z.string().trim().min(1).max(2000).optional(),
+
+    // Allow normalized field names too
+    category: z.string().trim().min(1).max(64).optional(),
+    details: z.string().trim().min(1).max(2000).optional(),
+  })
+  .superRefine((val, ctx) => {
+    const category = val.category ?? val.reportCategory
+    const details = val.details ?? val.reportDetails
+
+    if (!category) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Category is required',
+        path: ['category'],
+      })
+    }
+
+    if (!details) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Details are required',
+        path: ['details'],
+      })
+    }
+  })
+  .transform((val): Normalized => {
+    return {
+      propertyId: val.propertyId,
+      category: (val.category ?? val.reportCategory)!,
+      details: (val.details ?? val.reportDetails)!,
+    }
+  })
+
+export type CreatePropertyIssueReportRequest = z.infer<typeof createPropertyIssueReportSchema>
+

--- a/backend/src/schemas/supportMessage.ts
+++ b/backend/src/schemas/supportMessage.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod'
+
+const emptyStringToUndefined = (value: unknown) => {
+  if (typeof value === 'string' && value.trim() === '') return undefined
+  return value
+}
+
+export const createSupportMessageSchema = z.object({
+  name: z.string().trim().min(1, 'Name is required').max(100, 'Name is too long'),
+  email: z
+    .string()
+    .trim()
+    .email('Email must be a valid email address')
+    .max(254, 'Email is too long'),
+  phone: z.preprocess(
+    emptyStringToUndefined,
+    z.string().trim().min(3, 'Phone is too short').max(32, 'Phone is too long').optional(),
+  ),
+  subject: z
+    .string()
+    .trim()
+    .min(1, 'Subject is required')
+    .max(200, 'Subject is too long'),
+  message: z
+    .string()
+    .trim()
+    .min(1, 'Message is required')
+    .max(5000, 'Message is too long'),
+})
+
+export type CreateSupportMessageRequest = z.infer<typeof createSupportMessageSchema>
+

--- a/backend/src/schemas/whistleblowerRating.ts
+++ b/backend/src/schemas/whistleblowerRating.ts
@@ -1,0 +1,30 @@
+import { z } from 'zod'
+
+const emptyStringToUndefined = (value: unknown) => {
+  if (typeof value === 'string' && value.trim() === '') return undefined
+  return value
+}
+
+export const createWhistleblowerRatingSchema = z.object({
+  whistleblowerId: z.string().min(1, 'Whistleblower ID is required'),
+  dealId: z.string().min(1, 'Deal ID is required'),
+  rating: z
+    .number()
+    .int('Rating must be an integer')
+    .min(1, 'Rating must be between 1 and 5')
+    .max(5, 'Rating must be between 1 and 5'),
+  reviewText: z.preprocess(
+    emptyStringToUndefined,
+    z.string().trim().max(2000, 'Review text is too long').optional(),
+  ),
+})
+
+export const listWhistleblowerRatingsQuerySchema = z.object({
+  limit: z
+    .preprocess((v) => (v === undefined ? undefined : Number(v)), z.number().int().min(1).max(100))
+    .optional(),
+})
+
+export type CreateWhistleblowerRatingRequest = z.infer<typeof createWhistleblowerRatingSchema>
+export type ListWhistleblowerRatingsQuery = z.infer<typeof listWhistleblowerRatingsQuerySchema>
+


### PR DESCRIPTION
## Summary
Add a backend API for property issue reports so the report dialog on the property detail page can persist submissions instead of only logging to the console. The endpoint validates property ID, category, and free-text details, stores the report using the backend’s existing persistence approach (Postgres when DATABASE_URL is set; in-memory fallback otherwise), and returns stable success + structured validation error responses.

Linked issue 
Closes #546 

## Changes
Added POST /api/property-issue-reports endpoint for property issue report intake.
Validates payload fields (propertyId, reportCategory, reportDetails) and returns structured VALIDATION_ERROR responses for invalid input.
Persists reports via:
SQL migration for property_issue_reports
Hybrid store (Postgres-backed when configured; in-memory fallback)
Added route tests for success, validation failure, and malformed JSON request cases.
Documented the endpoint in backend/docs/openapi.yml under Risk/moderation-related endpoints.
How to test
cd backend
npm ci
npm run test:ci
npm run lint
npm run openapi:validate
Security Considerations
No secrets or sensitive data are logged.
No changes to authentication/authorization logic.
No changes to admin/upgrade logic.
## Checklist

I linked an issue (or explained why one is not needed)

I tested locally

I did not commit secrets

I updated docs if needed

Code follows the project's style guidelines

CI checks pass

If UI changes: I included before/after screenshots

If images added/changed: I verified they are optimized and accessible
