### PR TITLE
fix(properties): mark page as force-dynamic to fix static rendering

### DIFF
--- a/frontend/app/properties/page.tsx
+++ b/frontend/app/properties/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+export const dynamic = "force-dynamic";
+
 import { useState } from "react";
 import Link from "next/link";
 import {


### PR DESCRIPTION
## Summary

Fixes the Next.js 16 build error where useSearchParams() requires a Suspense boundary. The /properties page uses client-side state management for search and filtering, which is inherently dynamic content.

## Changes

- Mark /properties page with `export const dynamic = "force-dynamic"` to skip static prerendering
- This prevents Next.js from attempting to statically render dynamic client components

## Testing

This resolves the CI build failure on PR #651.

Closes #741