### PR TITLE
feat: dual-currency display, deal_escrow tests, tenant reputation, or…

### DIFF
--- a/backend/migrations/027_user_display_currency.sql
+++ b/backend/migrations/027_user_display_currency.sql
@@ -1,0 +1,6 @@
+-- User display currency preference (issue #914)
+ALTER TABLE users
+  ADD COLUMN IF NOT EXISTS display_currency TEXT NOT NULL DEFAULT 'NGN'
+    CHECK (display_currency IN ('NGN', 'USDC'));
+
+COMMENT ON COLUMN users.display_currency IS 'Preferred currency for displaying monetary amounts in the UI';

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -71,6 +71,9 @@ import { createComprehensiveRateLimiter } from "./middleware/comprehensiveRateLi
 import { createWhistleblowerApplicationsRouter } from "./routes/whistleblowerApplications.js"
 import { createAdminWhistleblowerApplicationsRouter } from "./routes/adminWhistleblowerApplications.js"
 import { createConversionProviderFromEnv } from "./services/conversionProviderFactory.js"
+import { ConversionRateService } from "./services/conversionRateService.js"
+import { createConversionRouter } from "./routes/conversion.js"
+import { createUserPreferencesRouter } from "./routes/userPreferences.js"
 import { createAdminAuditRouter } from "./routes/adminAudit.js"
 import { createAdminUnderwritingRouter } from "./routes/adminUnderwriting.js"
 import { PostgresRewardsDataLayer } from "./services/postgres-rewards-data-layer.js"
@@ -229,13 +232,13 @@ export function createApp() {
   const rewardsDataLayer = process.env.DATABASE_URL
     ? new PostgresRewardsDataLayer()
     : new StubRewardsDataLayer();
-  const earningsService = new EarningsServiceImpl(rewardsDataLayer, {
-    usdcToNgnRate: 1600, // Example exchange rate: 1 USDC = 1600 NGN
-  });
-
   const conversionProvider = createConversionProviderFromEnv(env);
+  const conversionRateService = new ConversionRateService(conversionProvider);
   const conversionService = new ConversionService(conversionProvider, "onramp");
   app.set("conversionService", conversionService);
+  app.set("conversionRateService", conversionRateService);
+
+  const earningsService = new EarningsServiceImpl(rewardsDataLayer, conversionRateService);
   const stakingService = new StakingService(sorobanAdapter);
 
   // Workers collection for graceful shutdown
@@ -439,6 +442,8 @@ export function createApp() {
   // Routes
   app.use("/health", createHealthRouter(sorobanAdapter))
   app.use("/api/auth", createAuthRateLimiter(env), authRouter)
+  app.use("/api/conversion", createConversionRouter(conversionRateService))
+  app.use("/api/user", createUserPreferencesRouter())
   app.use(createPublicRateLimiter(env))
 
   // API versioning — applied to all /api routes after rate limiting
@@ -460,7 +465,7 @@ export function createApp() {
   app.use('/api/admin/webhook-replay', createWebhookReplayRouter())
   app.use('/api/deals', createDealsRouter())
   app.use('/api/whistleblower', createWhistleblowerRouter(earningsService))
-  app.use('/api/staking', createStakingRouter(sorobanAdapter, walletService, linkedAddressStore, ngnWalletService, conversionService, stakingService))
+  app.use('/api/staking', createStakingRouter(sorobanAdapter, walletService, linkedAddressStore, ngnWalletService, conversionService, stakingService, conversionRateService))
   app.use('/api/webhooks', createWebhooksRouter(ngnWalletService))
   app.use('/api/deposits', createDepositsRouter(conversionService))
   app.use('/api/gas-metrics', createGasMetricsRouter())
@@ -524,6 +529,7 @@ export function createApp() {
       ngnWalletService,
       conversionService,
       stakingService,
+      conversionRateService,
     ),
   );
   app.use("/api/webhooks", createWebhooksRouter(ngnWalletService));

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -10,6 +10,7 @@ export interface AuthenticatedRequest extends Request {
     email: string
     name: string
     role: 'tenant' | 'landlord' | 'agent'
+    displayCurrency?: 'NGN' | 'USDC'
   }
 }
 
@@ -59,7 +60,13 @@ export async function authenticateToken(
       return
     }
 
-    req.user = user
+    req.user = {
+      id: user.id,
+      email: user.email,
+      name: user.name,
+      role: user.role,
+      displayCurrency: user.displayCurrency,
+    }
     logger.info('User authenticated successfully', {
       userId: user.id,
       email: user.email,

--- a/backend/src/models/authStore.ts
+++ b/backend/src/models/authStore.ts
@@ -50,11 +50,29 @@ class UserStore {
         name: email.split('@')[0] ?? email,
         role: 'tenant',
         tier: 'free',
-        planQuota: 100
+        planQuota: 100,
+        displayCurrency: 'NGN',
       }
 
       this.fallbackCache.set(email, user)
       return user
+    }
+  }
+
+  async updateDisplayCurrency(email: string, displayCurrency: 'NGN' | 'USDC'): Promise<User> {
+    try {
+      const user = await this.postgresRepo.updateDisplayCurrency(email, displayCurrency)
+      this.fallbackCache.set(email, user)
+      return user
+    } catch (error) {
+      console.warn('Postgres display currency update failed, using fallback cache:', error)
+      const user = this.fallbackCache.get(email)
+      if (user) {
+        user.displayCurrency = displayCurrency
+        this.fallbackCache.set(email, user)
+        return user
+      }
+      throw new Error('User not found for preference update')
     }
   }
 

--- a/backend/src/repositories/AuthRepository.ts
+++ b/backend/src/repositories/AuthRepository.ts
@@ -3,6 +3,7 @@ import { getPool } from '../db.js'
 import { userCache } from '../utils/cache.js'
 
 export type UserRole = 'tenant' | 'landlord' | 'agent'
+export type DisplayCurrency = 'NGN' | 'USDC'
 
 export interface User {
   id: string
@@ -13,6 +14,7 @@ export interface User {
   walletAddress?: string
   tier: 'free' | 'pro' | 'enterprise'
   planQuota: number
+  displayCurrency: DisplayCurrency
 }
 
 export interface LandlordProfile {
@@ -69,7 +71,7 @@ export class PostgresUserRepository {
 
     const pool = await this.pool()
     const { rows } = await pool.query(
-      `SELECT id, email, name, role, wallet_address, created_at, tier, plan_quota 
+      `SELECT id, email, name, role, wallet_address, created_at, tier, plan_quota, display_currency 
        FROM users WHERE email = $1`,
       [email.toLowerCase()]
     )
@@ -85,7 +87,8 @@ export class PostgresUserRepository {
       walletAddress: row.wallet_address,
       createdAt: row.created_at,
       tier: row.tier,
-      planQuota: row.plan_quota
+      planQuota: row.plan_quota,
+      displayCurrency: row.display_currency ?? 'NGN',
     }
 
     await userCache.set(cacheKey, user)
@@ -100,7 +103,7 @@ export class PostgresUserRepository {
 
     const pool = await this.pool()
     const { rows } = await pool.query(
-      `SELECT id, email, name, role, wallet_address, created_at, tier, plan_quota 
+      `SELECT id, email, name, role, wallet_address, created_at, tier, plan_quota, display_currency 
        FROM users WHERE id = $1`,
       [id]
     )
@@ -116,7 +119,8 @@ export class PostgresUserRepository {
       walletAddress: row.wallet_address,
       createdAt: row.created_at,
       tier: row.tier,
-      planQuota: row.plan_quota
+      planQuota: row.plan_quota,
+      displayCurrency: row.display_currency ?? 'NGN',
     }
 
     await userCache.set(cacheKey, user)
@@ -132,7 +136,7 @@ export class PostgresUserRepository {
     const { rows } = await pool.query(
       `INSERT INTO users (email, name, role) 
        VALUES ($1, $2, $3) 
-       RETURNING id, email, name, role, wallet_address, created_at, tier, plan_quota`,
+       RETURNING id, email, name, role, wallet_address, created_at, tier, plan_quota, display_currency`,
       [
         email.toLowerCase(),
         email.split('@')[0] ?? email,
@@ -149,14 +153,43 @@ export class PostgresUserRepository {
       walletAddress: row.wallet_address,
       createdAt: row.created_at,
       tier: row.tier,
-      planQuota: row.plan_quota
+      planQuota: row.plan_quota,
+      displayCurrency: row.display_currency ?? 'NGN',
     }
+  }
+
+  async updateDisplayCurrency(email: string, displayCurrency: DisplayCurrency): Promise<User> {
+    const pool = await this.pool()
+    const { rows } = await pool.query(
+      `UPDATE users SET display_currency = $1, updated_at = NOW()
+       WHERE email = $2
+       RETURNING id, email, name, role, wallet_address, created_at, tier, plan_quota, display_currency`,
+      [displayCurrency, email.toLowerCase()],
+    )
+    if (rows.length === 0) {
+      throw new Error('User not found')
+    }
+    const row = rows[0]
+    const user: User = {
+      id: row.id,
+      email: row.email,
+      name: row.name,
+      role: row.role,
+      walletAddress: row.wallet_address,
+      createdAt: row.created_at,
+      tier: row.tier,
+      planQuota: row.plan_quota,
+      displayCurrency: row.display_currency,
+    }
+    await userCache.delete(`email:${email.toLowerCase()}`)
+    await userCache.delete(`id:${user.id}`)
+    return user
   }
 
   async getByWalletAddress(address: string): Promise<User | null> {
     const pool = await this.pool()
     const { rows } = await pool.query(
-      `SELECT id, email, name, role, wallet_address, created_at, tier, plan_quota 
+      `SELECT id, email, name, role, wallet_address, created_at, tier, plan_quota, display_currency 
        FROM users WHERE wallet_address = $1`,
       [address.toLowerCase()]
     )
@@ -172,7 +205,8 @@ export class PostgresUserRepository {
       walletAddress: row.wallet_address,
       createdAt: row.created_at,
       tier: row.tier,
-      planQuota: row.plan_quota
+      planQuota: row.plan_quota,
+      displayCurrency: row.display_currency ?? 'NGN',
     }
   }
 
@@ -182,7 +216,7 @@ export class PostgresUserRepository {
       `UPDATE users 
        SET wallet_address = $1, updated_at = NOW() 
        WHERE email = $2 
-       RETURNING id, email, name, role, wallet_address, created_at, tier, plan_quota`,
+       RETURNING id, email, name, role, wallet_address, created_at, tier, plan_quota, display_currency`,
       [walletAddress.toLowerCase(), email.toLowerCase()]
     )
 
@@ -195,7 +229,8 @@ export class PostgresUserRepository {
       walletAddress: row.wallet_address,
       createdAt: row.created_at,
       tier: row.tier,
-      planQuota: row.plan_quota
+      planQuota: row.plan_quota,
+      displayCurrency: row.display_currency ?? 'NGN',
     }
     // Invalidate/Update
     await userCache.set(`id:${user.id}`, user)

--- a/backend/src/routes/conversion.ts
+++ b/backend/src/routes/conversion.ts
@@ -1,0 +1,21 @@
+import { Router, type Request, type Response, type NextFunction } from 'express'
+import type { ConversionRateService } from '../services/conversionRateService.js'
+
+export function createConversionRouter(rateService: ConversionRateService): Router {
+  const router = Router()
+
+  /**
+   * GET /api/conversion/rate
+   * Public endpoint — returns cached USDC/NGN rate (NGN per 1 USDC).
+   */
+  router.get('/rate', async (_req: Request, res: Response, next: NextFunction) => {
+    try {
+      const rate = await rateService.getRate()
+      res.json(rate)
+    } catch (error) {
+      next(error)
+    }
+  })
+
+  return router
+}

--- a/backend/src/routes/staking.ts
+++ b/backend/src/routes/staking.ts
@@ -15,6 +15,8 @@ import { stakeFromDepositSchema, type StakeFromDepositRequest } from '../schemas
 import { stakeFinalizeSchema, type StakeFinalizeRequest } from '../schemas/stakeFinalize.js'
 import { conversionStore } from '../models/conversionStore.js'
 import { ConversionService } from '../services/conversionService.js'
+import type { ConversionRateService } from '../services/conversionRateService.js'
+import { getDisplayAmounts } from '../services/conversionUtils.js'
 import { WalletService } from '../services/walletService.js'
 import { NgnWalletService } from '../services/ngnWalletService.js'
 import { stakingQuoteSchema, type StakingQuoteRequest } from '../schemas/stakingQuote.js'
@@ -66,6 +68,7 @@ export function createStakingRouter(
   ngnWalletService?: NgnWalletService,
   conversionService?: ConversionService,
   stakingService?: StakingService,
+  conversionRateService?: ConversionRateService,
 ) {
   const router = Router()
   const sender = new OutboxSender(adapter)
@@ -745,9 +748,26 @@ export function createStakingRouter(
           adapter.getClaimableRewards(account),
         ])
 
+        const stakedUsdc = Number(formatAmount6(stakedMicro))
+        const claimableUsdc = Number(formatAmount6(claimableMicro))
+        let dualFields: Record<string, string | number> = {}
+        if (conversionRateService) {
+          const { rate } = await conversionRateService.getRate()
+          const stakedDual = getDisplayAmounts(0, stakedUsdc, rate)
+          const claimableDual = getDisplayAmounts(0, claimableUsdc, rate)
+          dualFields = {
+            stakedAmountNgn: stakedDual.ngn,
+            stakedAmountUsdc: stakedDual.usdc,
+            claimableAmountNgn: claimableDual.ngn,
+            claimableAmountUsdc: claimableDual.usdc,
+            rateUsed: rate,
+          }
+        }
+
         const position: StakingPositionResponse = stakingPositionSchema.parse({
           staked: formatAmount6(stakedMicro),
           claimable: formatAmount6(claimableMicro),
+          ...dualFields,
         })
 
         logger.info('Staking position requested', {

--- a/backend/src/routes/userPreferences.ts
+++ b/backend/src/routes/userPreferences.ts
@@ -1,0 +1,52 @@
+import { Router, type Response, type NextFunction } from 'express'
+import { z } from 'zod'
+import { authenticateToken, type AuthenticatedRequest } from '../middleware/auth.js'
+import { validate } from '../middleware/validate.js'
+import { userStore } from '../models/authStore.js'
+import { AppError } from '../errors/AppError.js'
+import { ErrorCode } from '../errors/errorCodes.js'
+
+const updatePreferencesSchema = z.object({
+  displayCurrency: z.enum(['NGN', 'USDC']),
+})
+
+export function createUserPreferencesRouter(): Router {
+  const router = Router()
+
+  /**
+   * PATCH /api/user/preferences
+   * Update user display preferences (requires auth).
+   */
+  router.patch(
+    '/preferences',
+    authenticateToken,
+    validate(updatePreferencesSchema, 'body'),
+    async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
+      try {
+        const userId = req.user?.id
+        const email = req.user?.email
+        if (!userId || !email) {
+          throw new AppError(ErrorCode.UNAUTHORIZED, 401, 'Authentication required')
+        }
+
+        const { displayCurrency } = req.body as z.infer<typeof updatePreferencesSchema>
+        const updated = await userStore.updateDisplayCurrency(email, displayCurrency)
+
+        res.json({
+          displayCurrency: updated.displayCurrency,
+          user: {
+            id: updated.id,
+            email: updated.email,
+            name: updated.name,
+            role: updated.role,
+            displayCurrency: updated.displayCurrency,
+          },
+        })
+      } catch (error) {
+        next(error)
+      }
+    },
+  )
+
+  return router
+}

--- a/backend/src/schemas/staking.ts
+++ b/backend/src/schemas/staking.ts
@@ -94,6 +94,11 @@ export const stakingPositionSchema = z.object({
     .string()
     .regex(/^\d+(\.\d{1,6})?$/, 'Must be a positive decimal with up to 6 places')
     .describe('Amount of rewards available for claiming in USDC'),
+  stakedAmountNgn: z.string().optional(),
+  stakedAmountUsdc: z.string().optional(),
+  claimableAmountNgn: z.string().optional(),
+  claimableAmountUsdc: z.string().optional(),
+  rateUsed: z.number().optional(),
 })
 
 export type StakingPositionResponse = z.infer<typeof stakingPositionSchema>

--- a/backend/src/services/conversionProvider.ts
+++ b/backend/src/services/conversionProvider.ts
@@ -12,8 +12,15 @@ export interface ConvertNgnToUsdcOutput {
   providerRef: string
 }
 
+export interface ConversionRateQuote {
+  /** NGN per 1 USDC */
+  rate: number
+  source: string
+}
+
 export interface ConversionProvider {
   convertNgnToUsdc(input: ConvertNgnToUsdcInput): Promise<ConvertNgnToUsdcOutput>
+  getRate(): Promise<ConversionRateQuote>
 }
 
 export type ConversionProviderErrorCode = 'INVALID_RESPONSE' | 'NETWORK' | 'VALIDATION'
@@ -101,11 +108,7 @@ export class HttpConversionProvider implements ConversionProvider {
     return rate
   }
 
-  async convertNgnToUsdc(input: ConvertNgnToUsdcInput): Promise<ConvertNgnToUsdcOutput> {
-    if (input.amountNgn <= 0) {
-      throw new ConversionProviderError('amountNgn must be positive', 'VALIDATION')
-    }
-
+  async getRate(): Promise<ConversionRateQuote> {
     const controller = new AbortController()
     const timer = setTimeout(() => controller.abort(), this.opts.timeoutMs)
 
@@ -138,18 +141,26 @@ export class HttpConversionProvider implements ConversionProvider {
         throw new ConversionProviderError('Conversion rate response is not valid JSON', 'INVALID_RESPONSE')
       }
 
-      const fxRateNgnPerUsdc = this.validateBoundedRate(parseFxRateFromJson(json))
-      const amountUsdc = input.amountNgn / fxRateNgnPerUsdc
-      const providerRef =
-        parseOptionalProviderRef(json) ?? `http:${input.depositId}:${fxRateNgnPerUsdc}`
-
-      return {
-        amountUsdc: toUsdcDecimalString(amountUsdc),
-        fxRateNgnPerUsdc,
-        providerRef,
-      }
+      const rate = this.validateBoundedRate(parseFxRateFromJson(json))
+      return { rate, source: 'http' }
     } finally {
       clearTimeout(timer)
+    }
+  }
+
+  async convertNgnToUsdc(input: ConvertNgnToUsdcInput): Promise<ConvertNgnToUsdcOutput> {
+    if (input.amountNgn <= 0) {
+      throw new ConversionProviderError('amountNgn must be positive', 'VALIDATION')
+    }
+
+    const { rate: fxRateNgnPerUsdc } = await this.getRate()
+    const amountUsdc = input.amountNgn / fxRateNgnPerUsdc
+    const providerRef = `http:${input.depositId}:${fxRateNgnPerUsdc}`
+
+    return {
+      amountUsdc: toUsdcDecimalString(amountUsdc),
+      fxRateNgnPerUsdc,
+      providerRef,
     }
   }
 }
@@ -162,6 +173,17 @@ export class FallbackConversionProvider implements ConversionProvider {
     private readonly primary: ConversionProvider,
     private readonly fallback: ConversionProvider,
   ) {}
+
+  async getRate(): Promise<ConversionRateQuote> {
+    try {
+      return await this.primary.getRate()
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e)
+      logger.warn('Conversion rate primary provider failed; using fallback', { error: msg })
+      const quote = await this.fallback.getRate()
+      return { ...quote, source: `fallback:${quote.source}` }
+    }
+  }
 
   async convertNgnToUsdc(input: ConvertNgnToUsdcInput): Promise<ConvertNgnToUsdcOutput> {
     try {
@@ -189,6 +211,13 @@ export class FallbackConversionProvider implements ConversionProvider {
  */
 export class StubConversionProvider implements ConversionProvider {
   constructor(private fxRateNgnPerUsdc: number) {}
+
+  async getRate(): Promise<ConversionRateQuote> {
+    if (this.fxRateNgnPerUsdc <= 0) {
+      throw new ConversionProviderError('fxRateNgnPerUsdc must be positive', 'VALIDATION')
+    }
+    return { rate: this.fxRateNgnPerUsdc, source: 'stub' }
+  }
 
   async convertNgnToUsdc(input: ConvertNgnToUsdcInput): Promise<ConvertNgnToUsdcOutput> {
     if (input.amountNgn <= 0) {

--- a/backend/src/services/conversionProvider.ts
+++ b/backend/src/services/conversionProvider.ts
@@ -16,6 +16,8 @@ export interface ConversionRateQuote {
   /** NGN per 1 USDC */
   rate: number
   source: string
+  /** When the rate HTTP response includes providerRef, pass it through to conversions */
+  providerRef?: string
 }
 
 export interface ConversionProvider {
@@ -142,7 +144,8 @@ export class HttpConversionProvider implements ConversionProvider {
       }
 
       const rate = this.validateBoundedRate(parseFxRateFromJson(json))
-      return { rate, source: 'http' }
+      const providerRef = parseOptionalProviderRef(json)
+      return { rate, source: 'http', providerRef }
     } finally {
       clearTimeout(timer)
     }
@@ -153,13 +156,13 @@ export class HttpConversionProvider implements ConversionProvider {
       throw new ConversionProviderError('amountNgn must be positive', 'VALIDATION')
     }
 
-    const { rate: fxRateNgnPerUsdc } = await this.getRate()
-    const amountUsdc = input.amountNgn / fxRateNgnPerUsdc
-    const providerRef = `http:${input.depositId}:${fxRateNgnPerUsdc}`
+    const quote = await this.getRate()
+    const amountUsdc = input.amountNgn / quote.rate
+    const providerRef = quote.providerRef ?? `http:${input.depositId}:${quote.rate}`
 
     return {
       amountUsdc: toUsdcDecimalString(amountUsdc),
-      fxRateNgnPerUsdc,
+      fxRateNgnPerUsdc: quote.rate,
       providerRef,
     }
   }

--- a/backend/src/services/conversionRateService.ts
+++ b/backend/src/services/conversionRateService.ts
@@ -1,0 +1,44 @@
+import type { ConversionProvider } from './conversionProvider.js'
+
+export interface ConversionRateResponse {
+  rate: number
+  source: string
+  fetchedAt: string
+  expiresAt: string
+}
+
+const CACHE_TTL_MS = 5 * 60 * 1000
+
+export class ConversionRateService {
+  private cache: ConversionRateResponse | null = null
+
+  constructor(private readonly provider: ConversionProvider) {}
+
+  async getRate(): Promise<ConversionRateResponse> {
+    const now = Date.now()
+    if (this.cache) {
+      const expiresMs = new Date(this.cache.expiresAt).getTime()
+      if (now < expiresMs) {
+        return this.cache
+      }
+    }
+
+    const quote = await this.provider.getRate()
+    const fetchedAt = new Date(now)
+    const expiresAt = new Date(now + CACHE_TTL_MS)
+
+    this.cache = {
+      rate: quote.rate,
+      source: quote.source,
+      fetchedAt: fetchedAt.toISOString(),
+      expiresAt: expiresAt.toISOString(),
+    }
+
+    return this.cache
+  }
+
+  /** Clears cache (for tests). */
+  clearCache(): void {
+    this.cache = null
+  }
+}

--- a/backend/src/services/conversionUtils.test.ts
+++ b/backend/src/services/conversionUtils.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest'
+import {
+  ConversionMathError,
+  convertNgnToUsdc,
+  convertUsdcToNgn,
+  getDisplayAmounts,
+} from './conversionUtils.js'
+
+describe('convertNgnToUsdc', () => {
+  it('converts using rate', () => {
+    expect(convertNgnToUsdc(1600, 1600)).toBe(1)
+  })
+
+  it('returns 0 for zero NGN', () => {
+    expect(convertNgnToUsdc(0, 1600)).toBe(0)
+  })
+
+  it('rejects negative NGN', () => {
+    expect(() => convertNgnToUsdc(-1, 1600)).toThrow(ConversionMathError)
+  })
+
+  it('rejects zero or negative rate', () => {
+    expect(() => convertNgnToUsdc(100, 0)).toThrow(ConversionMathError)
+    expect(() => convertNgnToUsdc(100, -1)).toThrow(ConversionMathError)
+  })
+})
+
+describe('convertUsdcToNgn', () => {
+  it('converts using rate', () => {
+    expect(convertUsdcToNgn(1, 1600)).toBe(1600)
+  })
+
+  it('returns 0 for zero USDC', () => {
+    expect(convertUsdcToNgn(0, 1600)).toBe(0)
+  })
+
+  it('rejects negative USDC', () => {
+    expect(() => convertUsdcToNgn(-0.01, 1600)).toThrow(ConversionMathError)
+  })
+
+  it('rejects zero or negative rate', () => {
+    expect(() => convertUsdcToNgn(1, 0)).toThrow(ConversionMathError)
+  })
+})
+
+describe('getDisplayAmounts', () => {
+  it('derives USDC from NGN when only NGN provided', () => {
+    const d = getDisplayAmounts(1600, undefined, 1600)
+    expect(d.ngn).toBe('1600.00')
+    expect(d.usdc).toBe('1.00')
+    expect(d.rateUsed).toBe(1600)
+  })
+
+  it('uses both amounts when provided', () => {
+    const d = getDisplayAmounts(3200, 2, 1600)
+    expect(d.ngn).toBe('3200.00')
+    expect(d.usdc).toBe('2.00')
+  })
+})

--- a/backend/src/services/conversionUtils.ts
+++ b/backend/src/services/conversionUtils.ts
@@ -1,0 +1,91 @@
+/**
+ * Pure NGN ↔ USDC conversion utilities for display serialization.
+ * Rates are NGN per 1 USDC (fxRateNgnPerUsdc).
+ */
+
+export class ConversionMathError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'ConversionMathError'
+  }
+}
+
+export function convertNgnToUsdc(amountNgn: number, rate: number): number {
+  if (!Number.isFinite(amountNgn) || !Number.isFinite(rate)) {
+    throw new ConversionMathError('amountNgn and rate must be finite numbers')
+  }
+  if (amountNgn < 0) {
+    throw new ConversionMathError('amountNgn must be non-negative')
+  }
+  if (rate <= 0) {
+    throw new ConversionMathError('rate must be positive')
+  }
+  if (amountNgn === 0) return 0
+  return amountNgn / rate
+}
+
+export function convertUsdcToNgn(amountUsdc: number, rate: number): number {
+  if (!Number.isFinite(amountUsdc) || !Number.isFinite(rate)) {
+    throw new ConversionMathError('amountUsdc and rate must be finite numbers')
+  }
+  if (amountUsdc < 0) {
+    throw new ConversionMathError('amountUsdc must be non-negative')
+  }
+  if (rate <= 0) {
+    throw new ConversionMathError('rate must be positive')
+  }
+  if (amountUsdc === 0) return 0
+  return amountUsdc * rate
+}
+
+export function formatNgnDecimal(amount: number): string {
+  return amount.toFixed(2)
+}
+
+export function formatUsdcDecimal(amount: number): string {
+  return amount.toFixed(2)
+}
+
+export interface DisplayAmounts {
+  ngn: string
+  usdc: string
+  rateUsed: number
+}
+
+/**
+ * Compute dual-currency display strings from NGN and/or USDC inputs.
+ * When only one side is provided, the other is derived using `rate`.
+ */
+export function getDisplayAmounts(
+  amountNgn: number,
+  amountUsdc?: number,
+  rate?: number,
+): DisplayAmounts {
+  const fxRate = rate ?? (() => {
+    throw new ConversionMathError('rate is required when amountUsdc is omitted')
+  })()
+
+  let ngn = amountNgn
+  let usdc: number
+
+  if (amountUsdc !== undefined) {
+    usdc = amountUsdc
+    if (amountNgn === 0 && amountUsdc > 0) {
+      ngn = convertUsdcToNgn(amountUsdc, fxRate)
+    } else if (amountUsdc === 0 && amountNgn > 0) {
+      usdc = convertNgnToUsdc(amountNgn, fxRate)
+    } else if (amountNgn > 0 && amountUsdc > 0) {
+      usdc = amountUsdc
+    } else {
+      usdc = convertNgnToUsdc(amountNgn, fxRate)
+    }
+  } else {
+    usdc = convertNgnToUsdc(amountNgn, fxRate)
+  }
+
+  return {
+    ngn: formatNgnDecimal(ngn),
+    usdc: formatUsdcDecimal(usdc),
+    rateUsed: fxRate,
+  }
+}

--- a/backend/src/services/earnings.test.ts
+++ b/backend/src/services/earnings.test.ts
@@ -1,5 +1,18 @@
 import { describe, expect, it, vi } from "vitest";
 import { EarningsServiceImpl, RewardRecord, RewardsDataLayer } from "./earnings.js";
+import type { ConversionRateService } from "./conversionRateService.js";
+
+function mockRateService(rate = 1600): ConversionRateService {
+  return {
+    getRate: vi.fn().mockResolvedValue({
+      rate,
+      source: "stub",
+      fetchedAt: new Date().toISOString(),
+      expiresAt: new Date(Date.now() + 300_000).toISOString(),
+    }),
+    clearCache: vi.fn(),
+  } as unknown as ConversionRateService;
+}
 
 function createReward(partial: Partial<RewardRecord>): RewardRecord {
   return {
@@ -41,7 +54,7 @@ describe("EarningsServiceImpl", () => {
       whistleblowerExists: vi.fn().mockResolvedValue(true),
       getRewardsByWhistleblower: vi.fn().mockResolvedValue(rewards),
     };
-    const service = new EarningsServiceImpl(dataLayer, { usdcToNgnRate: 1600 });
+    const service = new EarningsServiceImpl(dataLayer, mockRateService(1600));
 
     const result = await service.getEarnings("wb-1");
 
@@ -61,7 +74,7 @@ describe("EarningsServiceImpl", () => {
       whistleblowerExists: vi.fn().mockResolvedValue(true),
       getRewardsByWhistleblower: vi.fn().mockResolvedValue([]),
     };
-    const service = new EarningsServiceImpl(dataLayer, { usdcToNgnRate: 1600 });
+    const service = new EarningsServiceImpl(dataLayer, mockRateService(1600));
 
     const result = await service.getEarnings("wb-empty");
 
@@ -81,7 +94,7 @@ describe("EarningsServiceImpl", () => {
       whistleblowerExists: vi.fn().mockResolvedValue(false),
       getRewardsByWhistleblower: vi.fn(),
     };
-    const service = new EarningsServiceImpl(dataLayer, { usdcToNgnRate: 1600 });
+    const service = new EarningsServiceImpl(dataLayer, mockRateService(1600));
 
     await expect(service.getEarnings("wb-missing")).rejects.toMatchObject({
       name: "AppError",

--- a/backend/src/services/earnings.ts
+++ b/backend/src/services/earnings.ts
@@ -1,5 +1,6 @@
 import { EarningsResponse, EarningsTotals, EarningsHistoryItem } from '../schemas/whistleblower.js'
 import { notFound, internalError } from '../errors/AppError.js'
+import type { ConversionRateService } from './conversionRateService.js'
 
 /**
  * Internal data model representing a reward record from the data layer.
@@ -34,19 +35,12 @@ export interface EarningsService {
 }
 
 /**
- * Configuration for the earnings service.
- */
-export interface EarningsServiceConfig {
-  usdcToNgnRate: number
-}
-
-/**
  * Implementation of the earnings service with aggregation and currency conversion logic.
  */
 export class EarningsServiceImpl implements EarningsService {
   constructor(
     private readonly dataLayer: RewardsDataLayer,
-    private readonly config: EarningsServiceConfig,
+    private readonly rateService: ConversionRateService,
   ) {}
 
   async getEarnings(whistleblowerId: string): Promise<EarningsResponse> {
@@ -57,14 +51,16 @@ export class EarningsServiceImpl implements EarningsService {
         throw notFound('Whistleblower')
       }
 
+      const { rate } = await this.rateService.getRate()
+
       // Query rewards from data layer
       const rewards = await this.dataLayer.getRewardsByWhistleblower(whistleblowerId)
 
       // Calculate aggregated totals
-      const totals = this.calculateTotals(rewards)
+      const totals = this.calculateTotals(rewards, rate)
 
       // Format and sort history
-      const history = this.formatHistory(rewards)
+      const history = this.formatHistory(rewards, rate)
 
       return {
         totals,
@@ -86,9 +82,9 @@ export class EarningsServiceImpl implements EarningsService {
    * Convert USDC amount (bigint in smallest unit) to NGN decimal.
    * USDC has 6 decimal places, so 1 USDC = 1_000_000 units.
    */
-  private convertUsdcToNgn(usdcAmount: bigint): number {
+  private convertUsdcToNgn(usdcAmount: bigint, rate: number): number {
     const usdcDecimal = Number(usdcAmount) / 1_000_000
-    return usdcDecimal * this.config.usdcToNgnRate
+    return usdcDecimal * rate
   }
 
   /**
@@ -102,7 +98,7 @@ export class EarningsServiceImpl implements EarningsService {
    * Calculate aggregated totals from reward records.
    * Implements requirements 2.2, 2.3, 2.4, 2.5.
    */
-  private calculateTotals(rewards: RewardRecord[]): EarningsTotals {
+  private calculateTotals(rewards: RewardRecord[], rate: number): EarningsTotals {
     // Calculate USDC totals
     const totalUsdc = rewards.reduce((sum, r) => sum + r.amountUsdc, 0n)
     const pendingUsdc = rewards
@@ -113,9 +109,9 @@ export class EarningsServiceImpl implements EarningsService {
       .reduce((sum, r) => sum + r.amountUsdc, 0n)
 
     // Convert to NGN
-    const totalNgn = this.convertUsdcToNgn(totalUsdc)
-    const pendingNgn = this.convertUsdcToNgn(pendingUsdc)
-    const paidNgn = this.convertUsdcToNgn(paidUsdc)
+    const totalNgn = this.convertUsdcToNgn(totalUsdc, rate)
+    const pendingNgn = this.convertUsdcToNgn(pendingUsdc, rate)
+    const paidNgn = this.convertUsdcToNgn(paidUsdc, rate)
 
     return {
       totalNgn,
@@ -131,7 +127,7 @@ export class EarningsServiceImpl implements EarningsService {
    * Format reward records into history items and sort by createdAt descending.
    * Implements requirements 3.1, 3.2, 3.3, 3.4, 3.5.
    */
-  private formatHistory(rewards: RewardRecord[]): EarningsHistoryItem[] {
+  private formatHistory(rewards: RewardRecord[], rate: number): EarningsHistoryItem[] {
     // Sort by createdAt descending (most recent first)
     const sortedRewards = [...rewards].sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
 
@@ -140,7 +136,7 @@ export class EarningsServiceImpl implements EarningsService {
         rewardId: reward.id,
         listingId: reward.listingId,
         dealId: reward.dealId,
-        amountNgn: this.convertUsdcToNgn(reward.amountUsdc),
+        amountNgn: this.convertUsdcToNgn(reward.amountUsdc, rate),
         amountUsdc: this.convertUsdcToDecimal(reward.amountUsdc),
         status: reward.status,
         createdAt: reward.createdAt.toISOString(),

--- a/backend/src/soroban/oracle.ts
+++ b/backend/src/soroban/oracle.ts
@@ -1,0 +1,75 @@
+import type { SorobanAdapter } from './adapter.js'
+
+export interface PriceFeed {
+  pair: string
+  price: string
+  decimals: number
+  updatedAt: number
+  sequence: number
+}
+
+export interface OracleClient {
+  updatePrice(pair: string, price: bigint, sequence: bigint): Promise<string>
+  getPrice(pair: string): Promise<PriceFeed>
+  getPriceUnsafe(pair: string): Promise<PriceFeed>
+  isStale(pair: string): Promise<boolean>
+}
+
+/**
+ * Typed wrapper for the oracle_price_feeds Soroban contract.
+ * Invokes contract methods via SorobanAdapter simulation/submit hooks.
+ */
+export class OracleSorobanClient implements OracleClient {
+  constructor(
+    private readonly adapter: SorobanAdapter,
+    private readonly contractId: string,
+  ) {}
+
+  async updatePrice(pair: string, price: bigint, sequence: bigint): Promise<string> {
+    return this.invoke('update_price', [pair, price.toString(), sequence.toString()])
+  }
+
+  async getPrice(pair: string): Promise<PriceFeed> {
+    const raw = await this.simulate('get_price', [pair])
+    return this.parseFeed(raw)
+  }
+
+  async getPriceUnsafe(pair: string): Promise<PriceFeed> {
+    const raw = await this.simulate('get_price_unsafe', [pair])
+    return this.parseFeed(raw)
+  }
+
+  async isStale(pair: string): Promise<boolean> {
+    const raw = await this.simulate('is_stale', [pair])
+    return Boolean(raw)
+  }
+
+  private async invoke(fn: string, args: string[]): Promise<string> {
+    const invoke = (this.adapter as { invokeContract?: (...a: unknown[]) => Promise<string> })
+      .invokeContract
+    if (typeof invoke !== 'function') {
+      throw new Error('SorobanAdapter does not support contract invocation')
+    }
+    return invoke(this.contractId, fn, args)
+  }
+
+  private async simulate(fn: string, args: string[]): Promise<unknown> {
+    const simulate = (this.adapter as { simulateContract?: (...a: unknown[]) => Promise<unknown> })
+      .simulateContract
+    if (typeof simulate !== 'function') {
+      throw new Error('SorobanAdapter does not support contract simulation')
+    }
+    return simulate(this.contractId, fn, args)
+  }
+
+  private parseFeed(raw: unknown): PriceFeed {
+    const rec = raw as Record<string, unknown>
+    return {
+      pair: String(rec.pair ?? ''),
+      price: String(rec.price ?? '0'),
+      decimals: Number(rec.decimals ?? 7),
+      updatedAt: Number(rec.updated_at ?? rec.updatedAt ?? 0),
+      sequence: Number(rec.sequence ?? 0),
+    }
+  }
+}

--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -1059,6 +1059,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "oracle_price_feeds"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk 22.0.10",
+ "soroban_access_control",
+]
+
+[[package]]
 name = "p256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2041,6 +2049,15 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys",
+]
+
+[[package]]
+name = "tenant_reputation"
+version = "0.1.0"
+dependencies = [
+ "soroban-pausable",
+ "soroban-sdk 22.0.10",
+ "soroban_access_control",
 ]
 
 [[package]]

--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -22,6 +22,8 @@ members = [
   "epoch_rewards",
   "slashing_module",
   "stake_delegation",
+  "oracle_price_feeds",
+  "tenant_reputation",
 ]
 
 [profile.release-with-logs]

--- a/contracts/deal_escrow/src/lib.rs
+++ b/contracts/deal_escrow/src/lib.rs
@@ -1267,6 +1267,7 @@ mod test {
     use super::{
         ContractError, DataKey, DealEscrow, DealEscrowClient, SettlementOutcome, TokenClient,
     };
+    use soroban_pausable::PausableError;
     use soroban_sdk::testutils::{Address as _, Ledger, MockAuth, MockAuthInvoke};
     use soroban_sdk::token::StellarAssetClient;
     use soroban_sdk::{Address, BytesN, Env, IntoVal, String, Symbol};
@@ -1629,6 +1630,315 @@ mod test {
             .unwrap_err()
             .unwrap();
         assert_eq!(err, ContractError::Paused);
+    }
+
+    #[test]
+    fn deposit_zero_amount_panics() {
+        let env = Env::default();
+        let (contract_id, client, _admin, _operator, _token, _token_admin, _rcpt) = setup(&env);
+        let from = Address::generate(&env);
+        let deal_id = String::from_str(&env, "deal-zero");
+        env.mock_auths(&[MockAuth {
+            address: &from,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "deposit",
+                args: (from.clone(), deal_id.clone(), 0i128).into_val(&env),
+                sub_invokes: &[],
+            },
+        }]);
+        let err = client
+            .try_deposit(&from, &deal_id, &0i128)
+            .unwrap_err()
+            .unwrap();
+        assert_eq!(err, ContractError::InvalidAmount);
+    }
+
+    #[test]
+    fn multiple_deposits_accumulate() {
+        let env = Env::default();
+        let (contract_id, client, _admin, _operator, token, token_admin, _rcpt) = setup(&env);
+        let from = Address::generate(&env);
+        let token_sac = StellarAssetClient::new(&env, &token);
+        let deal_id = String::from_str(&env, "deal-multi");
+        env.mock_auths(&[MockAuth {
+            address: &token_admin,
+            invoke: &MockAuthInvoke {
+                contract: &token,
+                fn_name: "mint",
+                args: (from.clone(), 500i128).into_val(&env),
+                sub_invokes: &[],
+            },
+        }]);
+        token_sac.mint(&from, &500i128);
+
+        for amount in [100i128, 150i128] {
+            env.mock_auths(&[MockAuth {
+                address: &from,
+                invoke: &MockAuthInvoke {
+                    contract: &contract_id,
+                    fn_name: "deposit",
+                    args: (from.clone(), deal_id.clone(), amount).into_val(&env),
+                    sub_invokes: &[MockAuthInvoke {
+                        contract: &token,
+                        fn_name: "transfer",
+                        args: (from.clone(), contract_id.clone(), amount).into_val(&env),
+                        sub_invokes: &[],
+                    }],
+                },
+            }]);
+            client
+                .try_deposit(&from, &deal_id, &amount)
+                .unwrap()
+                .unwrap();
+        }
+        assert_eq!(client.balance(&deal_id), 250i128);
+    }
+
+    #[test]
+    fn balance_unknown_deal_returns_zero() {
+        let env = Env::default();
+        let (_contract_id, client, _admin, _operator, _token, _token_admin, _rcpt) = setup(&env);
+        let deal_id = String::from_str(&env, "nonexistent-deal");
+        assert_eq!(client.balance(&deal_id), 0i128);
+    }
+
+    #[test]
+    fn pause_non_admin_panics() {
+        let env = Env::default();
+        let (contract_id, client, _admin, _operator, _token, _token_admin, _rcpt) = setup(&env);
+        let stranger = Address::generate(&env);
+        env.mock_auths(&[MockAuth {
+            address: &stranger,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "pause",
+                args: (stranger.clone(),).into_val(&env),
+                sub_invokes: &[],
+            },
+        }]);
+        let err = client.try_pause(&stranger).unwrap_err().unwrap();
+        assert_eq!(err, PausableError::NotAuthorized);
+    }
+
+    #[test]
+    fn unpause_allows_deposit_after_pause() {
+        let env = Env::default();
+        let (contract_id, client, admin, _operator, token, token_admin, _rcpt) = setup(&env);
+        let from = Address::generate(&env);
+        let token_sac = StellarAssetClient::new(&env, &token);
+        let deal_id = String::from_str(&env, "deal-unpause");
+        env.mock_auths(&[MockAuth {
+            address: &token_admin,
+            invoke: &MockAuthInvoke {
+                contract: &token,
+                fn_name: "mint",
+                args: (from.clone(), 100i128).into_val(&env),
+                sub_invokes: &[],
+            },
+        }]);
+        token_sac.mint(&from, &100i128);
+
+        env.mock_auths(&[MockAuth {
+            address: &admin,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "pause",
+                args: (admin.clone(),).into_val(&env),
+                sub_invokes: &[],
+            },
+        }]);
+        client.try_pause(&admin).unwrap().unwrap();
+        assert!(client.is_paused());
+
+        env.mock_auths(&[MockAuth {
+            address: &admin,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "unpause",
+                args: (admin.clone(),).into_val(&env),
+                sub_invokes: &[],
+            },
+        }]);
+        client.try_unpause(&admin).unwrap().unwrap();
+        assert!(!client.is_paused());
+
+        env.mock_auths(&[MockAuth {
+            address: &from,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "deposit",
+                args: (from.clone(), deal_id.clone(), 40i128).into_val(&env),
+                sub_invokes: &[MockAuthInvoke {
+                    contract: &token,
+                    fn_name: "transfer",
+                    args: (from.clone(), contract_id.clone(), 40i128).into_val(&env),
+                    sub_invokes: &[],
+                }],
+            },
+        }]);
+        client
+            .try_deposit(&from, &deal_id, &40i128)
+            .unwrap()
+            .unwrap();
+        assert_eq!(client.balance(&deal_id), 40i128);
+    }
+
+    #[test]
+    fn release_by_admin_succeeds() {
+        let env = Env::default();
+        let (contract_id, client, admin, _operator, token, token_admin, _rcpt) = setup(&env);
+        let from = Address::generate(&env);
+        let to = Address::generate(&env);
+        let platform_addr = Address::generate(&env);
+        let reporter_addr = Address::generate(&env);
+        let token_sac = StellarAssetClient::new(&env, &token);
+        let deal_id = String::from_str(&env, "deal-admin-release");
+        env.mock_auths(&[MockAuth {
+            address: &token_admin,
+            invoke: &MockAuthInvoke {
+                contract: &token,
+                fn_name: "mint",
+                args: (from.clone(), 100i128).into_val(&env),
+                sub_invokes: &[],
+            },
+        }]);
+        token_sac.mint(&from, &100i128);
+        env.mock_auths(&[MockAuth {
+            address: &from,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "deposit",
+                args: (from.clone(), deal_id.clone(), 100i128).into_val(&env),
+                sub_invokes: &[MockAuthInvoke {
+                    contract: &token,
+                    fn_name: "transfer",
+                    args: (from.clone(), contract_id.clone(), 100i128).into_val(&env),
+                    sub_invokes: &[],
+                }],
+            },
+        }]);
+        client
+            .try_deposit(&from, &deal_id, &100i128)
+            .unwrap()
+            .unwrap();
+
+        env.mock_auths(&[MockAuth {
+            address: &admin,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "release",
+                args: (
+                    admin.clone(),
+                    deal_id.clone(),
+                    to.clone(),
+                    80i128,
+                    platform_addr.clone(),
+                    15i128,
+                    reporter_addr.clone(),
+                    5i128,
+                    Symbol::new(&env, "manual_admin"),
+                    String::from_str(&env, "admin-rel"),
+                )
+                    .into_val(&env),
+                sub_invokes: &[],
+            },
+        }]);
+        let released = client
+            .try_release(
+                &admin,
+                &deal_id,
+                &to,
+                &80i128,
+                &platform_addr,
+                &15i128,
+                &reporter_addr,
+                &5i128,
+                &Symbol::new(&env, "manual_admin"),
+                &String::from_str(&env, "admin-rel"),
+            )
+            .unwrap()
+            .unwrap();
+        assert_eq!(released, 100i128);
+        assert_eq!(client.balance(&deal_id), 0i128);
+    }
+
+    #[test]
+    fn release_insufficient_balance_when_split_exceeds_escrow() {
+        let env = Env::default();
+        let (contract_id, client, _admin, operator, token, token_admin, _rcpt) = setup(&env);
+        let from = Address::generate(&env);
+        let to = Address::generate(&env);
+        let platform_addr = Address::generate(&env);
+        let reporter_addr = Address::generate(&env);
+        let token_sac = StellarAssetClient::new(&env, &token);
+        let deal_id = String::from_str(&env, "deal-insuff");
+        env.mock_auths(&[MockAuth {
+            address: &token_admin,
+            invoke: &MockAuthInvoke {
+                contract: &token,
+                fn_name: "mint",
+                args: (from.clone(), 50i128).into_val(&env),
+                sub_invokes: &[],
+            },
+        }]);
+        token_sac.mint(&from, &50i128);
+        env.mock_auths(&[MockAuth {
+            address: &from,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "deposit",
+                args: (from.clone(), deal_id.clone(), 50i128).into_val(&env),
+                sub_invokes: &[MockAuthInvoke {
+                    contract: &token,
+                    fn_name: "transfer",
+                    args: (from.clone(), contract_id.clone(), 50i128).into_val(&env),
+                    sub_invokes: &[],
+                }],
+            },
+        }]);
+        client
+            .try_deposit(&from, &deal_id, &50i128)
+            .unwrap()
+            .unwrap();
+
+        env.mock_auths(&[MockAuth {
+            address: &operator,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "release",
+                args: (
+                    operator.clone(),
+                    deal_id.clone(),
+                    to.clone(),
+                    50i128,
+                    platform_addr.clone(),
+                    10i128,
+                    reporter_addr.clone(),
+                    5i128,
+                    Symbol::new(&env, "manual_admin"),
+                    String::from_str(&env, "x"),
+                )
+                    .into_val(&env),
+                sub_invokes: &[],
+            },
+        }]);
+        let err = client
+            .try_release(
+                &operator,
+                &deal_id,
+                &to,
+                &50i128,
+                &platform_addr,
+                &10i128,
+                &reporter_addr,
+                &5i128,
+                &Symbol::new(&env, "manual_admin"),
+                &String::from_str(&env, "x"),
+            )
+            .unwrap_err()
+            .unwrap();
+        assert_eq!(err, ContractError::InvalidSplit);
     }
 
     #[test]

--- a/contracts/deal_escrow/test_snapshots/test/release_fails_if_split_sum_invalid.1.json
+++ b/contracts/deal_escrow/test_snapshots/test/release_fails_if_split_sum_invalid.1.json
@@ -230,6 +230,130 @@
         {
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "DealDepositor"
+                },
+                {
+                  "string": "deal-bad"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "DealDepositor"
+                    },
+                    {
+                      "string": "deal-bad"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "DealState"
+                },
+                {
+                  "string": "deal-bad"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "DealState"
+                    },
+                    {
+                      "string": "deal-bad"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "locked_amount"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 0
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "pending_payout"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 0
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "total_balance"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 250
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
             "key": "ledger_key_contract_instance",
             "durability": "persistent"
           }
@@ -319,6 +443,18 @@
                         },
                         "val": {
                           "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "StorageSchemaVersion"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 3
                         }
                       },
                       {

--- a/contracts/oracle_price_feeds/src/access_control.rs
+++ b/contracts/oracle_price_feeds/src/access_control.rs
@@ -1,0 +1,35 @@
+use soroban_sdk::{Address, Env};
+
+use crate::ContractError;
+
+pub fn require_admin_permission(
+    env: &Env,
+    admin: &Address,
+    caller: &Address,
+    operation: &str,
+) -> Result<(), ContractError> {
+    soroban_access_control::require_admin_permission(
+        env,
+        admin,
+        caller,
+        operation,
+        ContractError::NotAuthorized,
+    )
+}
+
+pub fn require_admin_or_operator_permission(
+    env: &Env,
+    admin: &Address,
+    operator: &Address,
+    caller: &Address,
+    operation: &str,
+) -> Result<(), ContractError> {
+    soroban_access_control::require_admin_or_operator_permission(
+        env,
+        admin,
+        Some(operator),
+        caller,
+        operation,
+        ContractError::NotAuthorized,
+    )
+}

--- a/contracts/oracle_price_feeds/src/lib.rs
+++ b/contracts/oracle_price_feeds/src/lib.rs
@@ -1,71 +1,45 @@
 #![no_std]
 
-use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Address, Env, Symbol, Vec};
+use soroban_sdk::{contract, contracterror, contractimpl, contracttype, panic_with_error, Address, Env, Symbol};
 
-// ── Constants ─────────────────────────────────────────────────────────────────
+pub mod access_control;
 
-const DEFAULT_STALENESS_SECONDS: u64 = 300;
-
-// ── Types ─────────────────────────────────────────────────────────────────────
+const DEFAULT_STALENESS_SECONDS: u64 = 600;
+const PRICE_DECIMALS: u32 = 7;
 
 #[contracttype]
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct PriceRecord {
-    /// Price scaled by 1e7 (e.g., 1.5000000 USD = 15_000_000i128)
+pub struct PriceFeed {
+    pub pair: Symbol,
     pub price: i128,
-    /// Ledger timestamp when this price was recorded by the feed
-    pub timestamp: u64,
-    /// The feed that produced this record
-    pub feed_id: Symbol,
-}
-
-#[contracttype]
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum DegradationPolicy {
-    Reject,
-    UseConservativeEstimate,
+    pub decimals: u32,
+    pub updated_at: u64,
+    pub sequence: u64,
 }
 
 #[contracttype]
 #[derive(Clone)]
 pub enum DataKey {
     Admin,
-    Paused,
-    /// Feed contract address keyed by feed_id
-    FeedAddress(Symbol),
-    /// Ordered feed chain for an asset pair
-    FeedChain(Symbol),
-    /// Staleness limit in seconds per feed
-    StalenessLimit(Symbol),
-    /// Degradation policy per asset pair
-    DegradationPolicy(Symbol),
-    /// Conservative estimate price (scaled 1e7) per asset pair
-    ConservativeEstimate(Symbol),
+    Operator,
+    StalenessThreshold,
+    Feed(Symbol),
+    Sequence(Symbol),
 }
 
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 #[repr(u32)]
 pub enum ContractError {
-    // General errors (1–99)
     AlreadyInitialized = 1,
     NotAuthorized = 2,
-    Paused = 3,
-    InvalidAmount = 4,
-    // Oracle-specific errors (100–199)
-    UnknownFeed = 100,
-    NoFeedChain = 101,
-    NoPriceFeedAvailable = 102,
-    ConservativeEstimateNotSet = 103,
-    StalePriceRecord = 104,
+    InvalidSequence = 3,
+    PriceTooStale = 4,
+    UnknownPair = 5,
 }
-
-// ── Contract ──────────────────────────────────────────────────────────────────
 
 #[contract]
 pub struct OraclePriceFeeds;
-
-// ── Internal helpers ──────────────────────────────────────────────────────────
 
 fn get_admin(env: &Env) -> Address {
     env.storage()
@@ -74,892 +48,273 @@ fn get_admin(env: &Env) -> Address {
         .expect("admin not set")
 }
 
-fn require_admin(env: &Env, caller: &Address) -> Result<(), ContractError> {
-    caller.require_auth();
-    if caller != &get_admin(env) {
-        return Err(ContractError::NotAuthorized);
-    }
-    Ok(())
-}
-
-fn require_not_paused(env: &Env) -> Result<(), ContractError> {
-    let paused = env
-        .storage()
+fn get_operator(env: &Env) -> Address {
+    env.storage()
         .instance()
-        .get::<_, bool>(&DataKey::Paused)
-        .unwrap_or(false);
-    if paused {
-        return Err(ContractError::Paused);
-    }
-    Ok(())
+        .get::<_, Address>(&DataKey::Operator)
+        .expect("operator not set")
 }
 
-/// Returns true when the price record is stale relative to `now`.
-/// Future timestamps (timestamp > now) are always treated as stale.
-pub fn is_stale(now: u64, record_timestamp: u64, staleness_limit: u64) -> bool {
-    if record_timestamp > now {
-        return true;
-    }
-    let age = now - record_timestamp;
-    age > staleness_limit
+fn get_staleness_threshold(env: &Env) -> u64 {
+    env.storage()
+        .instance()
+        .get::<_, u64>(&DataKey::StalenessThreshold)
+        .unwrap_or(DEFAULT_STALENESS_SECONDS)
 }
 
-fn emit(env: &Env, event_name: &str, data: impl soroban_sdk::IntoVal<Env, soroban_sdk::Val>) {
+fn emit_price_updated(env: &Env, feed: &PriceFeed) {
     env.events().publish(
         (
-            Symbol::new(env, "oracle_price_feeds"),
-            Symbol::new(env, event_name),
+            Symbol::new(env, "oracle"),
+            Symbol::new(env, "price_updated"),
+            feed.pair.clone(),
         ),
-        data,
+        (feed.price, feed.sequence, feed.updated_at),
     );
 }
 
-// ── Contract implementation ───────────────────────────────────────────────────
-
 #[contractimpl]
 impl OraclePriceFeeds {
-    // ── Lifecycle ─────────────────────────────────────────────────────────────
-
-    pub fn init(env: Env, admin: Address) -> Result<(), ContractError> {
+    pub fn init(
+        env: Env,
+        admin: Address,
+        operator: Address,
+        staleness_threshold: u64,
+    ) -> Result<(), ContractError> {
         if env.storage().instance().has(&DataKey::Admin) {
             return Err(ContractError::AlreadyInitialized);
         }
+        let threshold = if staleness_threshold == 0 {
+            DEFAULT_STALENESS_SECONDS
+        } else {
+            staleness_threshold
+        };
         env.storage().instance().set(&DataKey::Admin, &admin);
-        env.storage().instance().set(&DataKey::Paused, &false);
-        emit(&env, "init", admin);
+        env.storage().instance().set(&DataKey::Operator, &operator);
+        env.storage()
+            .instance()
+            .set(&DataKey::StalenessThreshold, &threshold);
         Ok(())
     }
 
-    pub fn pause(env: Env, admin: Address) -> Result<(), ContractError> {
-        require_admin(&env, &admin)?;
-        env.storage().instance().set(&DataKey::Paused, &true);
-        emit(&env, "pause", admin);
-        Ok(())
-    }
-
-    pub fn unpause(env: Env, admin: Address) -> Result<(), ContractError> {
-        require_admin(&env, &admin)?;
-        env.storage().instance().set(&DataKey::Paused, &false);
-        emit(&env, "unpause", admin);
-        Ok(())
-    }
-
-    pub fn set_admin(env: Env, admin: Address, new_admin: Address) -> Result<(), ContractError> {
-        require_admin(&env, &admin)?;
-        env.storage().instance().set(&DataKey::Admin, &new_admin);
-        emit(&env, "set_admin", new_admin);
-        Ok(())
-    }
-
-    // ── Feed Registration ─────────────────────────────────────────────────────
-
-    pub fn register_feed(
+    pub fn update_price(
         env: Env,
-        admin: Address,
-        feed_id: Symbol,
-        feed_address: Address,
-    ) -> Result<(), ContractError> {
-        require_admin(&env, &admin)?;
-        env.storage()
-            .persistent()
-            .set(&DataKey::FeedAddress(feed_id.clone()), &feed_address);
-        emit(&env, "register_feed", (feed_id, feed_address));
-        Ok(())
-    }
-
-    // ── FeedChain Configuration ───────────────────────────────────────────────
-
-    pub fn set_feed_chain(
-        env: Env,
-        admin: Address,
-        asset_pair: Symbol,
-        chain: Vec<Symbol>,
-    ) -> Result<(), ContractError> {
-        require_admin(&env, &admin)?;
-        // Validate all feed_ids are registered
-        for feed_id in chain.iter() {
-            if !env
-                .storage()
-                .persistent()
-                .has(&DataKey::FeedAddress(feed_id.clone()))
-            {
-                return Err(ContractError::UnknownFeed);
-            }
-        }
-        env.storage()
-            .persistent()
-            .set(&DataKey::FeedChain(asset_pair.clone()), &chain);
-        emit(&env, "set_feed_chain", asset_pair);
-        Ok(())
-    }
-
-    pub fn get_feed_chain(env: Env, asset_pair: Symbol) -> Result<Vec<Symbol>, ContractError> {
-        env.storage()
-            .persistent()
-            .get::<_, Vec<Symbol>>(&DataKey::FeedChain(asset_pair))
-            .ok_or(ContractError::NoFeedChain)
-    }
-
-    // ── Staleness Configuration ───────────────────────────────────────────────
-
-    pub fn set_staleness_limit(
-        env: Env,
-        admin: Address,
-        feed_id: Symbol,
-        max_age_seconds: u64,
-    ) -> Result<(), ContractError> {
-        require_admin(&env, &admin)?;
-        env.storage()
-            .persistent()
-            .set(&DataKey::StalenessLimit(feed_id.clone()), &max_age_seconds);
-        emit(&env, "set_staleness_limit", (feed_id, max_age_seconds));
-        Ok(())
-    }
-
-    pub fn get_staleness_limit(env: Env, feed_id: Symbol) -> u64 {
-        env.storage()
-            .persistent()
-            .get::<_, u64>(&DataKey::StalenessLimit(feed_id))
-            .unwrap_or(DEFAULT_STALENESS_SECONDS)
-    }
-
-    // ── Degradation Policy ────────────────────────────────────────────────────
-
-    pub fn set_degradation_policy(
-        env: Env,
-        admin: Address,
-        asset_pair: Symbol,
-        policy: DegradationPolicy,
-    ) -> Result<(), ContractError> {
-        require_admin(&env, &admin)?;
-        env.storage()
-            .persistent()
-            .set(&DataKey::DegradationPolicy(asset_pair.clone()), &policy);
-        emit(&env, "set_degradation_policy", asset_pair);
-        Ok(())
-    }
-
-    pub fn set_conservative_estimate(
-        env: Env,
-        admin: Address,
-        asset_pair: Symbol,
+        caller: Address,
+        pair: Symbol,
         price: i128,
+        sequence: u64,
     ) -> Result<(), ContractError> {
-        require_admin(&env, &admin)?;
-        if price <= 0 {
-            return Err(ContractError::InvalidAmount);
+        access_control::require_admin_or_operator_permission(
+            &env,
+            &get_admin(&env),
+            &get_operator(&env),
+            &caller,
+            "update_price",
+        )?;
+
+        let current_seq: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::Sequence(pair.clone()))
+            .unwrap_or(0);
+
+        if sequence <= current_seq {
+            return Err(ContractError::InvalidSequence);
         }
+
+        let feed = PriceFeed {
+            pair: pair.clone(),
+            price,
+            decimals: PRICE_DECIMALS,
+            updated_at: env.ledger().timestamp(),
+            sequence,
+        };
+
         env.storage()
-            .persistent()
-            .set(&DataKey::ConservativeEstimate(asset_pair.clone()), &price);
-        emit(&env, "set_conservative_estimate", (asset_pair, price));
+            .instance()
+            .set(&DataKey::Feed(pair.clone()), &feed);
+        env.storage()
+            .instance()
+            .set(&DataKey::Sequence(pair.clone()), &sequence);
+
+        emit_price_updated(&env, &feed);
         Ok(())
     }
 
-    // ── Price Query ───────────────────────────────────────────────────────────
-
-    pub fn get_price(env: Env, asset_pair: Symbol) -> Result<PriceRecord, ContractError> {
-        require_not_paused(&env)?;
-
-        let chain = env
-            .storage()
-            .persistent()
-            .get::<_, Vec<Symbol>>(&DataKey::FeedChain(asset_pair.clone()))
-            .ok_or(ContractError::NoFeedChain)?;
-
+    pub fn get_price(env: Env, pair: Symbol) -> PriceFeed {
+        let feed = Self::get_price_unsafe(env.clone(), pair);
+        let threshold = get_staleness_threshold(&env);
         let now = env.ledger().timestamp();
-        let mut skipped: Vec<Symbol> = Vec::new(&env);
-
-        for feed_id in chain.iter() {
-            let feed_addr = match env
-                .storage()
-                .persistent()
-                .get::<_, Address>(&DataKey::FeedAddress(feed_id.clone()))
-            {
-                Some(a) => a,
-                None => {
-                    skipped.push_back(feed_id.clone());
-                    continue;
-                }
-            };
-
-            let staleness_limit = env
-                .storage()
-                .persistent()
-                .get::<_, u64>(&DataKey::StalenessLimit(feed_id.clone()))
-                .unwrap_or(DEFAULT_STALENESS_SECONDS);
-
-            // Cross-contract call to the feed adapter
-            let record_opt: Option<PriceRecord> = env.invoke_contract(
-                &feed_addr,
-                &Symbol::new(&env, "get_price"),
-                soroban_sdk::vec![&env],
-            );
-
-            let record = match record_opt {
-                Some(r) => r,
-                None => {
-                    skipped.push_back(feed_id.clone());
-                    continue;
-                }
-            };
-
-            if is_stale(now, record.timestamp, staleness_limit) {
-                let age = if record.timestamp > now {
-                    u64::MAX
-                } else {
-                    now - record.timestamp
-                };
-                emit(
-                    &env,
-                    "staleness_warning",
-                    (asset_pair.clone(), feed_id.clone(), age, staleness_limit),
-                );
-                skipped.push_back(feed_id.clone());
-                continue;
-            }
-
-            // Fresh price found
-            if !skipped.is_empty() {
-                emit(
-                    &env,
-                    "fallback_used",
-                    (asset_pair.clone(), feed_id.clone(), skipped),
-                );
-            }
-            emit(
-                &env,
-                "price_updated",
-                (asset_pair, feed_id, record.price, record.timestamp),
-            );
-            return Ok(record);
+        if now.saturating_sub(feed.updated_at) > threshold {
+            panic_with_error!(&env, ContractError::PriceTooStale);
         }
+        feed
+    }
 
-        // No fresh price found — apply degradation policy
-        emit(&env, "no_price_available", asset_pair.clone());
+    pub fn get_price_unsafe(env: Env, pair: Symbol) -> PriceFeed {
+        env.storage()
+            .instance()
+            .get(&DataKey::Feed(pair))
+            .unwrap_or_else(|| panic_with_error!(&env, ContractError::UnknownPair))
+    }
 
-        let policy = env
-            .storage()
-            .persistent()
-            .get::<_, DegradationPolicy>(&DataKey::DegradationPolicy(asset_pair.clone()))
-            .unwrap_or(DegradationPolicy::Reject);
-
-        match policy {
-            DegradationPolicy::Reject => Err(ContractError::NoPriceFeedAvailable),
-            DegradationPolicy::UseConservativeEstimate => {
-                let estimate = env
-                    .storage()
-                    .persistent()
-                    .get::<_, i128>(&DataKey::ConservativeEstimate(asset_pair.clone()))
-                    .ok_or(ContractError::ConservativeEstimateNotSet)?;
-                emit(
-                    &env,
-                    "conservative_estimate_used",
-                    (asset_pair.clone(), estimate),
-                );
-                Ok(PriceRecord {
-                    price: estimate,
-                    timestamp: now,
-                    feed_id: Symbol::new(&env, "conservative"),
-                })
-            }
+    pub fn is_stale(env: Env, pair: Symbol) -> bool {
+        if !env.storage().instance().has(&DataKey::Feed(pair.clone())) {
+            return true;
         }
+        let feed: PriceFeed = env.storage().instance().get(&DataKey::Feed(pair)).unwrap();
+        let threshold = get_staleness_threshold(&env);
+        let now = env.ledger().timestamp();
+        now.saturating_sub(feed.updated_at) > threshold
+    }
+
+    pub fn set_staleness_threshold(
+        env: Env,
+        caller: Address,
+        threshold: u64,
+    ) -> Result<(), ContractError> {
+        access_control::require_admin_permission(
+            &env,
+            &get_admin(&env),
+            &caller,
+            "set_staleness_threshold",
+        )?;
+        env.storage()
+            .instance()
+            .set(&DataKey::StalenessThreshold, &threshold);
+        Ok(())
     }
 }
 
-// ── Tests ─────────────────────────────────────────────────────────────────────
-
 #[cfg(test)]
 mod test {
-    extern crate std;
+    use super::*;
+    use soroban_sdk::testutils::{Address as _, Ledger, MockAuth, MockAuthInvoke};
+    use soroban_sdk::{Address, Env, IntoVal, Symbol};
 
-    use super::{
-        ContractError, DegradationPolicy, OraclePriceFeeds, OraclePriceFeedsClient, PriceRecord,
-    };
-    use soroban_sdk::testutils::{Address as _, Events, Ledger as _};
-    use soroban_sdk::{contract, contractimpl, Address, Env, Symbol, TryFromVal, Vec};
-
-    // ── Stub feed contract ────────────────────────────────────────────────────
-    // A minimal feed adapter used in tests. Its price and availability are
-    // controlled via instance storage so tests can simulate stale / missing data.
-
-    #[contract]
-    pub struct StubFeed;
-
-    #[contractimpl]
-    impl StubFeed {
-        /// Store a price record that `get_price` will return.
-        pub fn set_price(env: Env, price: i128, timestamp: u64, feed_id: Symbol) {
-            env.storage()
-                .instance()
-                .set(&Symbol::new(&env, "price"), &price);
-            env.storage()
-                .instance()
-                .set(&Symbol::new(&env, "ts"), &timestamp);
-            env.storage()
-                .instance()
-                .set(&Symbol::new(&env, "fid"), &feed_id);
-        }
-
-        /// Mark the feed as unavailable (returns None).
-        pub fn set_unavailable(env: Env) {
-            env.storage()
-                .instance()
-                .set(&Symbol::new(&env, "unavail"), &true);
-        }
-
-        /// The oracle contract calls this via cross-contract invocation.
-        pub fn get_price(env: Env) -> Option<PriceRecord> {
-            let unavail = env
-                .storage()
-                .instance()
-                .get::<_, bool>(&Symbol::new(&env, "unavail"))
-                .unwrap_or(false);
-            if unavail {
-                return None;
-            }
-            let price = env
-                .storage()
-                .instance()
-                .get::<_, i128>(&Symbol::new(&env, "price"))?;
-            let timestamp = env
-                .storage()
-                .instance()
-                .get::<_, u64>(&Symbol::new(&env, "ts"))?;
-            let feed_id = env
-                .storage()
-                .instance()
-                .get::<_, Symbol>(&Symbol::new(&env, "fid"))?;
-            Some(PriceRecord {
-                price,
-                timestamp,
-                feed_id,
-            })
-        }
+    fn pair(env: &Env) -> Symbol {
+        Symbol::new(env, "NGN_USDC")
     }
 
-    // ── Helpers ───────────────────────────────────────────────────────────────
-
-    fn setup(env: &Env) -> (Address, OraclePriceFeedsClient<'_>) {
+    fn setup(env: &Env) -> (Address, OraclePriceFeedsClient<'_>, Address, Address, Symbol) {
         let contract_id = env.register(OraclePriceFeeds, ());
         let client = OraclePriceFeedsClient::new(env, &contract_id);
         let admin = Address::generate(env);
-        env.mock_all_auths();
-        client.try_init(&admin).unwrap().unwrap();
-        (admin, client)
-    }
-
-    fn register_stub_feed(
-        env: &Env,
-        client: &OraclePriceFeedsClient,
-        admin: &Address,
-        feed_id: &Symbol,
-        price: i128,
-        timestamp: u64,
-    ) -> Address {
-        let feed_addr = env.register(StubFeed, ());
-        let feed_client = StubFeedClient::new(env, &feed_addr);
-        feed_client.set_price(&price, &timestamp, feed_id);
+        let operator = Address::generate(env);
+        let p = pair(env);
         client
-            .try_register_feed(admin, feed_id, &feed_addr)
+            .try_init(&admin, &operator, &600u64)
             .unwrap()
             .unwrap();
-        feed_addr
-    }
-
-    fn register_unavailable_feed(
-        env: &Env,
-        client: &OraclePriceFeedsClient,
-        admin: &Address,
-        feed_id: &Symbol,
-    ) -> Address {
-        let feed_addr = env.register(StubFeed, ());
-        let feed_client = StubFeedClient::new(env, &feed_addr);
-        feed_client.set_unavailable();
-        client
-            .try_register_feed(admin, feed_id, &feed_addr)
-            .unwrap()
-            .unwrap();
-        feed_addr
-    }
-
-    // ── is_stale unit tests ───────────────────────────────────────────────────
-
-    #[test]
-    fn is_stale_fresh_at_boundary() {
-        // age == limit → fresh
-        assert!(!super::is_stale(1000, 700, 300));
+        (contract_id, client, admin, operator, p)
     }
 
     #[test]
-    fn is_stale_stale_one_over_boundary() {
-        // age == limit + 1 → stale
-        assert!(super::is_stale(1000, 699, 300));
-    }
-
-    #[test]
-    fn is_stale_future_timestamp() {
-        // timestamp in the future → always stale
-        assert!(super::is_stale(1000, 1001, 300));
-    }
-
-    #[test]
-    fn is_stale_zero_age() {
-        // age == 0 → fresh for any limit >= 0
-        assert!(!super::is_stale(1000, 1000, 0));
-    }
-
-    // ── init tests ────────────────────────────────────────────────────────────
-
-    #[test]
-    fn init_sets_admin_and_rejects_double_init() {
+    fn update_price_rejects_replay_sequence() {
         let env = Env::default();
-        let contract_id = env.register(OraclePriceFeeds, ());
-        let client = OraclePriceFeedsClient::new(&env, &contract_id);
-        let admin = Address::generate(&env);
-        env.mock_all_auths();
+        env.ledger().set_timestamp(1_000);
+        let (contract_id, client, _admin, operator, p) = setup(&env);
 
-        client.try_init(&admin).unwrap().unwrap();
-
-        let err = client.try_init(&admin).unwrap_err().unwrap();
-        assert_eq!(err, ContractError::AlreadyInitialized);
-    }
-
-    // ── pause / unpause tests ─────────────────────────────────────────────────
-
-    #[test]
-    fn pause_blocks_get_price_and_unpause_restores() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let (admin, client) = setup(&env);
-
-        let fid = Symbol::new(&env, "xlm_usd");
-        env.ledger().set_timestamp(1000);
-        register_stub_feed(&env, &client, &admin, &fid, 10_000_000, 900);
-
-        let mut chain = Vec::new(&env);
-        chain.push_back(fid.clone());
+        env.mock_auths(&[MockAuth {
+            address: &operator,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "update_price",
+                args: (operator.clone(), p.clone(), 6170i128, 1u64).into_val(&env),
+                sub_invokes: &[],
+            },
+        }]);
         client
-            .try_set_feed_chain(&admin, &Symbol::new(&env, "xlm_usd"), &chain)
+            .try_update_price(&operator, &p, &6170i128, &1u64)
             .unwrap()
             .unwrap();
 
-        client.try_pause(&admin).unwrap().unwrap();
+        env.mock_auths(&[MockAuth {
+            address: &operator,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "update_price",
+                args: (operator.clone(), p.clone(), 6200i128, 1u64).into_val(&env),
+                sub_invokes: &[],
+            },
+        }]);
         let err = client
-            .try_get_price(&Symbol::new(&env, "xlm_usd"))
+            .try_update_price(&operator, &p, &6200i128, &1u64)
             .unwrap_err()
             .unwrap();
-        assert_eq!(err, ContractError::Paused);
+        assert_eq!(err, ContractError::InvalidSequence);
+    }
 
-        client.try_unpause(&admin).unwrap().unwrap();
-        let record = client
-            .try_get_price(&Symbol::new(&env, "xlm_usd"))
+    #[test]
+    fn get_price_panics_when_stale() {
+        let env = Env::default();
+        env.ledger().set_timestamp(1_000);
+        let (contract_id, client, _admin, operator, p) = setup(&env);
+
+        env.mock_auths(&[MockAuth {
+            address: &operator,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "update_price",
+                args: (operator.clone(), p.clone(), 6170i128, 1u64).into_val(&env),
+                sub_invokes: &[],
+            },
+        }]);
+        client
+            .try_update_price(&operator, &p, &6170i128, &1u64)
             .unwrap()
             .unwrap();
-        assert_eq!(record.price, 10_000_000);
+
+        env.ledger().set_timestamp(1_000 + 601);
+        assert!(client.is_stale(&p));
+        let _ = client.try_get_price(&p).unwrap_err();
     }
 
     #[test]
-    fn non_admin_pause_returns_not_authorized() {
+    fn get_price_unsafe_returns_without_staleness_check() {
         let env = Env::default();
-        env.mock_all_auths();
-        let (_admin, client) = setup(&env);
-        let non_admin = Address::generate(&env);
+        env.ledger().set_timestamp(1_000);
+        let (contract_id, client, _admin, operator, p) = setup(&env);
 
-        let err = client.try_pause(&non_admin).unwrap_err().unwrap();
-        assert_eq!(err, ContractError::NotAuthorized);
+        env.mock_auths(&[MockAuth {
+            address: &operator,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "update_price",
+                args: (operator.clone(), p.clone(), 6170i128, 1u64).into_val(&env),
+                sub_invokes: &[],
+            },
+        }]);
+        client
+            .try_update_price(&operator, &p, &6170i128, &1u64)
+            .unwrap()
+            .unwrap();
+
+        env.ledger().set_timestamp(1_000 + 900);
+        let feed = client.get_price_unsafe(&p);
+        assert_eq!(feed.price, 6170);
+        assert_eq!(feed.decimals, 7);
     }
 
-    // ── set_admin tests ───────────────────────────────────────────────────────
-
     #[test]
-    fn set_admin_transfers_rights() {
+    fn operator_auth_required() {
         let env = Env::default();
-        env.mock_all_auths();
-        let (admin, client) = setup(&env);
-        let new_admin = Address::generate(&env);
+        let (contract_id, client, _admin, _operator, p) = setup(&env);
+        let stranger = Address::generate(&env);
 
-        client.try_set_admin(&admin, &new_admin).unwrap().unwrap();
-
-        // old admin can no longer pause
-        let err = client.try_pause(&admin).unwrap_err().unwrap();
-        assert_eq!(err, ContractError::NotAuthorized);
-
-        // new admin can pause
-        client.try_pause(&new_admin).unwrap().unwrap();
-    }
-
-    // ── register_feed / set_feed_chain tests ──────────────────────────────────
-
-    #[test]
-    fn set_feed_chain_rejects_unregistered_feed() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let (admin, client) = setup(&env);
-
-        let unknown = Symbol::new(&env, "ghost_feed");
-        let mut chain = Vec::new(&env);
-        chain.push_back(unknown);
-
+        env.mock_auths(&[MockAuth {
+            address: &stranger,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "update_price",
+                args: (stranger.clone(), p.clone(), 6170i128, 1u64).into_val(&env),
+                sub_invokes: &[],
+            },
+        }]);
         let err = client
-            .try_set_feed_chain(&admin, &Symbol::new(&env, "xlm_usd"), &chain)
-            .unwrap_err()
-            .unwrap();
-        assert_eq!(err, ContractError::UnknownFeed);
-    }
-
-    #[test]
-    fn get_feed_chain_round_trip() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let (admin, client) = setup(&env);
-
-        let fid1 = Symbol::new(&env, "feed_a");
-        let fid2 = Symbol::new(&env, "feed_b");
-        let pair = Symbol::new(&env, "xlm_usd");
-
-        let addr1 = env.register(StubFeed, ());
-        let addr2 = env.register(StubFeed, ());
-        client
-            .try_register_feed(&admin, &fid1, &addr1)
-            .unwrap()
-            .unwrap();
-        client
-            .try_register_feed(&admin, &fid2, &addr2)
-            .unwrap()
-            .unwrap();
-
-        let mut chain = Vec::new(&env);
-        chain.push_back(fid1.clone());
-        chain.push_back(fid2.clone());
-        client
-            .try_set_feed_chain(&admin, &pair, &chain)
-            .unwrap()
-            .unwrap();
-
-        let stored = client.try_get_feed_chain(&pair).unwrap().unwrap();
-        assert_eq!(stored.get(0).unwrap(), fid1);
-        assert_eq!(stored.get(1).unwrap(), fid2);
-    }
-
-    // ── get_price: primary feed fresh ────────────────────────────────────────
-
-    #[test]
-    fn get_price_returns_primary_when_fresh() {
-        let env = Env::default();
-        env.mock_all_auths();
-        env.ledger().set_timestamp(1000);
-        let (admin, client) = setup(&env);
-
-        let fid = Symbol::new(&env, "xlm_usd");
-        let pair = Symbol::new(&env, "xlm_usd");
-        register_stub_feed(&env, &client, &admin, &fid, 15_000_000, 900); // age=100, limit=300
-
-        let mut chain = Vec::new(&env);
-        chain.push_back(fid.clone());
-        client
-            .try_set_feed_chain(&admin, &pair, &chain)
-            .unwrap()
-            .unwrap();
-
-        let record = client.try_get_price(&pair).unwrap().unwrap();
-        assert_eq!(record.price, 15_000_000);
-        assert_eq!(record.feed_id, fid);
-    }
-
-    // ── get_price: primary stale, fallback fresh ──────────────────────────────
-
-    #[test]
-    fn get_price_falls_back_when_primary_stale() {
-        let env = Env::default();
-        env.mock_all_auths();
-        env.ledger().set_timestamp(1000);
-        let (admin, client) = setup(&env);
-
-        let fid_primary = Symbol::new(&env, "primary");
-        let fid_fallback = Symbol::new(&env, "fallback");
-        let pair = Symbol::new(&env, "xlm_usd");
-
-        register_stub_feed(&env, &client, &admin, &fid_primary, 5_000_000, 300);
-        register_stub_feed(&env, &client, &admin, &fid_fallback, 20_000_000, 950);
-
-        let mut chain = Vec::new(&env);
-        chain.push_back(fid_primary.clone());
-        chain.push_back(fid_fallback.clone());
-        client
-            .try_set_feed_chain(&admin, &pair, &chain)
-            .unwrap()
-            .unwrap();
-
-        let record = client.try_get_price(&pair).unwrap().unwrap();
-        assert_eq!(record.price, 20_000_000);
-        assert_eq!(record.feed_id, fid_fallback);
-    }
-
-    // ── get_price: all stale, Reject policy ──────────────────────────────────
-
-    #[test]
-    fn get_price_rejects_when_all_stale_and_reject_policy() {
-        let env = Env::default();
-        env.mock_all_auths();
-        env.ledger().set_timestamp(1000);
-        let (admin, client) = setup(&env);
-
-        let fid = Symbol::new(&env, "stale_feed");
-        let pair = Symbol::new(&env, "xlm_usd");
-        register_stub_feed(&env, &client, &admin, &fid, 5_000_000, 100);
-
-        let mut chain = Vec::new(&env);
-        chain.push_back(fid);
-        client
-            .try_set_feed_chain(&admin, &pair, &chain)
-            .unwrap()
-            .unwrap();
-
-        let err = client.try_get_price(&pair).unwrap_err().unwrap();
-        assert_eq!(err, ContractError::NoPriceFeedAvailable);
-    }
-
-    // ── get_price: all stale, UseConservativeEstimate ─────────────────────────
-
-    #[test]
-    fn get_price_returns_conservative_estimate_when_all_stale() {
-        let env = Env::default();
-        env.mock_all_auths();
-        env.ledger().set_timestamp(1000);
-        let (admin, client) = setup(&env);
-
-        let fid = Symbol::new(&env, "stale_feed");
-        let pair = Symbol::new(&env, "xlm_usd");
-        register_stub_feed(&env, &client, &admin, &fid, 5_000_000, 100);
-
-        let mut chain = Vec::new(&env);
-        chain.push_back(fid);
-        client
-            .try_set_feed_chain(&admin, &pair, &chain)
-            .unwrap()
-            .unwrap();
-        client
-            .try_set_degradation_policy(&admin, &pair, &DegradationPolicy::UseConservativeEstimate)
-            .unwrap()
-            .unwrap();
-        client
-            .try_set_conservative_estimate(&admin, &pair, &8_000_000i128)
-            .unwrap()
-            .unwrap();
-
-        let record = client.try_get_price(&pair).unwrap().unwrap();
-        assert_eq!(record.price, 8_000_000);
-        assert_eq!(record.feed_id, Symbol::new(&env, "conservative"));
-    }
-
-    // ── get_price: unavailable feed ───────────────────────────────────────────
-
-    #[test]
-    fn get_price_skips_unavailable_feed_and_uses_fallback() {
-        let env = Env::default();
-        env.mock_all_auths();
-        env.ledger().set_timestamp(1000);
-        let (admin, client) = setup(&env);
-
-        let fid_unavail = Symbol::new(&env, "unavail");
-        let fid_good = Symbol::new(&env, "good");
-        let pair = Symbol::new(&env, "xlm_usd");
-
-        register_unavailable_feed(&env, &client, &admin, &fid_unavail);
-        register_stub_feed(&env, &client, &admin, &fid_good, 12_000_000, 990);
-
-        let mut chain = Vec::new(&env);
-        chain.push_back(fid_unavail);
-        chain.push_back(fid_good.clone());
-        client
-            .try_set_feed_chain(&admin, &pair, &chain)
-            .unwrap()
-            .unwrap();
-
-        let record = client.try_get_price(&pair).unwrap().unwrap();
-        assert_eq!(record.price, 12_000_000);
-        assert_eq!(record.feed_id, fid_good);
-    }
-
-    // ── get_price: no feed chain ──────────────────────────────────────────────
-
-    #[test]
-    fn get_price_returns_no_feed_chain_when_unconfigured() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let (_admin, client) = setup(&env);
-
-        let err = client
-            .try_get_price(&Symbol::new(&env, "btc_usd"))
-            .unwrap_err()
-            .unwrap();
-        assert_eq!(err, ContractError::NoFeedChain);
-    }
-
-    // ── future timestamp treated as stale ─────────────────────────────────────
-
-    #[test]
-    fn get_price_treats_future_timestamp_as_stale() {
-        let env = Env::default();
-        env.mock_all_auths();
-        env.ledger().set_timestamp(1000);
-        let (admin, client) = setup(&env);
-
-        let fid = Symbol::new(&env, "future_feed");
-        let pair = Symbol::new(&env, "xlm_usd");
-        register_stub_feed(&env, &client, &admin, &fid, 5_000_000, 2000);
-
-        let mut chain = Vec::new(&env);
-        chain.push_back(fid);
-        client
-            .try_set_feed_chain(&admin, &pair, &chain)
-            .unwrap()
-            .unwrap();
-
-        let err = client.try_get_price(&pair).unwrap_err().unwrap();
-        assert_eq!(err, ContractError::NoPriceFeedAvailable);
-    }
-
-    // ── non-admin config rejection ────────────────────────────────────────────
-
-    #[test]
-    fn non_admin_register_feed_returns_not_authorized() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let (_admin, client) = setup(&env);
-        let non_admin = Address::generate(&env);
-        let feed_addr = env.register(StubFeed, ());
-
-        let err = client
-            .try_register_feed(&non_admin, &Symbol::new(&env, "feed_x"), &feed_addr)
+            .try_update_price(&stranger, &p, &6170i128, &1u64)
             .unwrap_err()
             .unwrap();
         assert_eq!(err, ContractError::NotAuthorized);
-    }
-
-    #[test]
-    fn non_admin_set_feed_chain_returns_not_authorized() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let (admin, client) = setup(&env);
-        let non_admin = Address::generate(&env);
-
-        let fid = Symbol::new(&env, "feed_x");
-        let addr = env.register(StubFeed, ());
-        client
-            .try_register_feed(&admin, &fid, &addr)
-            .unwrap()
-            .unwrap();
-
-        let mut chain = Vec::new(&env);
-        chain.push_back(fid);
-        let err = client
-            .try_set_feed_chain(&non_admin, &Symbol::new(&env, "xlm_usd"), &chain)
-            .unwrap_err()
-            .unwrap();
-        assert_eq!(err, ContractError::NotAuthorized);
-    }
-
-    // ── staleness limit configuration ─────────────────────────────────────────
-
-    #[test]
-    fn custom_staleness_limit_is_respected() {
-        let env = Env::default();
-        env.mock_all_auths();
-        env.ledger().set_timestamp(1000);
-        let (admin, client) = setup(&env);
-
-        let fid = Symbol::new(&env, "fast_feed");
-        let pair = Symbol::new(&env, "xlm_usd");
-        register_stub_feed(&env, &client, &admin, &fid, 5_000_000, 950);
-        client
-            .try_set_staleness_limit(&admin, &fid, &30u64)
-            .unwrap()
-            .unwrap();
-
-        let mut chain = Vec::new(&env);
-        chain.push_back(fid);
-        client
-            .try_set_feed_chain(&admin, &pair, &chain)
-            .unwrap()
-            .unwrap();
-
-        let err = client.try_get_price(&pair).unwrap_err().unwrap();
-        assert_eq!(err, ContractError::NoPriceFeedAvailable);
-    }
-
-    #[test]
-    fn default_staleness_limit_is_300() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let (_admin, client) = setup(&env);
-        let limit = client.get_staleness_limit(&Symbol::new(&env, "any_feed"));
-        assert_eq!(limit, 300u64);
-    }
-
-    // ── events: oracle_price_feeds prefix ────────────────────────────────────
-
-    #[test]
-    fn all_emitted_events_have_oracle_price_feeds_prefix() {
-        let env = Env::default();
-        env.mock_all_auths();
-        env.ledger().set_timestamp(1000);
-        let (admin, client) = setup(&env);
-
-        let fid = Symbol::new(&env, "xlm_usd");
-        let pair = Symbol::new(&env, "xlm_usd");
-        register_stub_feed(&env, &client, &admin, &fid, 10_000_000, 900);
-
-        let mut chain = Vec::new(&env);
-        chain.push_back(fid);
-        client
-            .try_set_feed_chain(&admin, &pair, &chain)
-            .unwrap()
-            .unwrap();
-        client.try_get_price(&pair).unwrap().unwrap();
-
-        let events = env.events().all();
-        let prefix = Symbol::new(&env, "oracle_price_feeds");
-        for event in events.iter() {
-            let topics = event.1;
-            let first = topics.get(0).unwrap();
-            let first_sym = Symbol::try_from_val(&env, &first).unwrap();
-            assert_eq!(first_sym, prefix, "event topic prefix mismatch");
-        }
-    }
-
-    // ── events: price_updated on success ─────────────────────────────────────
-
-    #[test]
-    fn successful_get_price_emits_price_updated_event() {
-        let env = Env::default();
-        env.mock_all_auths();
-        env.ledger().set_timestamp(1000);
-        let (admin, client) = setup(&env);
-
-        let fid = Symbol::new(&env, "xlm_usd");
-        let pair = Symbol::new(&env, "xlm_usd");
-        register_stub_feed(&env, &client, &admin, &fid, 10_000_000, 900);
-
-        let mut chain = Vec::new(&env);
-        chain.push_back(fid.clone());
-        client
-            .try_set_feed_chain(&admin, &pair, &chain)
-            .unwrap()
-            .unwrap();
-        client.try_get_price(&pair).unwrap().unwrap();
-
-        let events = env.events().all();
-        let price_updated = Symbol::new(&env, "price_updated");
-        let found = events.iter().any(|e| {
-            let topics = e.1;
-            topics
-                .get(1)
-                .and_then(|v| Symbol::try_from_val(&env, &v).ok())
-                .map(|t| t == price_updated)
-                .unwrap_or(false)
-        });
-        assert!(found, "price_updated event not emitted");
     }
 }

--- a/contracts/oracle_price_feeds/src/lib.rs
+++ b/contracts/oracle_price_feeds/src/lib.rs
@@ -1,6 +1,8 @@
 #![no_std]
 
-use soroban_sdk::{contract, contracterror, contractimpl, contracttype, panic_with_error, Address, Env, Symbol};
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contracttype, panic_with_error, Address, Env, Symbol,
+};
 
 pub mod access_control;
 
@@ -196,7 +198,15 @@ mod test {
         Symbol::new(env, "NGN_USDC")
     }
 
-    fn setup(env: &Env) -> (Address, OraclePriceFeedsClient<'_>, Address, Address, Symbol) {
+    fn setup(
+        env: &Env,
+    ) -> (
+        Address,
+        OraclePriceFeedsClient<'_>,
+        Address,
+        Address,
+        Symbol,
+    ) {
         let contract_id = env.register(OraclePriceFeeds, ());
         let client = OraclePriceFeedsClient::new(env, &contract_id);
         let admin = Address::generate(env);

--- a/contracts/tenant_reputation/Cargo.toml
+++ b/contracts/tenant_reputation/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "oracle_price_feeds"
+name = "tenant_reputation"
 version = "0.1.0"
 edition = "2021"
 
@@ -8,6 +8,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 soroban-sdk = "22.0.7"
+soroban-pausable = { version = "0.1.0", path = "../soroban_pausable" }
 soroban_access_control = { version = "0.1.0", path = "../soroban_access_control" }
 
 [dev-dependencies]

--- a/contracts/tenant_reputation/src/access_control.rs
+++ b/contracts/tenant_reputation/src/access_control.rs
@@ -1,0 +1,40 @@
+use soroban_sdk::{Address, Env};
+
+use crate::ContractError;
+
+#[inline]
+pub fn deny(env: &Env, caller: &Address, operation: &str) -> ContractError {
+    soroban_access_control::deny(env, caller, operation, ContractError::NotAuthorized)
+}
+
+pub fn require_admin_permission(
+    env: &Env,
+    admin: &Address,
+    caller: &Address,
+    operation: &str,
+) -> Result<(), ContractError> {
+    soroban_access_control::require_admin_permission(
+        env,
+        admin,
+        caller,
+        operation,
+        ContractError::NotAuthorized,
+    )
+}
+
+pub fn require_admin_or_operator_permission(
+    env: &Env,
+    admin: &Address,
+    operator: &Address,
+    caller: &Address,
+    operation: &str,
+) -> Result<(), ContractError> {
+    soroban_access_control::require_admin_or_operator_permission(
+        env,
+        admin,
+        Some(operator),
+        caller,
+        operation,
+        ContractError::NotAuthorized,
+    )
+}

--- a/contracts/tenant_reputation/src/lib.rs
+++ b/contracts/tenant_reputation/src/lib.rs
@@ -1,0 +1,418 @@
+#![no_std]
+
+use soroban_pausable::{Pausable, PausableError};
+use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Address, Env};
+
+pub mod access_control;
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ReputationRecord {
+    pub composite_score: u32,
+    pub payment_score: u32,
+    pub property_care_score: u32,
+    pub communication_score: u32,
+    pub total_ratings: u32,
+    pub last_updated: u64,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    Admin,
+    Operator,
+    Paused,
+    Reputation(Address),
+}
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum ContractError {
+    AlreadyInitialized = 1,
+    NotAuthorized = 2,
+    Paused = 3,
+    InvalidScore = 4,
+}
+
+#[contract]
+pub struct TenantReputation;
+
+fn get_admin(env: &Env) -> Address {
+    env.storage()
+        .instance()
+        .get::<_, Address>(&DataKey::Admin)
+        .expect("admin not set")
+}
+
+fn get_operator(env: &Env) -> Address {
+    env.storage()
+        .instance()
+        .get::<_, Address>(&DataKey::Operator)
+        .expect("operator not set")
+}
+
+fn require_not_paused(env: &Env) -> Result<(), ContractError> {
+    let paused = env
+        .storage()
+        .instance()
+        .get::<_, bool>(&DataKey::Paused)
+        .unwrap_or(false);
+    if paused {
+        return Err(ContractError::Paused);
+    }
+    Ok(())
+}
+
+fn validate_record(record: &ReputationRecord) -> Result<(), ContractError> {
+    if record.composite_score > 1000 {
+        return Err(ContractError::InvalidScore);
+    }
+    Ok(())
+}
+
+fn emit_updated(env: &Env, tenant: &Address, record: &ReputationRecord) {
+    env.events().publish(
+        (
+            soroban_sdk::Symbol::new(env, "tenant_reputation"),
+            soroban_sdk::Symbol::new(env, "updated"),
+            tenant.clone(),
+        ),
+        (
+            record.composite_score,
+            record.total_ratings,
+            record.last_updated,
+        ),
+    );
+}
+
+#[contractimpl]
+impl TenantReputation {
+    pub fn init(env: Env, admin: Address, operator: Address) -> Result<(), ContractError> {
+        if env.storage().instance().has(&DataKey::Admin) {
+            return Err(ContractError::AlreadyInitialized);
+        }
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage().instance().set(&DataKey::Operator, &operator);
+        env.storage().instance().set(&DataKey::Paused, &false);
+        Ok(())
+    }
+
+    pub fn update_reputation(
+        env: Env,
+        caller: Address,
+        tenant: Address,
+        record: ReputationRecord,
+    ) -> Result<(), ContractError> {
+        require_not_paused(&env)?;
+        access_control::require_admin_or_operator_permission(
+            &env,
+            &get_admin(&env),
+            &get_operator(&env),
+            &caller,
+            "update_reputation",
+        )?;
+        validate_record(&record)?;
+        let updated = ReputationRecord {
+            last_updated: env.ledger().timestamp(),
+            ..record
+        };
+        env.storage()
+            .persistent()
+            .set(&DataKey::Reputation(tenant.clone()), &updated);
+        emit_updated(&env, &tenant, &updated);
+        Ok(())
+    }
+
+    pub fn get_reputation(env: Env, tenant: Address) -> Option<ReputationRecord> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Reputation(tenant))
+    }
+
+    pub fn has_reputation(env: Env, tenant: Address) -> bool {
+        env.storage()
+            .persistent()
+            .has(&DataKey::Reputation(tenant))
+    }
+
+    pub fn revoke_reputation(env: Env, caller: Address, tenant: Address) -> Result<(), ContractError> {
+        access_control::require_admin_permission(
+            &env,
+            &get_admin(&env),
+            &caller,
+            "revoke_reputation",
+        )?;
+        if env.storage().persistent().has(&DataKey::Reputation(tenant.clone())) {
+            env.storage().persistent().remove(&DataKey::Reputation(tenant.clone()));
+            env.events().publish(
+                (
+                    soroban_sdk::Symbol::new(&env, "tenant_reputation"),
+                    soroban_sdk::Symbol::new(&env, "revoked"),
+                    tenant,
+                ),
+                (),
+            );
+        }
+        Ok(())
+    }
+
+}
+
+#[contractimpl]
+impl Pausable for TenantReputation {
+    fn pause(env: Env, admin: Address) -> Result<(), PausableError> {
+        access_control::require_admin_permission(
+            &env,
+            &get_admin(&env),
+            &admin,
+            "pause",
+        )
+        .map_err(|_| PausableError::NotAuthorized)?;
+        env.storage().instance().set(&DataKey::Paused, &true);
+        env.events().publish(
+            (
+                soroban_sdk::Symbol::new(&env, "Pausable"),
+                soroban_sdk::Symbol::new(&env, "pause"),
+            ),
+            (),
+        );
+        Ok(())
+    }
+
+    fn unpause(env: Env, admin: Address) -> Result<(), PausableError> {
+        access_control::require_admin_permission(
+            &env,
+            &get_admin(&env),
+            &admin,
+            "unpause",
+        )
+        .map_err(|_| PausableError::NotAuthorized)?;
+        env.storage().instance().set(&DataKey::Paused, &false);
+        Ok(())
+    }
+
+    fn is_paused(env: Env) -> bool {
+        env.storage()
+            .instance()
+            .get::<_, bool>(&DataKey::Paused)
+            .unwrap_or(false)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use soroban_sdk::testutils::{Address as _, Ledger, MockAuth, MockAuthInvoke};
+    use soroban_sdk::{Address, Env, IntoVal};
+
+    fn sample_record(env: &Env) -> ReputationRecord {
+        ReputationRecord {
+            composite_score: 750,
+            payment_score: 80,
+            property_care_score: 70,
+            communication_score: 90,
+            total_ratings: 5,
+            last_updated: env.ledger().timestamp(),
+        }
+    }
+
+    fn setup(env: &Env) -> (Address, TenantReputationClient<'_>, Address, Address) {
+        let contract_id = env.register(TenantReputation, ());
+        let client = TenantReputationClient::new(env, &contract_id);
+        let admin = Address::generate(env);
+        let operator = Address::generate(env);
+        client.try_init(&admin, &operator).unwrap().unwrap();
+        (contract_id, client, admin, operator)
+    }
+
+    #[test]
+    fn init_succeeds_once() {
+        let env = Env::default();
+        let (_id, client, admin, operator) = setup(&env);
+        assert!(!client.is_paused());
+        let _ = (admin, operator);
+    }
+
+    #[test]
+    fn init_cannot_be_called_twice() {
+        let env = Env::default();
+        let (_id, client, admin, operator) = setup(&env);
+        let err = client.try_init(&admin, &operator).unwrap_err().unwrap();
+        assert_eq!(err, ContractError::AlreadyInitialized);
+    }
+
+    #[test]
+    fn get_reputation_returns_none_for_unknown() {
+        let env = Env::default();
+        let (_id, client, _admin, _op) = setup(&env);
+        let tenant = Address::generate(&env);
+        assert_eq!(client.get_reputation(&tenant), None);
+        assert!(!client.has_reputation(&tenant));
+    }
+
+    #[test]
+    fn operator_can_update_and_overwrite() {
+        let env = Env::default();
+        env.ledger().set_timestamp(100);
+        let (contract_id, client, admin, operator) = setup(&env);
+        let tenant = Address::generate(&env);
+        let record = sample_record(&env);
+
+        env.mock_auths(&[MockAuth {
+            address: &operator,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "update_reputation",
+                args: (operator.clone(), tenant.clone(), record.clone()).into_val(&env),
+                sub_invokes: &[],
+            },
+        }]);
+        client
+            .try_update_reputation(&operator, &tenant, &record)
+            .unwrap()
+            .unwrap();
+
+        let stored = client.get_reputation(&tenant).unwrap();
+        assert_eq!(stored.composite_score, 750);
+        assert!(client.has_reputation(&tenant));
+
+        let mut updated = record.clone();
+        updated.composite_score = 800;
+        env.mock_auths(&[MockAuth {
+            address: &admin,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "update_reputation",
+                args: (admin.clone(), tenant.clone(), updated.clone()).into_val(&env),
+                sub_invokes: &[],
+            },
+        }]);
+        client
+            .try_update_reputation(&admin, &tenant, &updated)
+            .unwrap()
+            .unwrap();
+        assert_eq!(client.get_reputation(&tenant).unwrap().composite_score, 800);
+    }
+
+    #[test]
+    fn unauthorized_update_panics() {
+        let env = Env::default();
+        let (contract_id, client, _admin, _operator) = setup(&env);
+        let tenant = Address::generate(&env);
+        let stranger = Address::generate(&env);
+        let record = sample_record(&env);
+
+        env.mock_auths(&[MockAuth {
+            address: &stranger,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "update_reputation",
+                args: (stranger.clone(), tenant.clone(), record.clone()).into_val(&env),
+                sub_invokes: &[],
+            },
+        }]);
+        let err = client
+            .try_update_reputation(&stranger, &tenant, &record)
+            .unwrap_err()
+            .unwrap();
+        assert_eq!(err, ContractError::NotAuthorized);
+    }
+
+    #[test]
+    fn revoke_removes_record() {
+        let env = Env::default();
+        let (contract_id, client, admin, operator) = setup(&env);
+        let tenant = Address::generate(&env);
+        let record = sample_record(&env);
+
+        env.mock_auths(&[MockAuth {
+            address: &operator,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "update_reputation",
+                args: (operator.clone(), tenant.clone(), record.clone()).into_val(&env),
+                sub_invokes: &[],
+            },
+        }]);
+        client
+            .try_update_reputation(&operator, &tenant, &record)
+            .unwrap()
+            .unwrap();
+
+        env.mock_auths(&[MockAuth {
+            address: &admin,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "revoke_reputation",
+                args: (admin.clone(), tenant.clone()).into_val(&env),
+                sub_invokes: &[],
+            },
+        }]);
+        client.try_revoke_reputation(&admin, &tenant).unwrap().unwrap();
+        assert!(!client.has_reputation(&tenant));
+        assert_eq!(client.get_reputation(&tenant), None);
+    }
+
+    #[test]
+    fn pause_blocks_update() {
+        let env = Env::default();
+        let (contract_id, client, admin, operator) = setup(&env);
+        let tenant = Address::generate(&env);
+        let record = sample_record(&env);
+
+        env.mock_auths(&[MockAuth {
+            address: &admin,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "pause",
+                args: (admin.clone(),).into_val(&env),
+                sub_invokes: &[],
+            },
+        }]);
+        client.try_pause(&admin).unwrap().unwrap();
+        assert!(client.is_paused());
+
+        env.mock_auths(&[MockAuth {
+            address: &operator,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "update_reputation",
+                args: (operator.clone(), tenant.clone(), record.clone()).into_val(&env),
+                sub_invokes: &[],
+            },
+        }]);
+        let err = client
+            .try_update_reputation(&operator, &tenant, &record)
+            .unwrap_err()
+            .unwrap();
+        assert_eq!(err, ContractError::Paused);
+
+        // reads still work
+        assert_eq!(client.get_reputation(&tenant), None);
+    }
+
+    #[test]
+    fn invalid_composite_score_rejected() {
+        let env = Env::default();
+        let (contract_id, client, _admin, operator) = setup(&env);
+        let tenant = Address::generate(&env);
+        let mut record = sample_record(&env);
+        record.composite_score = 1001;
+
+        env.mock_auths(&[MockAuth {
+            address: &operator,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "update_reputation",
+                args: (operator.clone(), tenant.clone(), record.clone()).into_val(&env),
+                sub_invokes: &[],
+            },
+        }]);
+        let err = client
+            .try_update_reputation(&operator, &tenant, &record)
+            .unwrap_err()
+            .unwrap();
+        assert_eq!(err, ContractError::InvalidScore);
+    }
+}

--- a/contracts/tenant_reputation/src/lib.rs
+++ b/contracts/tenant_reputation/src/lib.rs
@@ -125,26 +125,32 @@ impl TenantReputation {
     }
 
     pub fn get_reputation(env: Env, tenant: Address) -> Option<ReputationRecord> {
-        env.storage()
-            .persistent()
-            .get(&DataKey::Reputation(tenant))
+        env.storage().persistent().get(&DataKey::Reputation(tenant))
     }
 
     pub fn has_reputation(env: Env, tenant: Address) -> bool {
-        env.storage()
-            .persistent()
-            .has(&DataKey::Reputation(tenant))
+        env.storage().persistent().has(&DataKey::Reputation(tenant))
     }
 
-    pub fn revoke_reputation(env: Env, caller: Address, tenant: Address) -> Result<(), ContractError> {
+    pub fn revoke_reputation(
+        env: Env,
+        caller: Address,
+        tenant: Address,
+    ) -> Result<(), ContractError> {
         access_control::require_admin_permission(
             &env,
             &get_admin(&env),
             &caller,
             "revoke_reputation",
         )?;
-        if env.storage().persistent().has(&DataKey::Reputation(tenant.clone())) {
-            env.storage().persistent().remove(&DataKey::Reputation(tenant.clone()));
+        if env
+            .storage()
+            .persistent()
+            .has(&DataKey::Reputation(tenant.clone()))
+        {
+            env.storage()
+                .persistent()
+                .remove(&DataKey::Reputation(tenant.clone()));
             env.events().publish(
                 (
                     soroban_sdk::Symbol::new(&env, "tenant_reputation"),
@@ -156,19 +162,13 @@ impl TenantReputation {
         }
         Ok(())
     }
-
 }
 
 #[contractimpl]
 impl Pausable for TenantReputation {
     fn pause(env: Env, admin: Address) -> Result<(), PausableError> {
-        access_control::require_admin_permission(
-            &env,
-            &get_admin(&env),
-            &admin,
-            "pause",
-        )
-        .map_err(|_| PausableError::NotAuthorized)?;
+        access_control::require_admin_permission(&env, &get_admin(&env), &admin, "pause")
+            .map_err(|_| PausableError::NotAuthorized)?;
         env.storage().instance().set(&DataKey::Paused, &true);
         env.events().publish(
             (
@@ -181,13 +181,8 @@ impl Pausable for TenantReputation {
     }
 
     fn unpause(env: Env, admin: Address) -> Result<(), PausableError> {
-        access_control::require_admin_permission(
-            &env,
-            &get_admin(&env),
-            &admin,
-            "unpause",
-        )
-        .map_err(|_| PausableError::NotAuthorized)?;
+        access_control::require_admin_permission(&env, &get_admin(&env), &admin, "unpause")
+            .map_err(|_| PausableError::NotAuthorized)?;
         env.storage().instance().set(&DataKey::Paused, &false);
         Ok(())
     }
@@ -349,7 +344,10 @@ mod test {
                 sub_invokes: &[],
             },
         }]);
-        client.try_revoke_reputation(&admin, &tenant).unwrap().unwrap();
+        client
+            .try_revoke_reputation(&admin, &tenant)
+            .unwrap()
+            .unwrap();
         assert!(!client.has_reputation(&tenant));
         assert_eq!(client.get_reputation(&tenant), None);
     }

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -9,6 +9,7 @@ import { ServiceWorkerRegister } from '@/components/service-worker-register'
 import { WebVitalsReporter } from '@/components/web-vitals-reporter'
 import { PerformanceMonitor } from '@/components/PerformanceMonitor'
 import { ThemeProvider } from '@/components/theme-provider'
+import { CurrencyProvider } from '@/contexts/CurrencyContext'
 import { Geist, Geist_Mono } from 'next/font/google'
 import './globals.css'
 
@@ -46,16 +47,18 @@ export default function RootLayout({
           enableSystem
           disableTransitionOnChange
         >
-          <ErrorBoundary>
-            <ServiceWorkerRegister />
-            <WebVitalsReporter />
-            <PerformanceMonitor />
-            <NetworkStatusBanner />
-            <Header />
-            {children}
-            <Footer />
-            <Toaster />
-          </ErrorBoundary>
+          <CurrencyProvider>
+            <ErrorBoundary>
+              <ServiceWorkerRegister />
+              <WebVitalsReporter />
+              <PerformanceMonitor />
+              <NetworkStatusBanner />
+              <Header />
+              {children}
+              <Footer />
+              <Toaster />
+            </ErrorBoundary>
+          </CurrencyProvider>
         </ThemeProvider>
       </body>
     </html>

--- a/frontend/app/whistleblower/earnings/page.tsx
+++ b/frontend/app/whistleblower/earnings/page.tsx
@@ -12,9 +12,12 @@ import {
 import { Card } from "@/components/ui/card";
 import useAuthStore from "@/store/useAuthStore";
 import { getWhistleblowerEarnings, type EarningsResponse } from "@/lib/api/whistleblowerApplications";
+import { useCurrency } from "@/contexts/CurrencyContext";
+import { formatDual } from "@/lib/currency";
 
 export default function WhistleblowerEarningsPage() {
   const { user } = useAuthStore();
+  const { formatAmount } = useCurrency();
   const [earningsData, setEarningsData] = useState<EarningsResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -119,7 +122,16 @@ export default function WhistleblowerEarningsPage() {
                         Total Earnings
                       </p>
                       <p className="text-2xl font-black md:text-3xl">
-                        ₦{totalEarnings.toLocaleString()}
+                        {formatAmount(
+                          totalEarnings,
+                          earningsData.totals.totalUsdc ?? 0,
+                        )}
+                      </p>
+                      <p className="text-xs text-muted-foreground mt-1">
+                        {formatDual(
+                          totalEarnings,
+                          earningsData.totals.totalUsdc ?? 0,
+                        )}
                       </p>
                     </div>
                   </div>
@@ -135,7 +147,10 @@ export default function WhistleblowerEarningsPage() {
                         Completed
                       </p>
                       <p className="text-2xl font-black md:text-3xl">
-                        ₦{completedEarnings.toLocaleString()}
+                        {formatAmount(
+                          completedEarnings,
+                          earningsData.totals.paidUsdc ?? 0,
+                        )}
                       </p>
                     </div>
                   </div>
@@ -151,7 +166,10 @@ export default function WhistleblowerEarningsPage() {
                         Pending
                       </p>
                       <p className="text-2xl font-black md:text-3xl">
-                        ₦{pendingEarnings.toLocaleString()}
+                        {formatAmount(
+                          pendingEarnings,
+                          earningsData.totals.pendingUsdc ?? 0,
+                        )}
                       </p>
                     </div>
                   </div>
@@ -194,7 +212,10 @@ export default function WhistleblowerEarningsPage() {
                             <div className="flex items-center justify-between gap-4 pt-3 border-t-2 border-foreground md:border-t-0 md:border-l-2 md:pl-4">
                               <div>
                                 <p className="text-lg font-black text-primary md:text-2xl">
-                                  ₦{Math.round(earning.amountNgn).toLocaleString()}
+                                  {formatAmount(earning.amountNgn, earning.amountUsdc)}
+                                </p>
+                                <p className="text-xs text-muted-foreground">
+                                  {formatDual(earning.amountNgn, earning.amountUsdc)}
                                 </p>
                                 {status === "pending" ? (
                                   <p className="text-xs text-muted-foreground">

--- a/frontend/components/currency-toggle.tsx
+++ b/frontend/components/currency-toggle.tsx
@@ -1,0 +1,34 @@
+'use client'
+
+import { useCurrency } from '@/contexts/CurrencyContext'
+import type { DisplayCurrency } from '@/lib/currency'
+
+export function CurrencyToggle() {
+  const { displayCurrency, setDisplayCurrency } = useCurrency()
+
+  const options: DisplayCurrency[] = ['NGN', 'USDC']
+
+  return (
+    <div
+      className="inline-flex items-center rounded-md border-2 border-foreground overflow-hidden text-xs font-mono font-bold"
+      role="group"
+      aria-label="Display currency"
+    >
+      {options.map((opt) => (
+        <button
+          key={opt}
+          type="button"
+          onClick={() => setDisplayCurrency(opt)}
+          className={`px-2.5 py-1 transition-colors ${
+            displayCurrency === opt
+              ? 'bg-primary text-foreground'
+              : 'bg-background text-foreground hover:bg-muted'
+          }`}
+          aria-pressed={displayCurrency === opt}
+        >
+          {opt}
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/frontend/components/header.tsx
+++ b/frontend/components/header.tsx
@@ -7,6 +7,7 @@ import { Home } from "lucide-react"
 import BackendHealthCompact from "@/components/BackendHealthCompact"
 import { MobileMenu } from "@/components/ui/mobile-menu"
 import { ThemeToggle } from "@/components/theme-toggle"
+import { CurrencyToggle } from "@/components/currency-toggle"
 
 const navLinks = [
   { href: "/properties", label: "Find a Home" },
@@ -53,6 +54,7 @@ export function Header() {
 
           {/* Desktop Actions */}
           <div className="hidden lg:flex items-center gap-3">
+            <CurrencyToggle />
             <ThemeToggle />
             <div className="hidden xl:block">
               <BackendHealthCompact />

--- a/frontend/contexts/CurrencyContext.tsx
+++ b/frontend/contexts/CurrencyContext.tsx
@@ -1,0 +1,83 @@
+'use client'
+
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react'
+import usePreferencesStore from '@/store/usePreferencesStore'
+import { formatByPreference, formatDual, type DisplayCurrency } from '@/lib/currency'
+
+interface CurrencyContextValue {
+  displayCurrency: DisplayCurrency
+  setDisplayCurrency: (currency: DisplayCurrency) => Promise<void>
+  formatAmount: (amountNgn: number | string, amountUsdc: number | string) => string
+  formatDual: (amountNgn: number | string, amountUsdc: number | string) => string
+}
+
+const CurrencyContext = createContext<CurrencyContextValue | null>(null)
+
+async function persistDisplayCurrency(currency: DisplayCurrency): Promise<void> {
+  const token = typeof window !== 'undefined' ? localStorage.getItem('auth_token') : null
+  if (!token) return
+
+  await fetch('/api/user/preferences', {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({ displayCurrency: currency }),
+  })
+}
+
+export function CurrencyProvider({ children }: { children: React.ReactNode }) {
+  const currency = usePreferencesStore((s) => s.currency) as DisplayCurrency
+  const setPreference = usePreferencesStore((s) => s.setPreference)
+  const [, setTick] = useState(0)
+
+  const setDisplayCurrency = useCallback(
+    async (next: DisplayCurrency) => {
+      setPreference('currency', next)
+      setTick((t) => t + 1)
+      try {
+        await persistDisplayCurrency(next)
+      } catch {
+        // Local preference still applies when offline
+      }
+    },
+    [setPreference],
+  )
+
+  useEffect(() => {
+    const token = typeof window !== 'undefined' ? localStorage.getItem('auth_token') : null
+    if (!token) return
+
+    fetch('/api/auth/me', { headers: { Authorization: `Bearer ${token}` } })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        const dc = data?.user?.displayCurrency as DisplayCurrency | undefined
+        if (dc === 'NGN' || dc === 'USDC') {
+          setPreference('currency', dc)
+          setTick((t) => t + 1)
+        }
+      })
+      .catch(() => undefined)
+  }, [setPreference])
+
+  const value = useMemo<CurrencyContextValue>(
+    () => ({
+      displayCurrency: currency === 'USDC' ? 'USDC' : 'NGN',
+      setDisplayCurrency,
+      formatAmount: (ngn, usdc) => formatByPreference(ngn, usdc, currency === 'USDC' ? 'USDC' : 'NGN'),
+      formatDual,
+    }),
+    [currency, setDisplayCurrency],
+  )
+
+  return <CurrencyContext.Provider value={value}>{children}</CurrencyContext.Provider>
+}
+
+export function useCurrency(): CurrencyContextValue {
+  const ctx = useContext(CurrencyContext)
+  if (!ctx) {
+    throw new Error('useCurrency must be used within CurrencyProvider')
+  }
+  return ctx
+}

--- a/frontend/lib/currency.ts
+++ b/frontend/lib/currency.ts
@@ -1,0 +1,25 @@
+export type DisplayCurrency = 'NGN' | 'USDC'
+
+export function formatNgn(amount: number | string): string {
+  const n = typeof amount === 'string' ? Number.parseFloat(amount) : amount
+  if (!Number.isFinite(n)) return '₦0.00'
+  return `₦${n.toLocaleString('en-NG', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+}
+
+export function formatUsdc(amount: number | string): string {
+  const n = typeof amount === 'string' ? Number.parseFloat(amount) : amount
+  if (!Number.isFinite(n)) return '0.00 USDC'
+  return `${n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })} USDC`
+}
+
+export function formatDual(ngn: number | string, usdc: number | string): string {
+  return `${formatNgn(ngn)} · ${formatUsdc(usdc)}`
+}
+
+export function formatByPreference(
+  amountNgn: number | string,
+  amountUsdc: number | string,
+  preference: DisplayCurrency,
+): string {
+  return preference === 'USDC' ? formatUsdc(amountUsdc) : formatNgn(amountNgn)
+}


### PR DESCRIPTION
## Summary

This PR delivers four related issues: a unified NGN/USDC display layer, expanded `deal_escrow` test coverage, a new on-chain `tenant_reputation` contract, and a spec-aligned `oracle_price_feeds` contract with backend client.

- **#914 — Dual-currency display:** Public `GET /api/conversion/rate` (5-minute cache), pure conversion utilities with tests, user `displayCurrency` preference (`PATCH /api/user/preferences`, returned on `GET /api/auth/me`), dual amounts on whistleblower earnings and staking position, frontend `CurrencyContext` + nav toggle.
- **#916 — `deal_escrow` tests:** Additional unit tests for init, deposit, balance, pause/unpause, release auth, and invalid splits (21 tests passing).
- **#917 — `tenant_reputation`:** New Soroban contract with `ReputationRecord`, operator/admin updates, admin revoke, pause behavior, and full unit test suite (8 tests passing).
- **#918 — `oracle_price_feeds`:** Rewritten oracle with sequence replay protection, staleness checks, `get_price` / `get_price_unsafe` / `is_stale`, plus `backend/src/soroban/oracle.ts` typed client (4 contract tests passing).

Closes #914
Closes #916
Closes #917
Closes #918

## Test plan

- [ ] Run migration `backend/migrations/027_user_display_currency.sql`
- [ ] `GET /api/conversion/rate` returns `{ rate, source, fetchedAt, expiresAt }` (cached within 5 min)
- [ ] `PATCH /api/user/preferences` with `{ "displayCurrency": "USDC" }` persists; `GET /api/auth/me` reflects it
- [ ] Toggle NGN/USDC in header updates whistleblower earnings amounts without page reload
- [ ] `cd contracts && cargo test -p deal_escrow -p tenant_reputation -p oracle_price_feeds`
- [ ] `cd backend && npm test -- src/services/conversionUtils.test.ts src/services/earnings.test.ts`