### PR TITLE
feat(wallet): expose filtered CSV export

### DIFF
--- a/frontend/app/wallet/WalletClient.tsx
+++ b/frontend/app/wallet/WalletClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState, useMemo, Suspense } from "react";
+import { useCallback, useEffect, useState, useMemo, Suspense, useRef } from "react";
 import { useSearchParams, useRouter, usePathname } from "next/navigation";
 import {
   AlertCircle,
@@ -18,7 +18,6 @@ import {
 } from "lucide-react";
 import { handleError, showSuccessToast } from "@/lib/toast";
 import { generateLedgerCsv, downloadCsv } from "@/lib/csvExport";
-import { featureFlags } from "@/lib/featureFlags";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -179,9 +178,12 @@ function WalletPageContent() {
   const [reloadNonce, setReloadNonce] = useState(0);
 
   const { isFrozen, freezeReason } = useRiskState();
-          const [isExporting, setIsExporting] = useState(false);
+  const [isExporting, setIsExporting] = useState(false);
+  const [isExportMenuOpen, setIsExportMenuOpen] = useState(false);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [showFiltersMobile, setShowFiltersMobile] = useState(false);
+
+  const exportMenuRef = useRef<HTMLDivElement | null>(null);
 
   const deficit =
     balanceState.type === "success"
@@ -193,6 +195,32 @@ function WalletPageContent() {
     [activeFilters]
   );
   const hasActiveFilters = activeFilters.length > 0;
+
+  useEffect(() => {
+    if (!isExportMenuOpen) return;
+
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        setIsExportMenuOpen(false);
+      }
+    }
+
+    function onPointerDown(e: PointerEvent) {
+      const target = e.target as Node | null;
+      if (!target) return;
+      if (exportMenuRef.current && !exportMenuRef.current.contains(target)) {
+        setIsExportMenuOpen(false);
+      }
+    }
+
+    document.addEventListener("keydown", onKeyDown);
+    document.addEventListener("pointerdown", onPointerDown);
+
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+      document.removeEventListener("pointerdown", onPointerDown);
+    };
+  }, [isExportMenuOpen]);
 
 
   // Retry function
@@ -310,6 +338,7 @@ function WalletPageContent() {
 
       setIsExporting(true);
       try {
+        setIsExportMenuOpen(false);
         // Determine which entries to export
         let entriesToExport: WalletLedgerEntry[];
         let filenameSuffix: string;
@@ -506,17 +535,25 @@ function WalletPageContent() {
 
             <div className="flex items-center gap-2">
               {/* CSV Export Dropdown */}
-              <div className="relative group">
+              <div
+                ref={exportMenuRef}
+                className="relative"
+                onMouseEnter={() => setIsExportMenuOpen(true)}
+                onMouseLeave={() => setIsExportMenuOpen(false)}
+              >
                 <Button
                   variant="outline"
                   size="sm"
                   disabled={isExporting || ledgerState.type !== "success"}
+                  aria-haspopup="menu"
+                  aria-expanded={isExportMenuOpen}
+                  onClick={() => setIsExportMenuOpen((v) => !v)}
                   className="border-3 border-foreground bg-background font-bold shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] transition-all hover:translate-x-0.5 hover:translate-y-0.5 hover:shadow-[2px_2px_0px_0px_rgba(26,26,26,1)] disabled:opacity-50"
                 >
                   {isExporting ? (
                     <>
                       <RefreshCw className="mr-2 h-4 w-4 animate-spin" />
-                      Exporting...
+                      Preparing CSV...
                     </>
                   ) : (
                     <>
@@ -526,20 +563,27 @@ function WalletPageContent() {
                   )}
                 </Button>
                 {/* Export Options Dropdown */}
-                <div className="absolute right-0 top-full z-10 mt-2 hidden w-56 rounded-md border-3 border-foreground bg-background p-2 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] group-hover:block">
+                <div
+                  role="menu"
+                  className={`absolute right-0 top-full z-10 mt-2 w-56 rounded-md border-3 border-foreground bg-background p-2 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] ${
+                    isExportMenuOpen ? "block" : "hidden"
+                  }`}
+                >
                   <p className="mb-2 px-2 text-xs font-medium text-muted-foreground">
                     Export options
                   </p>
                   <button
                     onClick={() => handleExportCsv(false)}
+                    disabled={isExporting || ledgerState.type !== "success"}
                     className="flex w-full items-center rounded-sm px-2 py-1.5 text-sm hover:bg-muted text-left"
                   >
                     <Download className="mr-2 h-4 w-4" />
                     Export all entries
                   </button>
-                  {featureFlags.enableAdvancedWalletOps && hasActiveFilters && (
+                  {hasActiveFilters && (
                     <button
                       onClick={() => handleExportCsv(true)}
+                      disabled={isExporting || ledgerState.type !== "success"}
                       className="flex w-full items-center rounded-sm px-2 py-1.5 text-sm hover:bg-muted text-left"
                     >
                       <Filter className="mr-2 h-4 w-4" />

--- a/frontend/app/wallet/page.test.tsx
+++ b/frontend/app/wallet/page.test.tsx
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import WalletPage from "./page";
+
+vi.mock("next/navigation", () => {
+  return {
+    useRouter: () => ({ replace: vi.fn() }),
+    usePathname: () => "/wallet",
+    useSearchParams: vi.fn(),
+  };
+});
+
+vi.mock("@/hooks/useRiskState", () => ({
+  useRiskState: () => ({ isFrozen: false, freezeReason: null }),
+}));
+
+vi.mock("@/components/wallet/TopUpModal", () => ({
+  TopUpModal: () => null,
+}));
+
+vi.mock("@/components/wallet/WithdrawalModal", () => ({
+  WithdrawalModal: () => null,
+}));
+
+vi.mock("@/components/wallet/WithdrawalHistory", () => ({
+  WithdrawalHistory: () => null,
+}));
+
+vi.mock("@/components/FrozenAccountBanner", () => ({
+  default: () => null,
+}));
+
+vi.mock("@/lib/toast", () => ({
+  handleError: vi.fn(),
+  showSuccessToast: vi.fn(),
+}));
+
+vi.mock("@/lib/csvExport", () => ({
+  generateLedgerCsv: vi.fn(() => "csv-content"),
+  downloadCsv: vi.fn(),
+}));
+
+vi.mock("@/lib/walletApi", () => ({
+  getNgnBalance: vi.fn(),
+  getNgnLedger: vi.fn(),
+}));
+
+import { useSearchParams } from "next/navigation";
+import { getNgnBalance, getNgnLedger } from "@/lib/walletApi";
+import { downloadCsv } from "@/lib/csvExport";
+
+type MockUseSearchParams = Mock<typeof useSearchParams>;
+type MockGetNgnBalance = Mock<typeof getNgnBalance>;
+type MockGetNgnLedger = Mock<typeof getNgnLedger>;
+type MockDownloadCsv = Mock<typeof downloadCsv>;
+
+function ledgerEntry(overrides?: Partial<{ id: string; type: string }>) {
+  return {
+    id: overrides?.id ?? "e-1",
+    type: overrides?.type ?? "top_up",
+    amountNgn: 1000,
+    status: "confirmed" as const,
+    timestamp: "2026-01-01T00:00:00.000Z",
+    reference: "ref-1",
+  };
+}
+
+describe("Wallet CSV export", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    const mockBalance = getNgnBalance as MockGetNgnBalance;
+    mockBalance.mockResolvedValue({ availableNgn: 0, heldNgn: 0, totalNgn: 0 });
+
+    const mockLedger = getNgnLedger as MockGetNgnLedger;
+    mockLedger.mockResolvedValue({ entries: [ledgerEntry()], nextCursor: null });
+
+    const mockUseSearchParams = useSearchParams as MockUseSearchParams;
+    mockUseSearchParams.mockReturnValue(new URLSearchParams() as any);
+  });
+
+  it("shows export all entries and hides filtered export when no filters are active", async () => {
+    render(<WalletPage />);
+
+    const exportButton = await screen.findByRole("button", { name: /export csv/i });
+    await waitFor(() => expect(exportButton).toBeEnabled());
+
+    await userEvent.click(exportButton);
+
+    expect(screen.getByText("Export all entries")).toBeInTheDocument();
+    expect(screen.queryByText(/Export filtered/i)).not.toBeInTheDocument();
+  });
+
+  it("shows filtered export option when filters are active", async () => {
+    const mockUseSearchParams = useSearchParams as MockUseSearchParams;
+    mockUseSearchParams.mockReturnValue(new URLSearchParams("filter=topups") as any);
+
+    render(<WalletPage />);
+
+    const exportButton = await screen.findByRole("button", { name: /export csv/i });
+    await waitFor(() => expect(exportButton).toBeEnabled());
+
+    await userEvent.click(exportButton);
+
+    expect(screen.getByText("Export all entries")).toBeInTheDocument();
+    expect(screen.getByText(/Export filtered \(Top-ups\)/i)).toBeInTheDocument();
+  });
+
+  it("exports ledger entries that match the active filter selection", async () => {
+    const mockUseSearchParams = useSearchParams as MockUseSearchParams;
+    mockUseSearchParams.mockReturnValue(new URLSearchParams("filter=topups") as any);
+
+    const mockLedger = getNgnLedger as MockGetNgnLedger;
+
+    mockLedger.mockImplementation(async (params?: { cursor?: string; limit?: number; type?: string[] }) => {
+      if (params?.limit === 10) {
+        return { entries: [ledgerEntry({ id: "initial" })], nextCursor: null };
+      }
+
+      if (params?.limit === 100 && !params?.cursor) {
+        return { entries: [ledgerEntry({ id: "p1" })], nextCursor: "c1" };
+      }
+
+      if (params?.limit === 100 && params?.cursor === "c1") {
+        return { entries: [ledgerEntry({ id: "p2" })], nextCursor: null };
+      }
+
+      return { entries: [], nextCursor: null };
+    });
+
+    render(<WalletPage />);
+
+    const exportButton = await screen.findByRole("button", { name: /export csv/i });
+    await waitFor(() => expect(exportButton).toBeEnabled());
+
+    await userEvent.click(exportButton);
+    await userEvent.click(screen.getByText(/Export filtered/i));
+
+    await waitFor(() => {
+      expect(downloadCsv).toHaveBeenCalledTimes(1);
+    });
+
+    const exportCalls = mockLedger.mock.calls
+      .map((c) => c[0])
+      .filter((p) => p?.limit === 100);
+
+    expect(exportCalls.length).toBe(2);
+    for (const call of exportCalls) {
+      expect(call?.type).toEqual(["top_up"]);
+    }
+
+    const mockDownload = downloadCsv as MockDownloadCsv;
+    expect(mockDownload.mock.calls[0]?.[1]).toMatch(
+      /^wallet-ledger-filtered-topups-\d{4}-\d{2}-\d{2}\.csv$/
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Expose the existing filtered wallet CSV export in the production wallet UI (no longer gated behind `enableAdvancedWalletOps`). Also makes the export dropdown usable via both hover (desktop) and click/tap (mobile), with improved exporting copy and robust close behavior.

## Linked issue

Closes #549

## Changes

- Exposed “Export filtered (…)” option whenever wallet filters are active (removed advanced feature gate).
- Implemented controlled export dropdown behavior:
  - Hover open/close (desktop)
  - Click/tap toggle (mobile)
  - Close on outside click and Escape
- Improved exporting UI copy (`Preparing CSV...`) and kept disabled state limited to “no data available” or “export in progress”.
- Added tests covering:
  - Export option visibility
  - Filtered export calling the ledger API with the correct `type` params and downloading the expected CSV filename format

## Checklist

- [ ] I tested locally
- [ ] I did not commit secrets
- [ ] I updated docs if needed
- [ ] If UI changes: I included before/after screenshots
- [ ] If images added/changed: I verified they are optimized and accessible