### PR TITLE
feat(frontend): show staking rewards summary on tenant dashboard

### DIFF
--- a/frontend/app/dashboard/tenant/page.tsx
+++ b/frontend/app/dashboard/tenant/page.tsx
@@ -22,6 +22,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { DashboardHeader } from "@/components/dashboard-header";
+import { TenantRewardsSummaryCard } from "@/components/tenant-rewards-summary-card";
 import {
   tenantCurrentLease as currentLease,
   tenantDashboardPaymentSchedule as paymentSchedule,
@@ -390,19 +391,7 @@ export default function TenantDashboard() {
                 </Card>
 
                 {featureFlags.enableExperimentalStaking && (
-                  <Card className="border-3 border-foreground bg-secondary/10 p-6 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] lg:col-span-2">
-                    <div className="flex items-center gap-3">
-                      <div className="flex h-12 w-12 items-center justify-center border-3 border-foreground bg-secondary">
-                        <Heart className="h-6 w-6" />
-                      </div>
-                      <div>
-                        <h3 className="text-lg font-bold">Experimental: Staking Rewards</h3>
-                        <p className="text-sm text-muted-foreground">
-                          Coming soon: Earn rewards automatically by paying rent on time!
-                        </p>
-                      </div>
-                    </div>
-                  </Card>
+                  <TenantRewardsSummaryCard />
                 )}
               </div>
             )}

--- a/frontend/components/__tests__/tenant-rewards-summary-card.test.tsx
+++ b/frontend/components/__tests__/tenant-rewards-summary-card.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
+
+import { TenantRewardsSummaryCard } from "@/components/tenant-rewards-summary-card";
+
+vi.mock("next/link", () => {
+  return {
+    default: ({ href, children }: { href: string; children: ReactNode }) => (
+      <a href={href}>{children}</a>
+    ),
+  };
+});
+
+vi.mock("@/lib/config", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/config")>(
+    "@/lib/config",
+  );
+
+  return {
+    ...actual,
+    getStakingPosition: vi.fn(),
+  };
+});
+
+describe("TenantRewardsSummaryCard", () => {
+  it("renders rewards summary when data is present", async () => {
+    process.env.NEXT_PUBLIC_BACKEND_URL = "http://localhost:4000";
+
+    const { getStakingPosition } = await import("@/lib/config");
+    vi.mocked(getStakingPosition).mockResolvedValue({
+      success: true,
+      position: {
+        staked: "100.12",
+        claimable: "5",
+        warming: "0",
+        cooling: "1",
+      },
+    });
+
+    render(<TenantRewardsSummaryCard />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Claimable")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("5.00 USDC")).toBeInTheDocument();
+    expect(screen.getByText("100.12 USDC")).toBeInTheDocument();
+    expect(screen.queryByText(/coming soon/i)).not.toBeInTheDocument();
+  });
+
+  it("renders empty state when no position data exists", async () => {
+    process.env.NEXT_PUBLIC_BACKEND_URL = "http://localhost:4000";
+
+    const { getStakingPosition } = await import("@/lib/config");
+    vi.mocked(getStakingPosition).mockResolvedValue({
+      success: true,
+      position: {
+        staked: "0",
+        claimable: "0",
+        warming: "0",
+        cooling: "0",
+      },
+    });
+
+    render(<TenantRewardsSummaryCard />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/don’t have a staking position yet/i),
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText(/coming soon/i)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/components/tenant-rewards-summary-card.tsx
+++ b/frontend/components/tenant-rewards-summary-card.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { Heart } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { getStakingPosition, type StakingPositionReponse } from "@/lib/config";
+
+type LoadState =
+  | { status: "idle" | "loading" }
+  | { status: "loaded"; data: StakingPositionReponse }
+  | { status: "error" };
+
+function formatUsdc(amount: number): string {
+  return `${amount.toFixed(2)} USDC`;
+}
+
+export function TenantRewardsSummaryCard() {
+  const [state, setState] = useState<LoadState>({ status: "idle" });
+
+  useEffect(() => {
+    if (!process.env.NEXT_PUBLIC_BACKEND_URL) {
+      const timer = setTimeout(() => {
+        setState({ status: "error" });
+      }, 0);
+      return () => clearTimeout(timer);
+    }
+
+    const loadingTimer = setTimeout(() => {
+      setState({ status: "loading" });
+    }, 0);
+
+    getStakingPosition()
+      .then((data) => {
+        const timer = setTimeout(() => {
+          setState({ status: "loaded", data });
+        }, 0);
+        return () => clearTimeout(timer);
+      })
+      .catch(() => {
+        const timer = setTimeout(() => {
+          setState({ status: "error" });
+        }, 0);
+        return () => clearTimeout(timer);
+      });
+
+    return () => clearTimeout(loadingTimer);
+  }, []);
+
+  const position = useMemo(() => {
+    if (state.status !== "loaded") return null;
+
+    const staked = Number(state.data.position.staked);
+    const claimable = Number(state.data.position.claimable);
+    const warming = Number(state.data.position.warming);
+    const cooling = Number(state.data.position.cooling);
+
+    return {
+      staked,
+      claimable,
+      warming,
+      cooling,
+      hasAnyData: staked > 0 || claimable > 0 || warming > 0 || cooling > 0,
+    };
+  }, [state]);
+
+  return (
+    <Card className="border-3 border-foreground bg-secondary/10 p-6 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] lg:col-span-2">
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex items-center gap-3">
+          <div className="flex h-12 w-12 flex-shrink-0 items-center justify-center border-3 border-foreground bg-secondary">
+            <Heart className="h-6 w-6" />
+          </div>
+          <div>
+            <h3 className="text-lg font-bold">Staking Rewards</h3>
+            <p className="text-sm text-muted-foreground">
+              Summary of your current staking position.
+            </p>
+          </div>
+        </div>
+
+        <Link href="/staking">
+          <Button className="border-2 border-foreground bg-background font-bold">
+            View
+          </Button>
+        </Link>
+      </div>
+
+      <div className="mt-4 grid gap-4 sm:grid-cols-2">
+        {state.status === "loading" && (
+          <div className="sm:col-span-2 text-sm text-muted-foreground">
+            Loading rewards...
+          </div>
+        )}
+
+        {state.status === "error" && (
+          <div className="sm:col-span-2 text-sm text-muted-foreground">
+            Rewards data is unavailable.
+          </div>
+        )}
+
+        {state.status === "loaded" && position && !position.hasAnyData && (
+          <div className="sm:col-span-2 text-sm text-muted-foreground">
+            You don’t have a staking position yet.
+          </div>
+        )}
+
+        {state.status === "loaded" && position && position.hasAnyData && (
+          <>
+            <div className="rounded-md border-2 border-foreground bg-background p-4">
+              <p className="text-sm text-muted-foreground">Claimable</p>
+              <p className="mt-1 font-mono text-lg font-bold">
+                {formatUsdc(position.claimable)}
+              </p>
+            </div>
+
+            <div className="rounded-md border-2 border-foreground bg-background p-4">
+              <p className="text-sm text-muted-foreground">Staked</p>
+              <p className="mt-1 font-mono text-lg font-bold">
+                {formatUsdc(position.staked)}
+              </p>
+            </div>
+
+            <div className="rounded-md border-2 border-foreground bg-background p-4">
+              <p className="text-sm text-muted-foreground">Warming</p>
+              <p className="mt-1 font-mono text-lg font-bold">
+                {formatUsdc(position.warming)}
+              </p>
+            </div>
+
+            <div className="rounded-md border-2 border-foreground bg-background p-4">
+              <p className="text-sm text-muted-foreground">Cooling</p>
+              <p className="mt-1 font-mono text-lg font-bold">
+                {formatUsdc(position.cooling)}
+              </p>
+            </div>
+          </>
+        )}
+      </div>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary

Replace the tenant dashboard experimental staking placeholder with a real rewards/position summary card powered by the existing staking position API.

## Linked issue

Closes #548

## Changes

- Replaced the tenant dashboard “Coming soon” staking placeholder with a real rewards summary card (still gated by `enableExperimentalStaking`).
- Added [TenantRewardsSummaryCard](cci:1://file:///c:/Users/Oluwaseun/Documents/monorepo/frontend/components/tenant-rewards-summary-card.tsx:18:0-142:1) that fetches `/api/staking/position` and renders:
  - Claimable, staked, warming, cooling values (USDC)
  - An explicit empty state when all values are zero
  - A fallback unavailable/error state
- Added component tests covering data-present and no-data variants.

## Checklist

- [ ] I tested locally
- [ ] I did not commit secrets
- [ ] I updated docs if needed
- [ ] If UI changes: I included before/after screenshots
- [ ] If images added/changed: I verified they are optimized and accessible