### PR TITLE
feat(backend): add full-payment incentive split settlement (#533)

### DIFF
--- a/backend/migrations/019_full_payment_settlement_ledger.sql
+++ b/backend/migrations/019_full_payment_settlement_ledger.sql
@@ -1,0 +1,21 @@
+-- Settlement ledger entries for full-payment incentive splits (platform + optional reporter).
+
+CREATE TABLE IF NOT EXISTS settlement_ledger_entries (
+    entry_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    deal_id UUID NOT NULL,
+    event_type TEXT NOT NULL,
+    beneficiary_type TEXT NOT NULL CHECK (beneficiary_type IN ('platform', 'reporter', 'landlord')),
+    beneficiary_id TEXT,
+    amount_ngn BIGINT NOT NULL,
+    currency TEXT NOT NULL DEFAULT 'NGN',
+    rationale TEXT NOT NULL,
+    split_config_version TEXT NOT NULL,
+    split_config_snapshot JSONB NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS settlement_ledger_entries_dedup_uidx
+    ON settlement_ledger_entries (deal_id, event_type, beneficiary_type, COALESCE(beneficiary_id, ''));
+
+CREATE INDEX IF NOT EXISTS settlement_ledger_entries_deal_idx
+    ON settlement_ledger_entries (deal_id, created_at);

--- a/backend/src/models/settlementLedger.ts
+++ b/backend/src/models/settlementLedger.ts
@@ -1,0 +1,23 @@
+export type SettlementLedgerBeneficiaryType = 'platform' | 'reporter' | 'landlord'
+
+export type SettlementLedgerEventType = 'full_payment_incentive'
+
+export type SettlementLedgerEntry = {
+  entryId: string
+  dealId: string
+  eventType: SettlementLedgerEventType
+  beneficiaryType: SettlementLedgerBeneficiaryType
+  beneficiaryId?: string
+  amountNgn: number
+  currency: 'NGN'
+  rationale: string
+  splitConfigVersion: string
+  splitConfigSnapshot: {
+    platformShare: number
+    reporterShare: number
+    reporterApplied: boolean
+  }
+  createdAt: Date
+}
+
+export type CreateSettlementLedgerEntryInput = Omit<SettlementLedgerEntry, 'entryId' | 'createdAt'>

--- a/backend/src/models/settlementLedgerStore.ts
+++ b/backend/src/models/settlementLedgerStore.ts
@@ -1,0 +1,186 @@
+import { randomUUID } from 'node:crypto'
+import { getPool, type PgPoolLike } from '../db.js'
+import type { CreateSettlementLedgerEntryInput, SettlementLedgerEntry, SettlementLedgerEventType } from './settlementLedger.js'
+
+interface SettlementLedgerStorePort {
+  insertMany(entries: CreateSettlementLedgerEntryInput[]): Promise<SettlementLedgerEntry[]>
+  listByDealId(dealId: string, eventType?: SettlementLedgerEventType): Promise<SettlementLedgerEntry[]>
+  clear(): Promise<void>
+}
+
+class InMemorySettlementLedgerStore implements SettlementLedgerStorePort {
+  private entries: SettlementLedgerEntry[] = []
+
+  async insertMany(entries: CreateSettlementLedgerEntryInput[]): Promise<SettlementLedgerEntry[]> {
+    const now = new Date()
+    const inserted: SettlementLedgerEntry[] = entries.map((e) => ({
+      ...e,
+      entryId: randomUUID(),
+      createdAt: now,
+    }))
+    this.entries.push(...inserted)
+    return inserted
+  }
+
+  async listByDealId(dealId: string, eventType?: SettlementLedgerEventType): Promise<SettlementLedgerEntry[]> {
+    return this.entries
+      .filter((e) => e.dealId === dealId && (!eventType || e.eventType === eventType))
+      .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
+  }
+
+  async clear(): Promise<void> {
+    this.entries = []
+  }
+}
+
+type SettlementLedgerEntryRow = {
+  entry_id: string
+  deal_id: string
+  event_type: string
+  beneficiary_type: string
+  beneficiary_id: string | null
+  amount_ngn: string | number
+  currency: string
+  rationale: string
+  split_config_version: string
+  split_config_snapshot: unknown
+  created_at: Date
+}
+
+class PostgresSettlementLedgerStore implements SettlementLedgerStorePort {
+  private async pool(): Promise<PgPoolLike> {
+    const pool = await getPool()
+    if (!pool) {
+      throw new Error('Database pool is not available (DATABASE_URL/pg not configured)')
+    }
+    return pool
+  }
+
+  async isAvailable(): Promise<boolean> {
+    return (await getPool()) !== null
+  }
+
+  async insertMany(entries: CreateSettlementLedgerEntryInput[]): Promise<SettlementLedgerEntry[]> {
+    const pool = await this.pool()
+    if (entries.length === 0) return []
+
+    const inserted: SettlementLedgerEntry[] = []
+
+    for (const e of entries) {
+      const entryId = randomUUID()
+      const { rows } = await pool.query(
+        `INSERT INTO settlement_ledger_entries (
+          entry_id,
+          deal_id,
+          event_type,
+          beneficiary_type,
+          beneficiary_id,
+          amount_ngn,
+          currency,
+          rationale,
+          split_config_version,
+          split_config_snapshot
+        ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)
+        ON CONFLICT (deal_id, event_type, beneficiary_type, COALESCE(beneficiary_id, '')) DO NOTHING
+        RETURNING *`,
+        [
+          entryId,
+          e.dealId,
+          e.eventType,
+          e.beneficiaryType,
+          e.beneficiaryId ?? null,
+          e.amountNgn,
+          e.currency,
+          e.rationale,
+          e.splitConfigVersion,
+          JSON.stringify(e.splitConfigSnapshot),
+        ],
+      )
+      if (rows.length > 0) {
+        inserted.push(this.mapRow(rows[0] as SettlementLedgerEntryRow))
+      }
+    }
+
+    return inserted
+  }
+
+  async listByDealId(dealId: string, eventType?: SettlementLedgerEventType): Promise<SettlementLedgerEntry[]> {
+    const pool = await this.pool()
+    const params: unknown[] = [dealId]
+    let where = 'deal_id = $1'
+    if (eventType) {
+      params.push(eventType)
+      where += ` AND event_type = $${params.length}`
+    }
+    const { rows } = await pool.query(
+      `SELECT * FROM settlement_ledger_entries WHERE ${where} ORDER BY created_at DESC`,
+      params,
+    )
+    return rows.map((r) => this.mapRow(r as SettlementLedgerEntryRow))
+  }
+
+  async clear(): Promise<void> {
+    const pool = await this.pool()
+    if (process.env.NODE_ENV !== 'test') {
+      throw new Error('settlementLedgerStore.clear() is only supported in test env when using Postgres')
+    }
+    await pool.query('TRUNCATE settlement_ledger_entries RESTART IDENTITY CASCADE')
+  }
+
+  private mapRow(row: SettlementLedgerEntryRow): SettlementLedgerEntry {
+    const snapshotValue = row.split_config_snapshot
+    let splitConfigSnapshot: SettlementLedgerEntry['splitConfigSnapshot']
+    if (snapshotValue && typeof snapshotValue === 'string') {
+      splitConfigSnapshot = JSON.parse(snapshotValue)
+    } else {
+      splitConfigSnapshot = snapshotValue as SettlementLedgerEntry['splitConfigSnapshot']
+    }
+
+    return {
+      entryId: row.entry_id,
+      dealId: row.deal_id,
+      eventType: row.event_type as SettlementLedgerEntry['eventType'],
+      beneficiaryType: row.beneficiary_type as SettlementLedgerEntry['beneficiaryType'],
+      beneficiaryId: row.beneficiary_id ?? undefined,
+      amountNgn: toNumber(row.amount_ngn),
+      currency: (row.currency as 'NGN') ?? 'NGN',
+      rationale: row.rationale,
+      splitConfigVersion: row.split_config_version,
+      splitConfigSnapshot,
+      createdAt: new Date(row.created_at),
+    }
+  }
+}
+
+class HybridSettlementLedgerStore implements SettlementLedgerStorePort {
+  private memory = new InMemorySettlementLedgerStore()
+  private postgres = new PostgresSettlementLedgerStore()
+
+  private async adapter(): Promise<SettlementLedgerStorePort> {
+    if (await this.postgres.isAvailable()) {
+      return this.postgres
+    }
+    return this.memory
+  }
+
+  async insertMany(entries: CreateSettlementLedgerEntryInput[]): Promise<SettlementLedgerEntry[]> {
+    const adapter = await this.adapter()
+    return adapter.insertMany(entries)
+  }
+
+  async listByDealId(dealId: string, eventType?: SettlementLedgerEventType): Promise<SettlementLedgerEntry[]> {
+    const adapter = await this.adapter()
+    return adapter.listByDealId(dealId, eventType)
+  }
+
+  async clear(): Promise<void> {
+    const adapter = await this.adapter()
+    return adapter.clear()
+  }
+}
+
+function toNumber(value: string | number): number {
+  return typeof value === 'number' ? value : Number(value)
+}
+
+export const settlementLedgerStore = new HybridSettlementLedgerStore()

--- a/backend/src/routes/payments.fullPayment.test.ts
+++ b/backend/src/routes/payments.fullPayment.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import request from 'supertest'
+
+describe('POST /api/payments/confirm includes full-payment payout breakdown', () => {
+  beforeEach(async () => {
+    process.env.FULL_PAYMENT_SPLIT_VERSION = 'test-v1'
+    process.env.FULL_PAYMENT_PLATFORM_SHARE = '0.1'
+    process.env.FULL_PAYMENT_REPORTER_SHARE = '0.05'
+    vi.resetModules()
+
+    const { settlementLedgerStore } = await import('../models/settlementLedgerStore.js')
+    await settlementLedgerStore.clear()
+  })
+
+  it('returns payout breakdown and persists settlement ledger entries', async () => {
+    const { createApp } = await import('../app.js')
+    const { settlementLedgerStore } = await import('../models/settlementLedgerStore.js')
+    const app = createApp()
+
+    // Create a deal (no listing linkage required for this test)
+    const createDealRes = await request(app)
+      .post('/api/deals')
+      .send({
+        tenantId: 'tenant-1',
+        landlordId: 'landlord-1',
+        annualRentNgn: 1200000,
+        depositNgn: 240000,
+        termMonths: 12,
+      })
+
+    expect(createDealRes.status).toBe(201)
+    const dealId = createDealRes.body.data.dealId
+
+    const res = await request(app)
+      .post('/api/payments/confirm')
+      .send({
+        dealId,
+        txType: 'tenant_repayment',
+        amountUsdc: '100.00',
+        tokenAddress: 'USDC_TOKEN_ADDRESS_TESTNET',
+        externalRefSource: 'manual',
+        externalRef: 'fullpay-1',
+        amountNgn: 960000,
+        fxRateNgnPerUsdc: 1000,
+        fxProvider: 'stub',
+      })
+
+    expect([200, 202]).toContain(res.status)
+    expect(res.body.payoutBreakdown).toBeDefined()
+    expect(res.body.payoutBreakdown.platformAmountNgn).toBeDefined()
+    expect(res.body.payoutBreakdown.landlordNetAmountNgn).toBeDefined()
+    expect(res.body.payoutBreakdown.reporterAmountNgn).toBe(0)
+
+    const entries = await settlementLedgerStore.listByDealId(dealId, 'full_payment_incentive')
+    expect(entries.length).toBeGreaterThan(0)
+    expect(entries.some((e) => e.beneficiaryType === 'platform')).toBe(true)
+  }, 15000)
+})

--- a/backend/src/routes/payments.ts
+++ b/backend/src/routes/payments.ts
@@ -7,6 +7,8 @@ import { logger } from '../utils/logger.js'
 import { auditWalletSigningUsed } from '../utils/auditLogger.js'
 import { AppError } from '../errors/AppError.js'
 import { ErrorCode } from '../errors/errorCodes.js'
+import { TxType } from '../outbox/types.js'
+import { settleFullPaymentIncentive } from '../services/fullPaymentIncentiveSettlement.js'
 
 export function createPaymentsRouter(adapter: SorobanAdapter) {
   const router = Router()
@@ -91,11 +93,34 @@ export function createPaymentsRouter(adapter: SorobanAdapter) {
           )
         }
 
+        const payoutBreakdown =
+          txType === TxType.TENANT_REPAYMENT && typeof amountNgn === 'number' && amountNgn > 0
+            ? await settleFullPaymentIncentive({ dealId, grossAmountNgn: amountNgn })
+            : null
+
+        if (payoutBreakdown) {
+          logger.info('full_payment_incentive.split_applied', {
+            dealId,
+            splitConfigVersion: payoutBreakdown.splitConfigVersion,
+            reporterApplied: payoutBreakdown.reporterApplied,
+            requestId: req.requestId,
+          })
+        }
+
         res.status(sent ? 200 : 202).json({
           success: true,
           outboxId: updatedItem.id,
           txId: updatedItem.txId,
           status: updatedItem.status,
+          payoutBreakdown: payoutBreakdown
+            ? {
+                platformAmountNgn: payoutBreakdown.platformAmountNgn,
+                reporterAmountNgn: payoutBreakdown.reporterAmountNgn,
+                landlordNetAmountNgn: payoutBreakdown.landlordNetAmountNgn,
+                splitConfigVersion: payoutBreakdown.splitConfigVersion,
+                reporterApplied: payoutBreakdown.reporterApplied,
+              }
+            : null,
           message: sent
             ? 'Payment confirmed and USDC receipt written to chain'
             : 'Payment confirmed, USDC receipt queued for retry',

--- a/backend/src/routes/receiptsRoute.ts
+++ b/backend/src/routes/receiptsRoute.ts
@@ -4,6 +4,7 @@ import { TxType } from '../outbox/types.js'
 import { AppError } from '../errors/AppError.js'
 import { ErrorCode } from '../errors/errorCodes.js'
 import { authenticateToken } from '../middleware/auth.js'
+import { settlementLedgerStore } from '../models/settlementLedgerStore.js'
 
 const VALID_TX_TYPES = new Set(Object.values(TxType))
 
@@ -96,7 +97,27 @@ export function createReceiptsRouter(repo: ReceiptRepository): Router {
     if (!dealId) return next(new AppError(ErrorCode.VALIDATION_ERROR, 400, 'dealId is required'))
     try {
       const receipts = await repo.findByDealId(dealId)
-      res.json({ dealId, receipts, total: receipts.length })
+
+      const ledgerEntries = await settlementLedgerStore.listByDealId(dealId, 'full_payment_incentive')
+      const platform = ledgerEntries.find((e) => e.beneficiaryType === 'platform')
+      const reporter = ledgerEntries.find((e) => e.beneficiaryType === 'reporter')
+      const landlord = ledgerEntries.find((e) => e.beneficiaryType === 'landlord')
+      const splitConfigVersion = platform?.splitConfigVersion ?? reporter?.splitConfigVersion ?? landlord?.splitConfigVersion
+
+      res.json({
+        dealId,
+        receipts,
+        total: receipts.length,
+        payoutBreakdown: splitConfigVersion
+          ? {
+              platformAmountNgn: platform?.amountNgn ?? 0,
+              reporterAmountNgn: reporter?.amountNgn ?? 0,
+              landlordNetAmountNgn: landlord?.amountNgn ?? 0,
+              splitConfigVersion,
+              reporterApplied: !!reporter,
+            }
+          : null,
+      })
     } catch (err) {
       next(err)
     }

--- a/backend/src/schemas/env.ts
+++ b/backend/src/schemas/env.ts
@@ -60,6 +60,11 @@ export const envSchema = z.object({
   // Metrics (Prometheus)
   PROMETHEUS_PORT: z.coerce.number().default(9464),
   REDIS_URL: z.string().url().default('redis://localhost:6379'),
+
+  // Full-payment incentive payout split (NGN)
+  FULL_PAYMENT_SPLIT_VERSION: z.string().default('v1'),
+  FULL_PAYMENT_PLATFORM_SHARE: z.coerce.number().min(0).max(1).default(0),
+  FULL_PAYMENT_REPORTER_SHARE: z.coerce.number().min(0).max(1).default(0),
 }).refine((data) => {
   // Accept either field name; prefer SOROBAN_USDC_TOKEN_ID if provided
   const tokenId = data.SOROBAN_USDC_TOKEN_ID || data.USDC_TOKEN_ADDRESS
@@ -149,6 +154,14 @@ export const envSchema = z.object({
   .refine((data) => data.CONVERSION_RATE_MIN < data.CONVERSION_RATE_MAX, {
     message: 'CONVERSION_RATE_MIN must be less than CONVERSION_RATE_MAX',
     path: ['CONVERSION_RATE_MAX'],
+  })
+  .refine((data) => {
+    const platform = data.FULL_PAYMENT_PLATFORM_SHARE
+    const reporter = data.FULL_PAYMENT_REPORTER_SHARE
+    return platform + reporter <= 1
+  }, {
+    message: 'FULL_PAYMENT_PLATFORM_SHARE + FULL_PAYMENT_REPORTER_SHARE must be <= 1',
+    path: ['FULL_PAYMENT_REPORTER_SHARE'],
   })
 
 export type Env = z.infer<typeof envSchema>

--- a/backend/src/services/fullPaymentIncentiveSettlement.ts
+++ b/backend/src/services/fullPaymentIncentiveSettlement.ts
@@ -1,0 +1,96 @@
+import { dealStore } from '../models/dealStore.js'
+import { listingStore } from '../models/listingStore.js'
+import { settlementLedgerStore } from '../models/settlementLedgerStore.js'
+import { computeFullPaymentSplit } from './fullPaymentSplit.js'
+
+export type FullPaymentIncentiveSettlementResult = {
+  dealId: string
+  platformAmountNgn: number
+  reporterAmountNgn: number
+  landlordNetAmountNgn: number
+  splitConfigVersion: string
+  reporterApplied: boolean
+  reporterId?: string
+}
+
+export async function settleFullPaymentIncentive(params: {
+  dealId: string
+  grossAmountNgn: number
+}): Promise<FullPaymentIncentiveSettlementResult | null> {
+  const { dealId, grossAmountNgn } = params
+
+  const deal = await dealStore.findById(dealId)
+  if (!deal) return null
+
+  // Guard: apply only for payment-in-full events (covers financed amount)
+  if (grossAmountNgn < deal.financedAmountNgn) {
+    return null
+  }
+
+  const listing = deal.listingId ? await listingStore.getById(deal.listingId) : null
+  const reporterId = listing?.whistleblowerId
+  const reporterApplied = typeof reporterId === 'string' && reporterId.trim() !== ''
+
+  const split = computeFullPaymentSplit({ grossAmountNgn, reporterApplied })
+
+  await settlementLedgerStore.insertMany([
+    {
+      dealId,
+      eventType: 'full_payment_incentive',
+      beneficiaryType: 'platform',
+      amountNgn: split.platformAmountNgn,
+      currency: 'NGN',
+      rationale: 'Full payment incentive platform share',
+      splitConfigVersion: split.config.version,
+      splitConfigSnapshot: {
+        platformShare: split.config.platformShare,
+        reporterShare: split.config.reporterShare,
+        reporterApplied,
+      },
+    },
+    ...(reporterApplied
+      ? [
+          {
+            dealId,
+            eventType: 'full_payment_incentive' as const,
+            beneficiaryType: 'reporter' as const,
+            beneficiaryId: reporterId,
+            amountNgn: split.reporterAmountNgn,
+            currency: 'NGN' as const,
+            rationale: 'Full payment incentive reporter share',
+            splitConfigVersion: split.config.version,
+            splitConfigSnapshot: {
+              platformShare: split.config.platformShare,
+              reporterShare: split.config.reporterShare,
+              reporterApplied,
+            },
+          },
+        ]
+      : []),
+    {
+      dealId,
+      eventType: 'full_payment_incentive',
+      beneficiaryType: 'landlord',
+      beneficiaryId: deal.landlordId,
+      amountNgn: split.landlordNetAmountNgn,
+      currency: 'NGN',
+      rationale: 'Full payment incentive landlord net amount',
+      splitConfigVersion: split.config.version,
+      splitConfigSnapshot: {
+        platformShare: split.config.platformShare,
+        reporterShare: split.config.reporterShare,
+        reporterApplied,
+      },
+    },
+  ])
+
+  return {
+    dealId,
+    platformAmountNgn: split.platformAmountNgn,
+    reporterAmountNgn: split.reporterAmountNgn,
+    landlordNetAmountNgn: split.landlordNetAmountNgn,
+    splitConfigVersion: split.config.version,
+    reporterApplied,
+    reporterId: reporterApplied ? reporterId : undefined,
+  }
+}

--- a/backend/src/services/fullPaymentSplit.test.ts
+++ b/backend/src/services/fullPaymentSplit.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+describe('computeFullPaymentSplit', () => {
+  beforeEach(() => {
+    process.env.FULL_PAYMENT_SPLIT_VERSION = 'test-v1'
+    process.env.FULL_PAYMENT_PLATFORM_SHARE = '0.1'
+    process.env.FULL_PAYMENT_REPORTER_SHARE = '0.05'
+    vi.resetModules()
+  })
+
+  it('computes deterministic split with reporter applied', async () => {
+    const mod = await import('./fullPaymentSplit.js')
+    const out = mod.computeFullPaymentSplit({ grossAmountNgn: 1000, reporterApplied: true })
+    expect(out.platformAmountNgn).toBe(100)
+    expect(out.reporterAmountNgn).toBe(50)
+    expect(out.landlordNetAmountNgn).toBe(850)
+    expect(out.config.version).toBe('test-v1')
+  })
+
+  it('guards reporter payout when reporter is not applied', async () => {
+    const mod = await import('./fullPaymentSplit.js')
+    const out = mod.computeFullPaymentSplit({ grossAmountNgn: 1000, reporterApplied: false })
+    expect(out.platformAmountNgn).toBe(100)
+    expect(out.reporterAmountNgn).toBe(0)
+    expect(out.landlordNetAmountNgn).toBe(900)
+  })
+
+  it('throws on non-positive amount', async () => {
+    const mod = await import('./fullPaymentSplit.js')
+    expect(() => mod.computeFullPaymentSplit({ grossAmountNgn: 0, reporterApplied: true })).toThrow()
+  })
+})

--- a/backend/src/services/fullPaymentSplit.ts
+++ b/backend/src/services/fullPaymentSplit.ts
@@ -1,0 +1,59 @@
+import { env } from '../schemas/env.js'
+
+export type FullPaymentSplitConfig = {
+  version: string
+  platformShare: number
+  reporterShare: number
+}
+
+export type FullPaymentSplitResult = {
+  config: FullPaymentSplitConfig
+  grossAmountNgn: number
+  platformAmountNgn: number
+  reporterAmountNgn: number
+  landlordNetAmountNgn: number
+  reporterApplied: boolean
+}
+
+function roundNgn(value: number): number {
+  // Deterministic integer rounding for NGN amounts
+  return Math.round(value)
+}
+
+export function getFullPaymentSplitConfig(): FullPaymentSplitConfig {
+  return {
+    version: env.FULL_PAYMENT_SPLIT_VERSION,
+    platformShare: env.FULL_PAYMENT_PLATFORM_SHARE,
+    reporterShare: env.FULL_PAYMENT_REPORTER_SHARE,
+  }
+}
+
+export function computeFullPaymentSplit(params: {
+  grossAmountNgn: number
+  reporterApplied: boolean
+}): FullPaymentSplitResult {
+  const { grossAmountNgn, reporterApplied } = params
+  const config = getFullPaymentSplitConfig()
+
+  if (!Number.isFinite(grossAmountNgn) || grossAmountNgn <= 0) {
+    throw new Error('grossAmountNgn must be a positive number')
+  }
+
+  const platformAmountNgn = roundNgn(grossAmountNgn * config.platformShare)
+  const reporterAmountNgn = reporterApplied ? roundNgn(grossAmountNgn * config.reporterShare) : 0
+
+  const landlordNetAmountNgn = grossAmountNgn - platformAmountNgn - reporterAmountNgn
+
+  if (landlordNetAmountNgn < 0) {
+    throw new Error('Split resulted in negative landlord net amount')
+  }
+
+  return {
+    config,
+    grossAmountNgn,
+    platformAmountNgn,
+    reporterAmountNgn,
+    landlordNetAmountNgn,
+    reporterApplied,
+  }
+}


### PR DESCRIPTION
## Summary

Implement backend settlement logic for payment-in-full events, producing deterministic incentive payout splits between platform and (optionally) a linked reporter, and persisting an auditable settlement ledger with config version snapshot.

## Linked issue

Closes #533

## Changes

- Add env-configured full-payment split config:
  - FULL_PAYMENT_SPLIT_VERSION
  - FULL_PAYMENT_PLATFORM_SHARE
  - FULL_PAYMENT_REPORTER_SHARE
  - Validation: shares in [0..1] and platform+reporter <= 1
- Add `settlement_ledger_entries` (migration 019) storing:
  - beneficiary type/id, rationale, amounts
  - split config version + snapshot used at execution time
  - dedupe index for deterministic settlement entries
- Add deterministic split calculator + settlement service:
  - Reporter payout applied only when reporter is linked
  - Guard: only settle when payment covers financed amount (payment-in-full)
- Extend APIs:
  - `POST /api/payments/confirm` returns `payoutBreakdown` (platform/reporter/landlord net + config version)
  - `GET /api/deals/:dealId/receipts` returns `payoutBreakdown` from settlement ledger entries
- Tests:
  - Unit tests for split computation and guard behavior
  - Integration-style test for end-to-end settlement + API payload

## Checklist

- [x] I tested locally
- [x] I did not commit secrets
- [ ] I updated docs if needed
- [x] No UI changes