### PR TITLE
feat(backend): RTI, landlord payout, escrow conditions, audit report

### DIFF
--- a/backend/src/config/underwriting.ts
+++ b/backend/src/config/underwriting.ts
@@ -1,0 +1,45 @@
+/**
+ * Underwriting configuration.
+ *
+ * Centralises tunable risk thresholds so they can be changed via environment
+ * variables without code changes (see issue #908). Currently holds the
+ * rent-to-income (RTI) thresholds used by the RTI assessment engine.
+ */
+
+export interface RtiThresholds {
+  /** RTI percent at or below this is a clean pass. */
+  passMaxPercent: number
+  /** RTI percent above passMax and at or below this is borderline (manual review). */
+  borderlineMaxPercent: number
+}
+
+export const DEFAULT_RTI_THRESHOLDS: RtiThresholds = {
+  passMaxPercent: 35,
+  borderlineMaxPercent: 45,
+}
+
+function readPercent(name: string, fallback: number): number {
+  const raw = process.env[name]
+  if (raw === undefined || raw === '') return fallback
+  const parsed = Number(raw)
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback
+  return parsed
+}
+
+/**
+ * Resolve the active RTI thresholds, allowing environment overrides:
+ *   RTI_PASS_MAX_PERCENT       (default 35)
+ *   RTI_BORDERLINE_MAX_PERCENT (default 45)
+ */
+export function getRtiThresholds(): RtiThresholds {
+  const passMaxPercent = readPercent('RTI_PASS_MAX_PERCENT', DEFAULT_RTI_THRESHOLDS.passMaxPercent)
+  const borderlineMaxPercent = readPercent(
+    'RTI_BORDERLINE_MAX_PERCENT',
+    DEFAULT_RTI_THRESHOLDS.borderlineMaxPercent,
+  )
+  // Borderline ceiling must sit above the pass ceiling to be meaningful.
+  if (borderlineMaxPercent <= passMaxPercent) {
+    return { passMaxPercent, borderlineMaxPercent: passMaxPercent }
+  }
+  return { passMaxPercent, borderlineMaxPercent }
+}

--- a/backend/src/models/escrowCondition.test.ts
+++ b/backend/src/models/escrowCondition.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest'
+import {
+  evaluateRelease,
+  isConditionSatisfied,
+  InMemoryEscrowConditionStore,
+  type EscrowCondition,
+  type EscrowReleasePolicy,
+} from './escrowCondition.js'
+
+function condition(
+  dealId: string,
+  conditionType: EscrowCondition['conditionType'],
+  satisfied: boolean,
+  instalmentNumber?: number,
+): EscrowCondition {
+  return { id: `${conditionType}-${instalmentNumber ?? 0}`, dealId, conditionType, satisfied, instalmentNumber }
+}
+
+describe('evaluateRelease — all_satisfied', () => {
+  const policy: EscrowReleasePolicy = {
+    dealId: 'deal-1',
+    requiredConditions: ['lease_signed', 'inspection_approved'],
+    releaseMode: 'all_satisfied',
+  }
+
+  it('does not release until every required condition is satisfied', () => {
+    const partial = evaluateRelease(policy, [
+      condition('deal-1', 'lease_signed', true),
+      condition('deal-1', 'inspection_approved', false),
+    ])
+    expect(partial.shouldRelease).toBe(false)
+    expect(partial.missingConditions).toEqual(['inspection_approved'])
+    expect(partial.reason).toBe('conditions_outstanding')
+  })
+
+  it('releases once all required conditions are satisfied', () => {
+    const full = evaluateRelease(policy, [
+      condition('deal-1', 'lease_signed', true),
+      condition('deal-1', 'inspection_approved', true),
+    ])
+    expect(full.shouldRelease).toBe(true)
+    expect(full.missingConditions).toEqual([])
+    expect(full.reason).toBe('all_conditions_satisfied')
+  })
+})
+
+describe('evaluateRelease — any_satisfied', () => {
+  const policy: EscrowReleasePolicy = {
+    dealId: 'deal-2',
+    requiredConditions: ['instalment_received', 'inspection_approved'],
+    releaseMode: 'any_satisfied',
+  }
+
+  it('releases when at least one condition is satisfied', () => {
+    const result = evaluateRelease(policy, [condition('deal-2', 'instalment_received', true, 1)])
+    expect(result.shouldRelease).toBe(true)
+    expect(result.reason).toBe('any_condition_satisfied')
+  })
+
+  it('does not release when none are satisfied', () => {
+    const result = evaluateRelease(policy, [])
+    expect(result.shouldRelease).toBe(false)
+    expect(result.reason).toBe('no_conditions_satisfied')
+  })
+})
+
+describe('evaluateRelease — admin override', () => {
+  it('admin_manual policy only releases on admin override', () => {
+    const policy: EscrowReleasePolicy = {
+      dealId: 'deal-3',
+      requiredConditions: ['lease_signed'],
+      releaseMode: 'admin_manual',
+    }
+    expect(evaluateRelease(policy, [condition('deal-3', 'lease_signed', true)]).shouldRelease).toBe(false)
+    const overridden = evaluateRelease(policy, [
+      condition('deal-3', 'lease_signed', true),
+      condition('deal-3', 'admin_override', true),
+    ])
+    expect(overridden.shouldRelease).toBe(true)
+    expect(overridden.reason).toBe('admin_override')
+  })
+
+  it('admin override forces release even under all_satisfied with missing conditions', () => {
+    const policy: EscrowReleasePolicy = {
+      dealId: 'deal-4',
+      requiredConditions: ['lease_signed', 'inspection_approved'],
+      releaseMode: 'all_satisfied',
+    }
+    const result = evaluateRelease(policy, [condition('deal-4', 'admin_override', true)])
+    expect(result.shouldRelease).toBe(true)
+    expect(result.reason).toBe('admin_override')
+  })
+})
+
+describe('isConditionSatisfied — per-instalment scoping', () => {
+  it('matches the specific instalment for partial release', () => {
+    const conditions = [
+      condition('deal-5', 'instalment_received', true, 1),
+      condition('deal-5', 'instalment_received', false, 2),
+    ]
+    expect(isConditionSatisfied(conditions, 'instalment_received', 1)).toBe(true)
+    expect(isConditionSatisfied(conditions, 'instalment_received', 2)).toBe(false)
+  })
+})
+
+describe('InMemoryEscrowConditionStore', () => {
+  it('marks conditions satisfied and lists them by deal', () => {
+    const store = new InMemoryEscrowConditionStore()
+    store.markSatisfied({ dealId: 'deal-6', conditionType: 'lease_signed', satisfiedBy: 'system' })
+    const list = store.listByDeal('deal-6')
+    expect(list).toHaveLength(1)
+    expect(list[0].satisfied).toBe(true)
+    expect(list[0].satisfiedBy).toBe('system')
+  })
+
+  it('is idempotent: re-marking does not duplicate or reset the timestamp', () => {
+    const store = new InMemoryEscrowConditionStore()
+    const first = store.markSatisfied({
+      dealId: 'deal-7',
+      conditionType: 'instalment_received',
+      instalmentNumber: 1,
+      satisfiedAt: '2026-01-01T00:00:00.000Z',
+    })
+    const second = store.markSatisfied({
+      dealId: 'deal-7',
+      conditionType: 'instalment_received',
+      instalmentNumber: 1,
+      satisfiedAt: '2026-02-02T00:00:00.000Z',
+    })
+    expect(store.listByDeal('deal-7')).toHaveLength(1)
+    expect(second.id).toBe(first.id)
+    expect(second.satisfiedAt).toBe('2026-01-01T00:00:00.000Z')
+  })
+
+  it('tracks distinct instalments separately', () => {
+    const store = new InMemoryEscrowConditionStore()
+    store.markSatisfied({ dealId: 'deal-8', conditionType: 'instalment_received', instalmentNumber: 1 })
+    store.markSatisfied({ dealId: 'deal-8', conditionType: 'instalment_received', instalmentNumber: 2 })
+    expect(store.listByDeal('deal-8')).toHaveLength(2)
+  })
+})

--- a/backend/src/models/escrowCondition.ts
+++ b/backend/src/models/escrowCondition.ts
@@ -1,0 +1,147 @@
+/**
+ * Escrow condition model & release-policy evaluation — issue #910.
+ *
+ * Models the conditions that gate an automated escrow release for a deal, and
+ * the policy that decides when the gate opens. The evaluation logic
+ * (`evaluateRelease`) is pure so it can be driven from condition-satisfaction
+ * hooks and from the scheduled release job alike.
+ */
+
+import { randomUUID } from 'node:crypto'
+
+export type EscrowConditionType =
+  | 'lease_signed'
+  | 'inspection_approved'
+  | 'instalment_received'
+  | 'admin_override'
+
+export type EscrowReleaseMode = 'all_satisfied' | 'any_satisfied' | 'admin_manual'
+
+export interface EscrowCondition {
+  id: string
+  dealId: string
+  conditionType: EscrowConditionType
+  /** For `instalment_received`: which instalment this condition tracks. */
+  instalmentNumber?: number
+  satisfied: boolean
+  satisfiedAt?: string
+  satisfiedBy?: string
+}
+
+export interface EscrowReleasePolicy {
+  dealId: string
+  requiredConditions: EscrowConditionType[]
+  releaseMode: EscrowReleaseMode
+}
+
+export interface ReleaseEvaluation {
+  shouldRelease: boolean
+  satisfiedConditions: EscrowConditionType[]
+  missingConditions: EscrowConditionType[]
+  reason: string
+}
+
+/**
+ * Is a condition of `conditionType` satisfied for the deal? When
+ * `instalmentNumber` is provided, the match is scoped to that instalment.
+ */
+export function isConditionSatisfied(
+  conditions: EscrowCondition[],
+  conditionType: EscrowConditionType,
+  instalmentNumber?: number,
+): boolean {
+  return conditions.some(
+    (c) =>
+      c.conditionType === conditionType &&
+      c.satisfied &&
+      (instalmentNumber === undefined || c.instalmentNumber === instalmentNumber),
+  )
+}
+
+/**
+ * Pure release decision. An admin override always opens the gate regardless of
+ * the policy mode. Otherwise:
+ *   - admin_manual:  released only by an admin override.
+ *   - all_satisfied: every required condition must be satisfied.
+ *   - any_satisfied: at least one required condition must be satisfied.
+ */
+export function evaluateRelease(
+  policy: EscrowReleasePolicy,
+  conditions: EscrowCondition[],
+): ReleaseEvaluation {
+  const required = policy.requiredConditions
+  const satisfiedConditions = required.filter((t) => isConditionSatisfied(conditions, t))
+  const missingConditions = required.filter((t) => !isConditionSatisfied(conditions, t))
+
+  const adminOverride = isConditionSatisfied(conditions, 'admin_override')
+  if (adminOverride) {
+    return {
+      shouldRelease: true,
+      satisfiedConditions,
+      missingConditions,
+      reason: 'admin_override',
+    }
+  }
+
+  let shouldRelease: boolean
+  let reason: string
+  switch (policy.releaseMode) {
+    case 'admin_manual':
+      shouldRelease = false
+      reason = 'awaiting_admin_override'
+      break
+    case 'any_satisfied':
+      shouldRelease = satisfiedConditions.length > 0
+      reason = shouldRelease ? 'any_condition_satisfied' : 'no_conditions_satisfied'
+      break
+    case 'all_satisfied':
+    default:
+      shouldRelease = required.length > 0 && missingConditions.length === 0
+      reason = shouldRelease ? 'all_conditions_satisfied' : 'conditions_outstanding'
+      break
+  }
+
+  return { shouldRelease, satisfiedConditions, missingConditions, reason }
+}
+
+/**
+ * In-memory store for escrow conditions. Marking a condition satisfied is
+ * idempotent: re-applying the same satisfaction does not create a duplicate
+ * record nor move the original `satisfiedAt` timestamp.
+ */
+export class InMemoryEscrowConditionStore {
+  private conditions: Map<string, EscrowCondition> = new Map()
+
+  private keyFor(dealId: string, type: EscrowConditionType, instalmentNumber?: number): string {
+    return `${dealId}:${type}:${instalmentNumber ?? '-'}`
+  }
+
+  listByDeal(dealId: string): EscrowCondition[] {
+    return Array.from(this.conditions.values()).filter((c) => c.dealId === dealId)
+  }
+
+  markSatisfied(params: {
+    dealId: string
+    conditionType: EscrowConditionType
+    instalmentNumber?: number
+    satisfiedBy?: string
+    satisfiedAt?: string
+  }): EscrowCondition {
+    const key = this.keyFor(params.dealId, params.conditionType, params.instalmentNumber)
+    const existing = this.conditions.get(key)
+    if (existing && existing.satisfied) {
+      return existing
+    }
+    const condition: EscrowCondition = {
+      id: existing?.id ?? randomUUID(),
+      dealId: params.dealId,
+      conditionType: params.conditionType,
+      instalmentNumber: params.instalmentNumber,
+      satisfied: true,
+      satisfiedAt: params.satisfiedAt ?? new Date().toISOString(),
+      satisfiedBy: params.satisfiedBy,
+    }
+    this.conditions.set(key, condition)
+    return condition
+  }
+}

--- a/backend/src/services/auditReportService.test.ts
+++ b/backend/src/services/auditReportService.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from 'vitest'
+import {
+  matchesAuditFilters,
+  parseEventTypeFilter,
+  encodeCursor,
+  decodeCursor,
+  paginateByCursor,
+  buildActivityReport,
+} from './auditReportService.js'
+import type { AuditEntry } from '../repositories/AuditRepository.js'
+
+function entry(overrides: Partial<AuditEntry> & { id: string; createdAt: Date }): AuditEntry {
+  return {
+    eventType: 'LISTING_APPROVED',
+    actorType: 'admin',
+    userId: 'admin-1',
+    requestId: null,
+    ipAddress: null,
+    httpMethod: null,
+    httpPath: null,
+    metadata: {},
+    prevHash: 'p',
+    eventHash: 'e',
+    chainHash: 'c',
+    ...overrides,
+  } as AuditEntry
+}
+
+describe('matchesAuditFilters', () => {
+  const e = entry({
+    id: '1',
+    createdAt: new Date('2026-03-10T12:00:00Z'),
+    eventType: 'DISPUTE_RESOLVED',
+    actorType: 'admin',
+    userId: 'admin-7',
+    metadata: { entityType: 'dispute', entityId: 'dispute-42' },
+  })
+
+  it('matches a multi-value eventType filter', () => {
+    expect(matchesAuditFilters(e, { eventType: ['KYC_APPROVED', 'DISPUTE_RESOLVED'] })).toBe(true)
+    expect(matchesAuditFilters(e, { eventType: ['KYC_APPROVED'] })).toBe(false)
+  })
+
+  it('matches actor and entity scoping from metadata', () => {
+    expect(matchesAuditFilters(e, { actorId: 'admin-7' })).toBe(true)
+    expect(matchesAuditFilters(e, { actorId: 'admin-9' })).toBe(false)
+    expect(matchesAuditFilters(e, { entityType: 'dispute', entityId: 'dispute-42' })).toBe(true)
+    expect(matchesAuditFilters(e, { entityType: 'dispute', entityId: 'dispute-99' })).toBe(false)
+  })
+
+  it('excludes events outside the date window', () => {
+    expect(matchesAuditFilters(e, { fromDate: new Date('2026-03-01T00:00:00Z'), toDate: new Date('2026-03-31T00:00:00Z') })).toBe(true)
+    expect(matchesAuditFilters(e, { fromDate: new Date('2026-03-11T00:00:00Z') })).toBe(false)
+    expect(matchesAuditFilters(e, { toDate: new Date('2026-03-09T00:00:00Z') })).toBe(false)
+  })
+})
+
+describe('parseEventTypeFilter', () => {
+  it('parses comma-separated and repeated params', () => {
+    expect(parseEventTypeFilter('A,B , C')).toEqual(['A', 'B', 'C'])
+    expect(parseEventTypeFilter(['A', 'B'])).toEqual(['A', 'B'])
+  })
+  it('returns undefined for empty input', () => {
+    expect(parseEventTypeFilter(undefined)).toBeUndefined()
+    expect(parseEventTypeFilter('  ,  ')).toBeUndefined()
+  })
+})
+
+describe('cursor pagination', () => {
+  const entries = [
+    entry({ id: 'a', createdAt: new Date('2026-01-01T00:00:00Z') }),
+    entry({ id: 'b', createdAt: new Date('2026-01-02T00:00:00Z') }),
+    entry({ id: 'c', createdAt: new Date('2026-01-03T00:00:00Z') }),
+    entry({ id: 'd', createdAt: new Date('2026-01-04T00:00:00Z') }),
+    entry({ id: 'e', createdAt: new Date('2026-01-05T00:00:00Z') }),
+  ]
+
+  it('round-trips a cursor', () => {
+    const c = encodeCursor({ id: 'x', createdAt: new Date('2026-01-01T00:00:00Z') })
+    expect(decodeCursor(c)).toEqual({ id: 'x', createdAt: '2026-01-01T00:00:00.000Z' })
+  })
+
+  it('returns invalid cursors as null', () => {
+    expect(decodeCursor('not-a-cursor')).toBeNull()
+  })
+
+  it('walks newest-first across pages with no skips or duplicates', () => {
+    const page1 = paginateByCursor(entries, { limit: 2 })
+    expect(page1.items.map((e) => e.id)).toEqual(['e', 'd'])
+    expect(page1.nextCursor).not.toBeNull()
+
+    const page2 = paginateByCursor(entries, { limit: 2, cursor: page1.nextCursor })
+    expect(page2.items.map((e) => e.id)).toEqual(['c', 'b'])
+
+    const page3 = paginateByCursor(entries, { limit: 2, cursor: page2.nextCursor })
+    expect(page3.items.map((e) => e.id)).toEqual(['a'])
+    expect(page3.nextCursor).toBeNull()
+
+    const allIds = [...page1.items, ...page2.items, ...page3.items].map((e) => e.id)
+    expect(new Set(allIds).size).toBe(5)
+  })
+
+  it('does not skip when a newer event is inserted between page reads', () => {
+    const page1 = paginateByCursor(entries, { limit: 2 })
+    const withInsert = [...entries, entry({ id: 'f', createdAt: new Date('2026-01-06T00:00:00Z') })]
+    const page2 = paginateByCursor(withInsert, { limit: 2, cursor: page1.nextCursor })
+    // The freshly inserted 'f' is newer than the cursor, so it is not re-served here.
+    expect(page2.items.map((e) => e.id)).toEqual(['c', 'b'])
+  })
+})
+
+describe('buildActivityReport', () => {
+  const entries = [
+    entry({ id: '1', createdAt: new Date('2026-02-01T08:00:00Z'), eventType: 'LISTING_APPROVED' }),
+    entry({ id: '2', createdAt: new Date('2026-02-01T20:00:00Z'), eventType: 'KYC_APPROVED' }),
+    entry({ id: '3', createdAt: new Date('2026-02-02T09:00:00Z'), eventType: 'LISTING_APPROVED' }),
+    entry({ id: '4', createdAt: new Date('2026-02-05T09:00:00Z'), eventType: 'DISPUTE_RESOLVED' }),
+  ]
+
+  it('aggregates totals by type and by day', () => {
+    const report = buildActivityReport(entries)
+    expect(report.totalEvents).toBe(4)
+    expect(report.byType).toEqual({ LISTING_APPROVED: 2, KYC_APPROVED: 1, DISPUTE_RESOLVED: 1 })
+    expect(report.byDay.map((d) => d.date)).toEqual(['2026-02-01', '2026-02-02', '2026-02-05'])
+    expect(report.byDay[0]).toEqual({ date: '2026-02-01', total: 2, byType: { LISTING_APPROVED: 1, KYC_APPROVED: 1 } })
+  })
+
+  it('honours the date range', () => {
+    const report = buildActivityReport(entries, {
+      from: new Date('2026-02-02T00:00:00Z'),
+      to: new Date('2026-02-03T00:00:00Z'),
+    })
+    expect(report.totalEvents).toBe(1)
+    expect(report.byType).toEqual({ LISTING_APPROVED: 1 })
+  })
+})

--- a/backend/src/services/auditReportService.ts
+++ b/backend/src/services/auditReportService.ts
@@ -1,0 +1,195 @@
+/**
+ * Admin audit-trail querying & reporting helpers — issue #909.
+ *
+ * Pure helpers that back the admin audit API:
+ *   - `matchesAuditFilters` — predicate supporting multi-value eventType,
+ *     actor, entity scoping (read from metadata.entityType/entityId), and a
+ *     date window.
+ *   - cursor-based pagination (`encodeCursor`/`decodeCursor`/`paginateByCursor`)
+ *     so large, live audit sets page without offset skips.
+ *   - `buildActivityReport` — events aggregated by type and by day over a range.
+ *
+ * These operate on already-fetched `AuditEntry` records (see AuditRepository),
+ * keeping query patterns in the repository and reporting logic testable here.
+ */
+
+import type { AuditEntry } from '../repositories/AuditRepository.js'
+
+export interface AuditTrailFilters {
+  /** One or more event types (OR-matched). */
+  eventType?: string[]
+  actorType?: string
+  /** Maps to AuditEntry.userId. */
+  actorId?: string
+  entityType?: string
+  entityId?: string
+  fromDate?: Date
+  toDate?: Date
+}
+
+function entityFieldsOf(entry: AuditEntry): { entityType?: string; entityId?: string } {
+  const md = entry.metadata ?? {}
+  const entityType = typeof md.entityType === 'string' ? md.entityType : undefined
+  const entityId =
+    typeof md.entityId === 'string'
+      ? md.entityId
+      : typeof md.entityId === 'number'
+        ? String(md.entityId)
+        : undefined
+  return { entityType, entityId }
+}
+
+/** True when an entry satisfies every supplied filter (absent filters ignored). */
+export function matchesAuditFilters(entry: AuditEntry, filters: AuditTrailFilters): boolean {
+  if (filters.eventType && filters.eventType.length > 0 && !filters.eventType.includes(entry.eventType)) {
+    return false
+  }
+  if (filters.actorType && entry.actorType !== filters.actorType) return false
+  if (filters.actorId && entry.userId !== filters.actorId) return false
+
+  if (filters.entityType || filters.entityId) {
+    const { entityType, entityId } = entityFieldsOf(entry)
+    if (filters.entityType && entityType !== filters.entityType) return false
+    if (filters.entityId && entityId !== filters.entityId) return false
+  }
+
+  const ts = entry.createdAt.getTime()
+  if (filters.fromDate && ts < filters.fromDate.getTime()) return false
+  if (filters.toDate && ts > filters.toDate.getTime()) return false
+
+  return true
+}
+
+/**
+ * Parse a multi-value eventType filter from a query value: accepts a repeated
+ * param (string[]) or a single comma-separated string. Returns undefined when
+ * nothing usable is supplied.
+ */
+export function parseEventTypeFilter(value: string | string[] | undefined): string[] | undefined {
+  if (value === undefined) return undefined
+  const raw = Array.isArray(value) ? value : value.split(',')
+  const cleaned = raw.map((v) => v.trim()).filter((v) => v.length > 0)
+  return cleaned.length > 0 ? cleaned : undefined
+}
+
+// ---- Cursor pagination ----------------------------------------------------
+
+export interface AuditCursor {
+  createdAt: string
+  id: string
+}
+
+export function encodeCursor(entry: Pick<AuditEntry, 'createdAt' | 'id'>): string {
+  const payload: AuditCursor = { createdAt: entry.createdAt.toISOString(), id: entry.id }
+  return Buffer.from(JSON.stringify(payload), 'utf8').toString('base64url')
+}
+
+export function decodeCursor(cursor: string): AuditCursor | null {
+  try {
+    const json = Buffer.from(cursor, 'base64url').toString('utf8')
+    const parsed = JSON.parse(json) as AuditCursor
+    if (typeof parsed.createdAt === 'string' && typeof parsed.id === 'string') return parsed
+    return null
+  } catch {
+    return null
+  }
+}
+
+/** Sort key: newest first, breaking ties by id descending for stability. */
+function isOlderThanCursor(entry: AuditEntry, cursor: AuditCursor): boolean {
+  const entryTs = entry.createdAt.getTime()
+  const cursorTs = new Date(cursor.createdAt).getTime()
+  if (entryTs !== cursorTs) return entryTs < cursorTs
+  return entry.id < cursor.id
+}
+
+export interface CursorPage {
+  items: AuditEntry[]
+  nextCursor: string | null
+}
+
+/**
+ * Cursor-paginate a set of entries newest-first. The cursor encodes the last
+ * returned (createdAt, id), so live inserts at the head never cause skips or
+ * duplicates within an in-progress walk.
+ */
+export function paginateByCursor(
+  entries: AuditEntry[],
+  options: { limit: number; cursor?: string | null },
+): CursorPage {
+  const limit = Math.max(1, options.limit)
+  const sorted = [...entries].sort((a, b) => {
+    const diff = b.createdAt.getTime() - a.createdAt.getTime()
+    return diff !== 0 ? diff : b.id.localeCompare(a.id)
+  })
+
+  let windowed = sorted
+  if (options.cursor) {
+    const decoded = decodeCursor(options.cursor)
+    if (decoded) windowed = sorted.filter((e) => isOlderThanCursor(e, decoded))
+  }
+
+  const items = windowed.slice(0, limit)
+  const nextCursor =
+    windowed.length > limit && items.length > 0 ? encodeCursor(items[items.length - 1]) : null
+  return { items, nextCursor }
+}
+
+// ---- Activity report ------------------------------------------------------
+
+export interface ActivityReportDay {
+  date: string // YYYY-MM-DD (UTC)
+  total: number
+  byType: Record<string, number>
+}
+
+export interface ActivityReport {
+  from: string | null
+  to: string | null
+  totalEvents: number
+  byType: Record<string, number>
+  byDay: ActivityReportDay[]
+}
+
+function utcDay(date: Date): string {
+  return date.toISOString().slice(0, 10)
+}
+
+/**
+ * Aggregate audit events by type and by UTC day over an optional date range.
+ * Days with no events are omitted; `byDay` is sorted ascending by date.
+ */
+export function buildActivityReport(
+  entries: AuditEntry[],
+  range: { from?: Date; to?: Date } = {},
+): ActivityReport {
+  const inRange = entries.filter((e) =>
+    matchesAuditFilters(e, { fromDate: range.from, toDate: range.to }),
+  )
+
+  const byType: Record<string, number> = {}
+  const dayMap = new Map<string, ActivityReportDay>()
+
+  for (const e of inRange) {
+    byType[e.eventType] = (byType[e.eventType] ?? 0) + 1
+
+    const day = utcDay(e.createdAt)
+    let bucket = dayMap.get(day)
+    if (!bucket) {
+      bucket = { date: day, total: 0, byType: {} }
+      dayMap.set(day, bucket)
+    }
+    bucket.total += 1
+    bucket.byType[e.eventType] = (bucket.byType[e.eventType] ?? 0) + 1
+  }
+
+  const byDay = Array.from(dayMap.values()).sort((a, b) => a.date.localeCompare(b.date))
+
+  return {
+    from: range.from ? range.from.toISOString() : null,
+    to: range.to ? range.to.toISOString() : null,
+    totalEvents: inRange.length,
+    byType,
+    byDay,
+  }
+}

--- a/backend/src/services/landlordPayoutService.test.ts
+++ b/backend/src/services/landlordPayoutService.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest'
+import {
+  computePayoutScheduleFromInput,
+  deriveInstalmentAmounts,
+  toDeductions,
+  DEFAULT_LANDLORD_PAYOUT_CONFIG,
+} from './landlordPayoutService.js'
+
+describe('deriveInstalmentAmounts', () => {
+  it('splits evenly when divisible', () => {
+    expect(deriveInstalmentAmounts(600000, 6)).toEqual([100000, 100000, 100000, 100000, 100000, 100000])
+  })
+
+  it('folds the rounding remainder into the final instalment', () => {
+    const parts = deriveInstalmentAmounts(100000, 3)
+    expect(parts).toEqual([33333, 33333, 33334])
+    expect(parts.reduce((a, b) => a + b, 0)).toBe(100000)
+  })
+
+  it('rejects invalid terms', () => {
+    expect(() => deriveInstalmentAmounts(1000, 0)).toThrow()
+    expect(() => deriveInstalmentAmounts(-1, 6)).toThrow()
+  })
+})
+
+describe('computePayoutScheduleFromInput', () => {
+  it('produces one landlord payout per instalment plus the upfront line (6-month plan)', () => {
+    const instalments = deriveInstalmentAmounts(600000, 6)
+    const schedule = computePayoutScheduleFromInput({
+      dealId: 'deal-1',
+      landlordId: 'landlord-1',
+      depositNgn: 500000,
+      instalmentAmountsNgn: instalments,
+    })
+
+    expect(schedule.lines).toHaveLength(7) // 1 upfront + 6 instalments
+    expect(schedule.lines.filter((l) => l.kind === 'instalment')).toHaveLength(6)
+    expect(schedule.lines[0].kind).toBe('upfront')
+    expect(schedule.lines.slice(1).map((l) => l.instalmentNumber)).toEqual([1, 2, 3, 4, 5, 6])
+  })
+
+  it('pays 80% of the deposit upfront and keeps 20% as platform fee by default', () => {
+    const schedule = computePayoutScheduleFromInput({
+      dealId: 'deal-2',
+      landlordId: 'landlord-2',
+      depositNgn: 500000,
+      instalmentAmountsNgn: [],
+    })
+    const upfront = schedule.lines[0]
+    expect(upfront.netAmount).toBe(400000)
+    expect(upfront.platformFee).toBe(100000)
+    expect(upfront.grossAmount).toBe(500000)
+  })
+
+  it('records gross and net separately, deducting the platform fee per instalment', () => {
+    const schedule = computePayoutScheduleFromInput({
+      dealId: 'deal-3',
+      landlordId: 'landlord-3',
+      depositNgn: 0,
+      instalmentAmountsNgn: [100000, 100000],
+    })
+    for (const line of schedule.lines.filter((l) => l.kind === 'instalment')) {
+      expect(line.grossAmount).toBe(100000)
+      expect(line.platformFee).toBe(20000)
+      expect(line.netAmount).toBe(80000)
+      expect(line.netAmount).not.toBe(line.grossAmount)
+    }
+    // Totals reconcile.
+    expect(schedule.totals.gross).toBe(200000)
+    expect(schedule.totals.platformFee).toBe(40000)
+    expect(schedule.totals.net).toBe(160000)
+  })
+
+  it('handles 3- and 12-month plans', () => {
+    for (const term of [3, 12]) {
+      const instalments = deriveInstalmentAmounts(term * 50000, term)
+      const schedule = computePayoutScheduleFromInput({
+        dealId: `deal-${term}`,
+        landlordId: 'landlord',
+        depositNgn: 200000,
+        instalmentAmountsNgn: instalments,
+      })
+      expect(schedule.lines.filter((l) => l.kind === 'instalment')).toHaveLength(term)
+    }
+  })
+
+  it('is deterministic / idempotent for identical input', () => {
+    const input = {
+      dealId: 'deal-x',
+      landlordId: 'landlord-x',
+      depositNgn: 300000,
+      instalmentAmountsNgn: [50000, 50000, 50000],
+    }
+    expect(computePayoutScheduleFromInput(input)).toEqual(computePayoutScheduleFromInput(input))
+  })
+
+  it('respects a custom fee config', () => {
+    const schedule = computePayoutScheduleFromInput(
+      { dealId: 'd', landlordId: 'l', depositNgn: 100000, instalmentAmountsNgn: [100000] },
+      { upfrontDepositShare: 0.9, instalmentPlatformFeeShare: 0.1 },
+    )
+    expect(schedule.lines[0].netAmount).toBe(90000)
+    expect(schedule.lines[1].platformFee).toBe(10000)
+  })
+})
+
+describe('toDeductions', () => {
+  it('emits a platform_fee deduction when a fee was charged', () => {
+    expect(toDeductions({ kind: 'instalment', instalmentNumber: 1, grossAmount: 100000, platformFee: 20000, netAmount: 80000 })).toEqual([
+      { type: 'platform_fee', label: 'Platform Fee', amount: 20000 },
+    ])
+  })
+
+  it('emits no deductions when there is no fee', () => {
+    expect(toDeductions({ kind: 'upfront', grossAmount: 0, platformFee: 0, netAmount: 0 })).toEqual([])
+  })
+})
+
+describe('DEFAULT_LANDLORD_PAYOUT_CONFIG', () => {
+  it('defaults to 80% upfront / 20% instalment fee', () => {
+    expect(DEFAULT_LANDLORD_PAYOUT_CONFIG).toEqual({ upfrontDepositShare: 0.8, instalmentPlatformFeeShare: 0.2 })
+  })
+})

--- a/backend/src/services/landlordPayoutService.ts
+++ b/backend/src/services/landlordPayoutService.ts
@@ -1,0 +1,169 @@
+/**
+ * Landlord Payout Computation Service — issue #907.
+ *
+ * Computes the payout schedule owed to a landlord for a deal:
+ *   - An upfront payout: a configurable share of the deposit (default 80%),
+ *     with the platform retaining the remainder as its service fee.
+ *   - One instalment payout per tenant instalment: the landlord's share of the
+ *     instalment gross, minus the platform fee margin.
+ *
+ * The computation here is pure and deterministic so it is straightforward to
+ * test and to replay idempotently. Persisting the result (via
+ * landlordPayoutScheduleStore) and triggering disbursement are the caller's
+ * responsibility.
+ */
+
+import type { Deduction } from '../schemas/landlordPayoutSchedule.js'
+
+export interface LandlordPayoutConfig {
+  /** Fraction of the deposit paid to the landlord upfront (0..1). */
+  upfrontDepositShare: number
+  /** Platform fee fraction applied to each instalment gross (0..1). */
+  instalmentPlatformFeeShare: number
+}
+
+export const DEFAULT_LANDLORD_PAYOUT_CONFIG: LandlordPayoutConfig = {
+  upfrontDepositShare: 0.8,
+  instalmentPlatformFeeShare: 0.2,
+}
+
+function readShare(name: string, fallback: number): number {
+  const raw = process.env[name]
+  if (raw === undefined || raw === '') return fallback
+  const parsed = Number(raw)
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) return fallback
+  return parsed
+}
+
+/**
+ * Resolve the active payout config, allowing environment overrides:
+ *   LANDLORD_UPFRONT_DEPOSIT_SHARE      (default 0.8)
+ *   LANDLORD_INSTALMENT_PLATFORM_FEE    (default 0.2)
+ */
+export function getLandlordPayoutConfig(): LandlordPayoutConfig {
+  return {
+    upfrontDepositShare: readShare(
+      'LANDLORD_UPFRONT_DEPOSIT_SHARE',
+      DEFAULT_LANDLORD_PAYOUT_CONFIG.upfrontDepositShare,
+    ),
+    instalmentPlatformFeeShare: readShare(
+      'LANDLORD_INSTALMENT_PLATFORM_FEE',
+      DEFAULT_LANDLORD_PAYOUT_CONFIG.instalmentPlatformFeeShare,
+    ),
+  }
+}
+
+export type PayoutLineKind = 'upfront' | 'instalment'
+
+export interface PayoutScheduleLine {
+  kind: PayoutLineKind
+  /** 1-based instalment index; undefined for the upfront line. */
+  instalmentNumber?: number
+  grossAmount: number
+  platformFee: number
+  netAmount: number
+}
+
+export interface ComputedPayoutSchedule {
+  dealId: string
+  landlordId: string
+  currency: 'NGN'
+  lines: PayoutScheduleLine[]
+  totals: {
+    gross: number
+    platformFee: number
+    net: number
+  }
+}
+
+export interface ComputePayoutScheduleInput {
+  dealId: string
+  landlordId: string
+  /** Total deposit amount in NGN. */
+  depositNgn: number
+  /** Gross amount (NGN) of each tenant instalment, in order. */
+  instalmentAmountsNgn: number[]
+}
+
+function roundNgn(value: number): number {
+  return Math.round(value)
+}
+
+/**
+ * Split a financed amount into `termMonths` instalments. Even split with any
+ * rounding remainder folded into the final instalment so the parts sum exactly.
+ */
+export function deriveInstalmentAmounts(financedAmountNgn: number, termMonths: number): number[] {
+  if (!Number.isFinite(financedAmountNgn) || financedAmountNgn < 0) {
+    throw new Error('financedAmountNgn must be a non-negative number')
+  }
+  if (!Number.isInteger(termMonths) || termMonths <= 0) {
+    throw new Error('termMonths must be a positive integer')
+  }
+  const base = Math.floor(financedAmountNgn / termMonths)
+  const amounts = new Array(termMonths).fill(base)
+  const remainder = financedAmountNgn - base * termMonths
+  amounts[termMonths - 1] += remainder
+  return amounts
+}
+
+/**
+ * Pure payout schedule computation. Deterministic: identical input yields an
+ * identical schedule (re-runnable / idempotent at the computation layer).
+ */
+export function computePayoutScheduleFromInput(
+  input: ComputePayoutScheduleInput,
+  config: LandlordPayoutConfig = getLandlordPayoutConfig(),
+): ComputedPayoutSchedule {
+  const { dealId, landlordId, depositNgn, instalmentAmountsNgn } = input
+
+  if (!Number.isFinite(depositNgn) || depositNgn < 0) {
+    throw new Error('depositNgn must be a non-negative number')
+  }
+
+  const lines: PayoutScheduleLine[] = []
+
+  // Upfront payout from the deposit.
+  const upfrontNet = roundNgn(depositNgn * config.upfrontDepositShare)
+  lines.push({
+    kind: 'upfront',
+    grossAmount: depositNgn,
+    platformFee: depositNgn - upfrontNet,
+    netAmount: upfrontNet,
+  })
+
+  // One payout per instalment, net of the platform fee margin.
+  instalmentAmountsNgn.forEach((gross, idx) => {
+    if (!Number.isFinite(gross) || gross < 0) {
+      throw new Error(`instalment ${idx + 1} amount must be a non-negative number`)
+    }
+    const platformFee = roundNgn(gross * config.instalmentPlatformFeeShare)
+    lines.push({
+      kind: 'instalment',
+      instalmentNumber: idx + 1,
+      grossAmount: gross,
+      platformFee,
+      netAmount: gross - platformFee,
+    })
+  })
+
+  const totals = lines.reduce(
+    (acc, l) => ({
+      gross: acc.gross + l.grossAmount,
+      platformFee: acc.platformFee + l.platformFee,
+      net: acc.net + l.netAmount,
+    }),
+    { gross: 0, platformFee: 0, net: 0 },
+  )
+
+  return { dealId, landlordId, currency: 'NGN', lines, totals }
+}
+
+/**
+ * Map a computed payout line to the `deductions` shape used by
+ * landlordPayoutScheduleStore, so the schedule can be persisted consistently.
+ */
+export function toDeductions(line: PayoutScheduleLine): Deduction[] {
+  if (line.platformFee <= 0) return []
+  return [{ type: 'platform_fee', label: 'Platform Fee', amount: line.platformFee }]
+}

--- a/backend/src/services/rtiAssessmentService.test.ts
+++ b/backend/src/services/rtiAssessmentService.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { assessRti, computeRti, resolveMonthlyIncome } from './rtiAssessmentService.js'
+import { tenantCreditScoreStore } from '../models/tenantCreditScoreStore.js'
+
+const FIXED_NOW = new Date('2026-01-01T00:00:00.000Z')
+
+describe('assessRti', () => {
+  it('passes when repayment is at or below the pass ceiling (35%)', () => {
+    const exact = assessRti({ monthlyIncome: 100000, monthlyRepayment: 35000 }, undefined, FIXED_NOW)
+    expect(exact.rtiPercent).toBe(35)
+    expect(exact.verdict).toBe('pass')
+
+    const under = assessRti({ monthlyIncome: 100000, monthlyRepayment: 20000 }, undefined, FIXED_NOW)
+    expect(under.verdict).toBe('pass')
+  })
+
+  it('flags borderline strictly between the pass and fail ceilings (35–45%)', () => {
+    const justOverPass = assessRti({ monthlyIncome: 100000, monthlyRepayment: 36000 }, undefined, FIXED_NOW)
+    expect(justOverPass.rtiPercent).toBe(36)
+    expect(justOverPass.verdict).toBe('borderline')
+
+    const atBorderlineCeiling = assessRti({ monthlyIncome: 100000, monthlyRepayment: 45000 }, undefined, FIXED_NOW)
+    expect(atBorderlineCeiling.rtiPercent).toBe(45)
+    expect(atBorderlineCeiling.verdict).toBe('borderline')
+  })
+
+  it('fails when repayment exceeds the borderline ceiling (>45%)', () => {
+    const result = assessRti({ monthlyIncome: 100000, monthlyRepayment: 46000 }, undefined, FIXED_NOW)
+    expect(result.rtiPercent).toBe(46)
+    expect(result.verdict).toBe('fail')
+  })
+
+  it('returns income_unverified for missing or non-positive income', () => {
+    expect(assessRti({ monthlyIncome: null, monthlyRepayment: 10000 }, undefined, FIXED_NOW).verdict).toBe('income_unverified')
+    expect(assessRti({ monthlyIncome: undefined, monthlyRepayment: 10000 }, undefined, FIXED_NOW).verdict).toBe('income_unverified')
+    expect(assessRti({ monthlyIncome: 0, monthlyRepayment: 10000 }, undefined, FIXED_NOW).verdict).toBe('income_unverified')
+    const r = assessRti({ monthlyIncome: -5, monthlyRepayment: 10000 }, undefined, FIXED_NOW)
+    expect(r.rtiPercent).toBeNull()
+    expect(r.monthlyIncome).toBeNull()
+  })
+
+  it('respects configurable thresholds', () => {
+    const strict = assessRti(
+      { monthlyIncome: 100000, monthlyRepayment: 30000 },
+      { passMaxPercent: 25, borderlineMaxPercent: 35 },
+      FIXED_NOW,
+    )
+    expect(strict.rtiPercent).toBe(30)
+    expect(strict.verdict).toBe('borderline')
+  })
+
+  it('is idempotent for identical inputs', () => {
+    const a = assessRti({ monthlyIncome: 250000, monthlyRepayment: 80000 }, undefined, FIXED_NOW)
+    const b = assessRti({ monthlyIncome: 250000, monthlyRepayment: 80000 }, undefined, FIXED_NOW)
+    expect(a).toEqual(b)
+  })
+})
+
+describe('computeRti / resolveMonthlyIncome', () => {
+  const tenantId = 'tenant-rti-test'
+
+  beforeEach(() => {
+    delete process.env.RTI_PASS_MAX_PERCENT
+    delete process.env.RTI_BORDERLINE_MAX_PERCENT
+  })
+
+  afterEach(() => {
+    delete process.env.RTI_PASS_MAX_PERCENT
+    delete process.env.RTI_BORDERLINE_MAX_PERCENT
+  })
+
+  it('reads verified monthly income from the credit score record', () => {
+    tenantCreditScoreStore.create({
+      tenantId,
+      computedScore: 700,
+      riskBand: 'low',
+      factorInputs: { monthlyNetIncome: 200000, paymentHistory: 90 },
+      factorWeights: {},
+    })
+
+    expect(resolveMonthlyIncome(tenantId)).toBe(200000)
+
+    const assessment = computeRti(tenantId, 50000)
+    expect(assessment.rtiPercent).toBe(25)
+    expect(assessment.verdict).toBe('pass')
+  })
+
+  it('flags income_unverified when the tenant has no credit record', () => {
+    const assessment = computeRti('tenant-with-no-record', 50000)
+    expect(assessment.verdict).toBe('income_unverified')
+    expect(resolveMonthlyIncome('tenant-with-no-record')).toBeNull()
+  })
+})

--- a/backend/src/services/rtiAssessmentService.ts
+++ b/backend/src/services/rtiAssessmentService.ts
@@ -1,0 +1,99 @@
+/**
+ * Rent-to-Income (RTI) Assessment Engine — issue #908.
+ *
+ * Assesses whether a tenant's monthly net income is sufficient to service the
+ * monthly repayment for a deal. The core math lives in the pure `assessRti`
+ * function; `computeRti` wires it to the tenant's verified income on record.
+ *
+ * Thresholds are configurable (see config/underwriting.ts):
+ *   pass        rtiPercent <= passMaxPercent       (default 35%)
+ *   borderline  passMax < rtiPercent <= borderline (default 35–45%)
+ *   fail        rtiPercent > borderlineMaxPercent  (default > 45%)
+ */
+
+import { getRtiThresholds, type RtiThresholds } from '../config/underwriting.js'
+import { tenantCreditScoreStore } from '../models/tenantCreditScoreStore.js'
+
+export type RtiVerdict = 'pass' | 'borderline' | 'fail' | 'income_unverified'
+
+export interface RtiAssessment {
+  monthlyIncome: number | null
+  monthlyRepayment: number
+  /** Repayment as a percentage of income, rounded to 2dp. Null when income is unverified. */
+  rtiPercent: number | null
+  verdict: RtiVerdict
+  assessedAt: string
+}
+
+/**
+ * Pure RTI computation. Deterministic: the same inputs always produce the same
+ * verdict. A non-positive or missing income yields `income_unverified` so the
+ * caller can route the application to manual review rather than auto-deciding.
+ */
+export function assessRti(
+  input: { monthlyIncome: number | null | undefined; monthlyRepayment: number },
+  thresholds: RtiThresholds = getRtiThresholds(),
+  now: Date = new Date(),
+): RtiAssessment {
+  const { monthlyRepayment } = input
+  const monthlyIncome = input.monthlyIncome ?? null
+  const assessedAt = now.toISOString()
+
+  if (monthlyIncome === null || !Number.isFinite(monthlyIncome) || monthlyIncome <= 0) {
+    return {
+      monthlyIncome: null,
+      monthlyRepayment,
+      rtiPercent: null,
+      verdict: 'income_unverified',
+      assessedAt,
+    }
+  }
+
+  const rtiPercent = Math.round((monthlyRepayment / monthlyIncome) * 100 * 100) / 100
+
+  let verdict: RtiVerdict
+  if (rtiPercent <= thresholds.passMaxPercent) {
+    verdict = 'pass'
+  } else if (rtiPercent <= thresholds.borderlineMaxPercent) {
+    verdict = 'borderline'
+  } else {
+    verdict = 'fail'
+  }
+
+  return { monthlyIncome, monthlyRepayment, rtiPercent, verdict, assessedAt }
+}
+
+/** Factor-input keys under which monthly net income may be stored on the credit record. */
+const INCOME_FACTOR_KEYS = ['monthlyNetIncome', 'monthlyIncome', 'netMonthlyIncome', 'income']
+
+/**
+ * Resolve a tenant's verified monthly net income from their credit score record.
+ * Returns null when no credit record exists or it carries no income figure —
+ * in which case the assessment is flagged `income_unverified`.
+ */
+export function resolveMonthlyIncome(tenantId: string): number | null {
+  const record = tenantCreditScoreStore.findByTenantId(tenantId)
+  if (!record) return null
+  for (const key of INCOME_FACTOR_KEYS) {
+    const value = record.factorInputs?.[key]
+    if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
+      return value
+    }
+  }
+  return null
+}
+
+/**
+ * Assess RTI for a tenant against a deal's monthly repayment amount.
+ *
+ * `monthlyRepayment` is the installment plan's `monthlyPayment` (from
+ * pricingService); it is passed in so this stays decoupled from the deal store.
+ */
+export function computeRti(
+  tenantId: string,
+  monthlyRepayment: number,
+  thresholds: RtiThresholds = getRtiThresholds(),
+): RtiAssessment {
+  const monthlyIncome = resolveMonthlyIncome(tenantId)
+  return assessRti({ monthlyIncome, monthlyRepayment }, thresholds)
+}


### PR DESCRIPTION
## Summary

Backend core logic for four assigned issues, bundled into one PR. Each piece is a focused, fully unit-tested module that closes the heart of its issue (the computation/decision logic), leaving heavier route/job/provider wiring to follow. All modules match existing conventions (in-memory stores, exported pure helpers, colocated vitest tests, env-driven config).

- **#908 — Rent-to-Income engine** (`src/config/underwriting.ts`, `src/services/rtiAssessmentService.ts`): `assessRti`/`computeRti` return `{ monthlyIncome, monthlyRepayment, rtiPercent, verdict }` where verdict is `pass | borderline | fail | income_unverified`. Thresholds (default pass ≤35%, borderline 35–45%, fail >45%) are configurable via `RTI_PASS_MAX_PERCENT` / `RTI_BORDERLINE_MAX_PERCENT`. Income is resolved from `tenantCreditScoreStore`; a missing/zero income yields `income_unverified` for manual review. Deterministic/idempotent.
- **#907 — Landlord payout computation** (`src/services/landlordPayoutService.ts`): `computePayoutScheduleFromInput` derives the full schedule — an upfront payout (default 80% of deposit, platform keeps 20%) plus one payout per instalment, each net of a configurable platform fee. Gross/fee/net are stored separately; `deriveInstalmentAmounts` splits a financed amount across a term (3/6/12-month covered). Fee shares come from config (`LANDLORD_UPFRONT_DEPOSIT_SHARE`, `LANDLORD_INSTALMENT_PLATFORM_FEE`).
- **#910 — Escrow condition model** (`src/models/escrowCondition.ts`): `EscrowCondition` / `EscrowReleasePolicy` types + pure `evaluateRelease` across `all_satisfied | any_satisfied | admin_manual` (admin override always opens the gate), with per-instalment scoping for partial release and an idempotent `InMemoryEscrowConditionStore`.
- **#909 — Audit trail querying & reporting** (`src/services/auditReportService.ts`): `matchesAuditFilters` (multi-value eventType, actor, metadata-based entity scoping, date window), cursor pagination (`encodeCursor`/`decodeCursor`/`paginateByCursor`, no offset skips on live data), and `buildActivityReport` aggregating events by type and by UTC day over a range.

## Test plan

- [x] `vitest run` on all four new suites — **41 tests pass**.
- [x] `tsc --noEmit` clean for the new files.
- [x] `eslint` clean for the new files (CI runs with `--max-warnings=0`).
- [ ] Route/job/provider wiring (e.g. `tenantApplications` RTI step, disbursement job, escrow release job, admin audit endpoints) — intentionally out of scope for this PR; these modules are the testable core they build on.

Closes #908
Closes #907
Closes #910
Closes #909