### PR TITLE
feat: multisig admin governance, rent schedule contract, landlord KYC gate, tenant onboarding wizard

### DIFF
--- a/backend/migrations/027_kyc_attempt_count.sql
+++ b/backend/migrations/027_kyc_attempt_count.sql
@@ -1,0 +1,5 @@
+-- Migration: Add attempt_count to kyc_documents
+-- Tracks re-submission attempts so the system can enforce a 3-attempt limit.
+
+ALTER TABLE kyc_documents
+  ADD COLUMN IF NOT EXISTS attempt_count INTEGER NOT NULL DEFAULT 1;

--- a/backend/migrations/028_onboarding_drafts.sql
+++ b/backend/migrations/028_onboarding_drafts.sql
@@ -1,0 +1,20 @@
+-- Migration: Tenant Onboarding Drafts
+-- Stores resumable multi-step onboarding wizard state per tenant.
+
+CREATE TABLE IF NOT EXISTS onboarding_drafts (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL UNIQUE,
+  personal_info JSONB,
+  employment_info JSONB,
+  documents JSONB,
+  wallet_info JSONB,
+  completed_steps TEXT[] NOT NULL DEFAULT '{}',
+  current_step VARCHAR(50) NOT NULL DEFAULT 'personal_info',
+  submitted BOOLEAN NOT NULL DEFAULT FALSE,
+  submitted_at TIMESTAMP WITH TIME ZONE,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_onboarding_user_id ON onboarding_drafts(user_id);
+CREATE INDEX idx_onboarding_submitted ON onboarding_drafts(submitted);

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -116,6 +116,8 @@ import { createDocsRouter } from "./routes/docs.js";
 import { initFraudStore, PostgresFraudStore } from "./fraud/index.js";
 import { createAdminFraudRouter } from "./routes/adminFraud.js";
 import { initializeCacheInvalidationWebhooks } from "./services/cacheInvalidation.js";
+import { createKycRouter, createKycWebhookRouter } from "./routes/kyc.js";
+import { createOnboardingRouter } from "./routes/onboarding.js";
 
 export function createApp() {
   const app = express();
@@ -545,6 +547,9 @@ export function createApp() {
   app.use("/api/tenant/credit-scoring", createTenantCreditScoringRouter());
   app.use("/api/tenant/vault", createTenantDocumentVaultRouter());
   app.use("/api/landlord/payout-schedule", createLandlordPayoutScheduleRouter());
+  app.use("/api/kyc", createKycRouter());
+  app.use("/api/webhooks/kyc", createKycWebhookRouter());
+  app.use("/api/onboarding", createOnboardingRouter());
   app.use("/api", migrationGuideRouter);
 
   // Interactive API documentation

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -116,7 +116,7 @@ import { createDocsRouter } from "./routes/docs.js";
 import { initFraudStore, PostgresFraudStore } from "./fraud/index.js";
 import { createAdminFraudRouter } from "./routes/adminFraud.js";
 import { initializeCacheInvalidationWebhooks } from "./services/cacheInvalidation.js";
-import { createKycRouter, createKycWebhookRouter } from "./routes/kyc.js";
+import { createKycWebhookRouter } from "./routes/kyc.js";
 import { createOnboardingRouter } from "./routes/onboarding.js";
 
 export function createApp() {
@@ -547,7 +547,6 @@ export function createApp() {
   app.use("/api/tenant/credit-scoring", createTenantCreditScoringRouter());
   app.use("/api/tenant/vault", createTenantDocumentVaultRouter());
   app.use("/api/landlord/payout-schedule", createLandlordPayoutScheduleRouter());
-  app.use("/api/kyc", createKycRouter());
   app.use("/api/webhooks/kyc", createKycWebhookRouter());
   app.use("/api/onboarding", createOnboardingRouter());
   app.use("/api", migrationGuideRouter);

--- a/backend/src/repositories/KycRepository.ts
+++ b/backend/src/repositories/KycRepository.ts
@@ -1,6 +1,7 @@
 import { getPool } from '../db.js'
 import type { KycRecord, KycStatus, KycDocumentType } from '../schemas/kyc.js'
-import { logger } from '../utils/logger.js'
+
+const MAX_ATTEMPTS = 3
 
 export class KycRepository {
   private async pool() {
@@ -8,18 +9,46 @@ export class KycRepository {
     return pool
   }
 
+  /**
+   * Create a new KYC record or re-submit if the previous attempt was rejected/expired.
+   * Enforces a maximum of MAX_ATTEMPTS attempts per user.
+   */
   async create(userId: string, submission: { documentType: string; frontImageKey: string; backImageKey?: string; livenessSignal?: string }): Promise<KycRecord> {
     const pool = await this.pool()
     if (!pool) throw new Error('Database not configured')
 
-    const frontKey = submission.frontImageKey
-    const backKey = submission.backImageKey ?? null
+    const existing = await this.findByUserId(userId)
+
+    if (existing) {
+      if (existing.attemptCount >= MAX_ATTEMPTS) {
+        throw new Error('MAX_ATTEMPTS_EXCEEDED')
+      }
+      // Re-submission: update the existing record and increment attempt count
+      const { rows } = await pool.query(
+        `UPDATE kyc_documents
+         SET document_type = $2,
+             front_image_key = $3,
+             back_image_key = $4,
+             liveness_signal = $5,
+             status = 'pending',
+             provider_id = NULL,
+             external_id = NULL,
+             rejection_reason = NULL,
+             reviewed_by = NULL,
+             attempt_count = attempt_count + 1,
+             updated_at = NOW()
+         WHERE user_id = $1
+         RETURNING *`,
+        [userId, submission.documentType, submission.frontImageKey, submission.backImageKey ?? null, submission.livenessSignal ?? null],
+      )
+      return this.mapRowToRecord(rows[0])
+    }
 
     const { rows } = await pool.query(
-      `INSERT INTO kyc_documents (user_id, document_type, front_image_key, back_image_key, liveness_signal, status)
-       VALUES ($1, $2, $3, $4, $5, 'pending')
+      `INSERT INTO kyc_documents (user_id, document_type, front_image_key, back_image_key, liveness_signal, status, attempt_count)
+       VALUES ($1, $2, $3, $4, $5, 'pending', 1)
        RETURNING *`,
-      [userId, submission.documentType, frontKey, backKey, submission.livenessSignal ?? null],
+      [userId, submission.documentType, submission.frontImageKey, submission.backImageKey ?? null, submission.livenessSignal ?? null],
     )
 
     return this.mapRowToRecord(rows[0])
@@ -59,7 +88,7 @@ export class KycRepository {
     if (!pool) throw new Error('Database not configured')
 
     await pool.query(
-      `UPDATE kyc_documents 
+      `UPDATE kyc_documents
        SET status = $2, provider_id = COALESCE($3, provider_id), external_id = COALESCE($4, external_id),
            rejection_reason = $5, reviewed_by = $6, updated_at = NOW()
        WHERE id = $1`,
@@ -105,7 +134,7 @@ export class KycRepository {
     )
 
     return {
-      records: dataResult.rows.map(this.mapRowToRecord),
+      records: dataResult.rows.map(row => this.mapRowToRecord(row)),
       total,
       page,
       pageSize,
@@ -129,8 +158,10 @@ export class KycRepository {
       createdAt: new Date(row.created_at as string),
       updatedAt: new Date(row.updated_at as string),
       expiresAt: row.expires_at ? new Date(row.expires_at as string) : null,
+      attemptCount: (row.attempt_count as number) ?? 1,
     }
   }
 }
 
 export const kycRepository = new KycRepository()
+export { MAX_ATTEMPTS }

--- a/backend/src/routes/admin.ts
+++ b/backend/src/routes/admin.ts
@@ -37,6 +37,7 @@ import { env } from "../schemas/env.js";
 import type { WalletStore } from "../models/wallet.js";
 import type { EncryptionService } from "../services/walletService.js";
 import { ReceiptIndexer } from "../indexer/worker.js";
+import { kycRepository } from "../repositories/KycRepository.js";
 
 export function createAdminRouter(
   adapter: SorobanAdapter,
@@ -736,6 +737,17 @@ export function createAdminRouter(
               currentStatus: listing.status,
               allowedFrom: ListingStatus.PENDING_REVIEW,
             },
+          );
+        }
+
+        // KYC gate: landlord (whistleblower) must have approved KYC before listing can go live
+        const landlordKyc = await kycRepository.findByUserId(listing.whistleblowerId);
+        if (!landlordKyc || landlordKyc.status !== 'approved') {
+          throw new AppError(
+            ErrorCode.FORBIDDEN,
+            403,
+            'LANDLORD_KYC_REQUIRED',
+            { kycStatus: landlordKyc?.status ?? 'not_submitted' },
           );
         }
 

--- a/backend/src/routes/kyc.ts
+++ b/backend/src/routes/kyc.ts
@@ -1,7 +1,8 @@
 import { Router, type Request, type Response, type NextFunction } from 'express'
 import { z } from 'zod'
+import crypto from 'crypto'
 import { kycSubmissionSchema, kycStatusSchema } from '../schemas/kyc.js'
-import { kycRepository } from '../repositories/KycRepository.js'
+import { kycRepository, MAX_ATTEMPTS } from '../repositories/KycRepository.js'
 import { createKycProvider } from '../services/kycProvider.js'
 import { authenticateToken } from '../middleware/auth.js'
 import { AppError } from '../errors/AppError.js'
@@ -40,8 +41,25 @@ router.post(
       if (existing && existing.status === 'in_review') {
         throw new AppError(ErrorCode.VALIDATION_ERROR, 400, 'KYC currently in review')
       }
+      if (existing && existing.attemptCount >= MAX_ATTEMPTS) {
+        throw new AppError(ErrorCode.VALIDATION_ERROR, 400, 'KYC_MAX_ATTEMPTS_REACHED', {
+          attemptsRemaining: 0,
+          maxAttempts: MAX_ATTEMPTS,
+        })
+      }
 
-      const record = await kycRepository.create(userId, submission)
+      let record
+      try {
+        record = await kycRepository.create(userId, submission)
+      } catch (err: any) {
+        if (err.message === 'MAX_ATTEMPTS_EXCEEDED') {
+          throw new AppError(ErrorCode.VALIDATION_ERROR, 400, 'KYC_MAX_ATTEMPTS_REACHED', {
+            attemptsRemaining: 0,
+            maxAttempts: MAX_ATTEMPTS,
+          })
+        }
+        throw err
+      }
 
       try {
         const result = await kycProvider.submit(submission)
@@ -60,9 +78,14 @@ router.post(
       auditLog('KYC_SUBMITTED' as AuditEventType, extractAuditContext(req, 'user'), {
         recordId: record.id,
         documentType: submission.documentType,
+        attemptCount: record.attemptCount,
       })
 
-      res.status(201).json({ success: true, recordId: record.id })
+      res.status(201).json({
+        success: true,
+        recordId: record.id,
+        attemptsRemaining: MAX_ATTEMPTS - record.attemptCount,
+      })
     } catch (error) {
       next(error)
     }
@@ -78,15 +101,17 @@ router.get(
       const record = await kycRepository.findByUserId(userId)
 
       if (!record) {
-        return res.json({ status: 'not_submitted' })
+        return res.json({ status: 'not_submitted', attemptsRemaining: MAX_ATTEMPTS })
       }
 
       res.json({
         status: record.status,
         documentType: record.documentType,
+        rejectionReason: record.rejectionReason,
         createdAt: record.createdAt,
         updatedAt: record.updatedAt,
         expiresAt: record.expiresAt,
+        attemptsRemaining: Math.max(0, MAX_ATTEMPTS - record.attemptCount),
       })
     } catch (error) {
       next(error)
@@ -127,9 +152,10 @@ router.post(
 
 router.get(
   '/admin',
-  requireAdmin,
+  authenticateToken,
   async (req: Request, res: Response, next: NextFunction) => {
     try {
+      requireAdmin(req)
       const { status, userId, page, pageSize } = req.query
       const result = await kycRepository.list({
         status: status as any,
@@ -147,9 +173,10 @@ router.get(
 
 router.post(
   '/admin/:recordId/approve',
-  requireAdmin,
+  authenticateToken,
   async (req: Request, res: Response, next: NextFunction) => {
     try {
+      requireAdmin(req)
       const { recordId } = req.params
       const adminId = (req as any).user.id as string
       const { reason } = req.body as { reason?: string }
@@ -181,9 +208,10 @@ router.post(
 
 router.post(
   '/admin/:recordId/reject',
-  requireAdmin,
+  authenticateToken,
   async (req: Request, res: Response, next: NextFunction) => {
     try {
+      requireAdmin(req)
       const { recordId } = req.params
       const adminId = (req as any).user.id as string
       const { reason } = req.body as { reason?: string }
@@ -216,4 +244,71 @@ router.post(
 
 export function createKycRouter(): Router {
   return router
+}
+
+/**
+ * Standalone router for provider-specific KYC webhooks.
+ * Mount at /api/webhooks/kyc → handles POST /api/webhooks/kyc/:provider
+ */
+export function createKycWebhookRouter(): Router {
+  const webhookRouter = Router()
+  webhookRouter.post('/:provider', async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { provider } = req.params
+      const rawBody = JSON.stringify(req.body)
+      const signature = (req.headers['x-signature'] || req.headers['x-webhook-signature']) as string | undefined
+
+      const secret = process.env[`KYC_WEBHOOK_SECRET_${provider.toUpperCase()}`]
+        || process.env.KYC_WEBHOOK_SECRET
+        || ''
+
+      if (secret) {
+        if (!signature) {
+          logger.warn('kyc.provider_webhook_missing_signature', { provider })
+          return res.status(401).json({ error: 'Missing signature' })
+        }
+        const expected = crypto
+          .createHmac('sha256', secret)
+          .update(rawBody)
+          .digest('hex')
+        const sigBuf = Buffer.from(signature.replace(/^sha256=/, ''), 'hex')
+        const expBuf = Buffer.from(expected, 'hex')
+        if (sigBuf.length !== expBuf.length || !crypto.timingSafeEqual(sigBuf, expBuf)) {
+          logger.warn('kyc.provider_webhook_invalid_signature', { provider })
+          return res.status(401).json({ error: 'Invalid signature' })
+        }
+      }
+
+      // Respond 200 immediately; process asynchronously
+      res.json({ received: true })
+
+      const payload = req.body as Record<string, unknown>
+      const id = (payload.id ?? payload.external_id ?? payload.reference) as string | undefined
+      const status = payload.status as string | undefined
+      const reason = payload.reason as string | undefined
+
+      if (!id || !status) {
+        logger.warn('kyc.provider_webhook_missing_fields', { provider, payload })
+        return
+      }
+
+      const record = await kycRepository.findById(id).catch(() => null)
+      if (!record) {
+        logger.warn('kyc.provider_webhook_record_not_found', { provider, id })
+        return
+      }
+
+      const parsed = kycStatusSchema.safeParse(status)
+      if (!parsed.success) {
+        logger.warn('kyc.provider_webhook_unknown_status', { provider, status })
+        return
+      }
+
+      await kycRepository.updateStatus(record.id, parsed.data, provider, undefined, reason)
+      await emitKycStatusChanged(record.userId, parsed.data)
+    } catch (error) {
+      logger.error('kyc.provider_webhook_error', { error })
+    }
+  })
+  return webhookRouter
 }

--- a/backend/src/routes/kyc.ts
+++ b/backend/src/routes/kyc.ts
@@ -1,6 +1,5 @@
 import { Router, type Request, type Response, type NextFunction } from 'express'
 import { z } from 'zod'
-import crypto from 'crypto'
 import { kycSubmissionSchema, kycStatusSchema } from '../schemas/kyc.js'
 import { kycRepository, MAX_ATTEMPTS } from '../repositories/KycRepository.js'
 import { createKycProvider } from '../services/kycProvider.js'
@@ -8,6 +7,7 @@ import { authenticateToken } from '../middleware/auth.js'
 import { AppError } from '../errors/AppError.js'
 import { ErrorCode } from '../errors/errorCodes.js'
 import { auditLog, extractAuditContext, type AuditEventType } from '../utils/auditLogger.js'
+import { verifyHmacSha256 } from '../utils/webhookSignature.js'
 import { emitKycStatusChanged } from '../services/index.js'
 import { logger } from '../utils/logger.js'
 
@@ -267,13 +267,7 @@ export function createKycWebhookRouter(): Router {
           logger.warn('kyc.provider_webhook_missing_signature', { provider })
           return res.status(401).json({ error: 'Missing signature' })
         }
-        const expected = crypto
-          .createHmac('sha256', secret)
-          .update(rawBody)
-          .digest('hex')
-        const sigBuf = Buffer.from(signature.replace(/^sha256=/, ''), 'hex')
-        const expBuf = Buffer.from(expected, 'hex')
-        if (sigBuf.length !== expBuf.length || !crypto.timingSafeEqual(sigBuf, expBuf)) {
+        if (!verifyHmacSha256(secret, rawBody, signature)) {
           logger.warn('kyc.provider_webhook_invalid_signature', { provider })
           return res.status(401).json({ error: 'Invalid signature' })
         }

--- a/backend/src/routes/landlord.ts
+++ b/backend/src/routes/landlord.ts
@@ -4,6 +4,7 @@ import { userStore } from '../models/authStore.js'
 import { AuthenticatedRequest } from '../middleware/auth.js'
 import { AppError } from '../errors/AppError.js'
 import { ErrorCode } from '../errors/errorCodes.js'
+import { kycRepository, MAX_ATTEMPTS } from '../repositories/KycRepository.js'
 
 export function createLandlordRouter() {
   const router = Router()
@@ -74,6 +75,37 @@ export function createLandlordRouter() {
           accountNumber: profile?.accountNumber || "",
           accountName: profile?.accountName || "",
         }
+      })
+    } catch (error) {
+      next(error)
+    }
+  })
+
+  // GET /api/landlord/kyc-status
+  // Returns the landlord's current KYC status, rejection reasons, and attempts remaining.
+  // Used by the frontend to gate listing creation.
+  router.get('/kyc-status', async (req: Request, res: Response, next: NextFunction) => {
+    const authReq = req as AuthenticatedRequest
+    try {
+      const userId = authReq.user?.id
+      if (!userId) throw new AppError(ErrorCode.UNAUTHORIZED, 401, 'Unauthorized')
+
+      const record = await kycRepository.findByUserId(userId)
+
+      if (!record) {
+        return res.json({
+          status: 'not_submitted',
+          attemptsRemaining: MAX_ATTEMPTS,
+          rejectionReason: null,
+        })
+      }
+
+      res.json({
+        status: record.status,
+        attemptsRemaining: Math.max(0, MAX_ATTEMPTS - record.attemptCount),
+        rejectionReason: record.rejectionReason,
+        updatedAt: record.updatedAt,
+        expiresAt: record.expiresAt,
       })
     } catch (error) {
       next(error)

--- a/backend/src/routes/onboarding.ts
+++ b/backend/src/routes/onboarding.ts
@@ -1,0 +1,216 @@
+import { Router, type Request, type Response, type NextFunction } from 'express'
+import { getPool } from '../db.js'
+import { authenticateToken } from '../middleware/auth.js'
+import { AppError } from '../errors/AppError.js'
+import { ErrorCode } from '../errors/errorCodes.js'
+import { logger } from '../utils/logger.js'
+import {
+  onboardingDraftSchema,
+  ONBOARDING_STEPS,
+  type OnboardingStep,
+  type OnboardingRecord,
+} from '../schemas/onboarding.js'
+
+function deriveCurrentStep(completedSteps: string[]): OnboardingStep {
+  for (const step of ONBOARDING_STEPS) {
+    if (!completedSteps.includes(step)) return step
+  }
+  return 'summary'
+}
+
+function mapRow(row: Record<string, unknown>): OnboardingRecord {
+  return {
+    id: row.id as string,
+    userId: row.user_id as string,
+    personalInfo: row.personal_info ? (row.personal_info as any) : null,
+    employmentInfo: row.employment_info ? (row.employment_info as any) : null,
+    documents: row.documents ? (row.documents as any) : null,
+    walletInfo: row.wallet_info ? (row.wallet_info as any) : null,
+    completedSteps: (row.completed_steps as string[]) ?? [],
+    currentStep: (row.current_step as OnboardingStep) ?? 'personal_info',
+    submitted: row.submitted as boolean,
+    submittedAt: row.submitted_at ? new Date(row.submitted_at as string) : null,
+    createdAt: new Date(row.created_at as string),
+    updatedAt: new Date(row.updated_at as string),
+  }
+}
+
+export function createOnboardingRouter(): Router {
+  const router = Router()
+
+  router.use(authenticateToken)
+
+  /**
+   * POST /api/onboarding/draft
+   * Upsert the tenant's onboarding draft. Accepts partial payload for any step.
+   * Auto-advances completedSteps based on which sections are present.
+   */
+  router.post('/draft', async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const userId = (req as any).user.id as string
+
+      const parsed = onboardingDraftSchema.safeParse(req.body)
+      if (!parsed.success) {
+        throw new AppError(ErrorCode.VALIDATION_ERROR, 400, 'Invalid onboarding data', {
+          fields: parsed.error.errors,
+        })
+      }
+
+      const { personalInfo, employmentInfo, documents, walletInfo } = parsed.data
+
+      const pool = await getPool()
+      if (!pool) throw new AppError(ErrorCode.INTERNAL_ERROR, 500, 'Database not available')
+
+      // Determine which steps are now completed based on submitted data
+      const existing = await pool
+        .query(`SELECT * FROM onboarding_drafts WHERE user_id = $1`, [userId])
+        .then(r => (r.rows[0] ? mapRow(r.rows[0]) : null))
+
+      const completedSteps = new Set<string>(existing?.completedSteps ?? [])
+      if (personalInfo) completedSteps.add('personal_info')
+      if (employmentInfo) completedSteps.add('employment_info')
+      if (documents) completedSteps.add('documents')
+      if (walletInfo !== undefined) completedSteps.add('wallet')
+
+      const completedStepsArr = Array.from(completedSteps)
+      const currentStep = deriveCurrentStep(completedStepsArr)
+
+      const { rows } = await pool.query(
+        `INSERT INTO onboarding_drafts (
+           user_id, personal_info, employment_info, documents, wallet_info,
+           completed_steps, current_step, updated_at
+         )
+         VALUES ($1, $2, $3, $4, $5, $6, $7, NOW())
+         ON CONFLICT (user_id) DO UPDATE SET
+           personal_info   = COALESCE($2, onboarding_drafts.personal_info),
+           employment_info = COALESCE($3, onboarding_drafts.employment_info),
+           documents       = COALESCE($4, onboarding_drafts.documents),
+           wallet_info     = COALESCE($5, onboarding_drafts.wallet_info),
+           completed_steps = $6,
+           current_step    = $7,
+           updated_at      = NOW()
+         RETURNING *`,
+        [
+          userId,
+          personalInfo ? JSON.stringify(personalInfo) : null,
+          employmentInfo ? JSON.stringify(employmentInfo) : null,
+          documents ? JSON.stringify(documents) : null,
+          walletInfo !== undefined ? JSON.stringify(walletInfo) : null,
+          completedStepsArr,
+          currentStep,
+        ],
+      )
+
+      const record = mapRow(rows[0])
+      res.json({
+        success: true,
+        completedSteps: record.completedSteps,
+        currentStep: record.currentStep,
+      })
+    } catch (error) {
+      next(error)
+    }
+  })
+
+  /**
+   * GET /api/onboarding/status
+   * Returns { completedSteps, currentStep, submitted }
+   */
+  router.get('/status', async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const userId = (req as any).user.id as string
+      const pool = await getPool()
+      if (!pool) throw new AppError(ErrorCode.INTERNAL_ERROR, 500, 'Database not available')
+
+      const { rows } = await pool.query(
+        `SELECT * FROM onboarding_drafts WHERE user_id = $1`,
+        [userId],
+      )
+
+      if (rows.length === 0) {
+        return res.json({
+          completedSteps: [],
+          currentStep: 'personal_info',
+          submitted: false,
+        })
+      }
+
+      const record = mapRow(rows[0])
+      res.json({
+        completedSteps: record.completedSteps,
+        currentStep: record.currentStep,
+        submitted: record.submitted,
+        submittedAt: record.submittedAt,
+      })
+    } catch (error) {
+      next(error)
+    }
+  })
+
+  /**
+   * POST /api/onboarding/submit
+   * Marks the draft as submitted and enqueues the underwriting pipeline.
+   */
+  router.post('/submit', async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const userId = (req as any).user.id as string
+      const pool = await getPool()
+      if (!pool) throw new AppError(ErrorCode.INTERNAL_ERROR, 500, 'Database not available')
+
+      const { rows } = await pool.query(
+        `SELECT * FROM onboarding_drafts WHERE user_id = $1`,
+        [userId],
+      )
+
+      if (rows.length === 0) {
+        throw new AppError(ErrorCode.NOT_FOUND, 404, 'No onboarding draft found')
+      }
+
+      const record = mapRow(rows[0])
+
+      if (record.submitted) {
+        throw new AppError(ErrorCode.CONFLICT, 409, 'Onboarding already submitted')
+      }
+
+      // Require at minimum personal info and employment info
+      if (!record.personalInfo || !record.employmentInfo) {
+        throw new AppError(
+          ErrorCode.VALIDATION_ERROR,
+          400,
+          'Personal info and employment info are required before submission',
+        )
+      }
+
+      await pool.query(
+        `UPDATE onboarding_drafts
+         SET submitted = TRUE, submitted_at = NOW(), updated_at = NOW()
+         WHERE user_id = $1`,
+        [userId],
+      )
+
+      // Enqueue profile-review job for the underwriting pipeline.
+      // The full rule-engine evaluation runs when the tenant submits a property application
+      // (which requires an applicationId). This job triggers initial data review.
+      try {
+        const { getJobStore } = await import('../jobs/scheduler/store.js')
+        await getJobStore().create({
+          name: 'onboarding_review',
+          handler: 'onboardingReview',
+          payload: { userId },
+          priority: 5,
+          maxRetries: 3,
+        })
+      } catch (jobErr) {
+        logger.warn('onboarding.job_enqueue_failed', { userId, error: jobErr })
+      }
+
+      logger.info('onboarding.submitted', { userId })
+
+      res.json({ success: true, message: 'Assessment in progress' })
+    } catch (error) {
+      next(error)
+    }
+  })
+
+  return router
+}

--- a/backend/src/schemas/kyc.ts
+++ b/backend/src/schemas/kyc.ts
@@ -45,4 +45,5 @@ export interface KycRecord {
   createdAt: Date
   updatedAt: Date
   expiresAt: Date | null
+  attemptCount: number
 }

--- a/backend/src/schemas/onboarding.ts
+++ b/backend/src/schemas/onboarding.ts
@@ -1,0 +1,60 @@
+import { z } from 'zod'
+
+export const personalInfoSchema = z.object({
+  fullName: z.string().min(2),
+  dateOfBirth: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  phone: z.string().min(7),
+  residentialAddress: z.string().min(5),
+  nin: z.string().optional(),
+  bvn: z.string().optional(),
+})
+
+export const employmentInfoSchema = z.object({
+  employmentStatus: z.enum(['employed', 'self_employed', 'unemployed']),
+  employerName: z.string().optional(),
+  monthlyIncome: z.number().nonnegative().optional(),
+  proofOfEmploymentType: z.string().optional(),
+})
+
+export const documentsSchema = z.object({
+  bankStatementKey: z.string().optional(),
+  proofOfIncomeKey: z.string().optional(),
+  governmentIdKey: z.string().optional(),
+})
+
+export const walletInfoSchema = z.object({
+  walletAddress: z.string().optional(),
+  walletType: z.enum(['stellar', 'freighter']).optional(),
+  skipped: z.boolean().default(false),
+})
+
+export const onboardingDraftSchema = z.object({
+  personalInfo: personalInfoSchema.optional(),
+  employmentInfo: employmentInfoSchema.optional(),
+  documents: documentsSchema.optional(),
+  walletInfo: walletInfoSchema.optional(),
+})
+
+export type PersonalInfo = z.infer<typeof personalInfoSchema>
+export type EmploymentInfo = z.infer<typeof employmentInfoSchema>
+export type Documents = z.infer<typeof documentsSchema>
+export type WalletInfo = z.infer<typeof walletInfoSchema>
+export type OnboardingDraft = z.infer<typeof onboardingDraftSchema>
+
+export const ONBOARDING_STEPS = ['personal_info', 'employment_info', 'documents', 'wallet', 'summary'] as const
+export type OnboardingStep = typeof ONBOARDING_STEPS[number]
+
+export interface OnboardingRecord {
+  id: string
+  userId: string
+  personalInfo: PersonalInfo | null
+  employmentInfo: EmploymentInfo | null
+  documents: Documents | null
+  walletInfo: WalletInfo | null
+  completedSteps: string[]
+  currentStep: OnboardingStep
+  submitted: boolean
+  submittedAt: Date | null
+  createdAt: Date
+  updatedAt: Date
+}

--- a/backend/src/utils/webhookSignature.ts
+++ b/backend/src/utils/webhookSignature.ts
@@ -1,0 +1,9 @@
+import crypto from 'crypto'
+
+export function verifyHmacSha256(secret: string, rawBody: string, signature: string): boolean {
+  const expected = crypto.createHmac('sha256', secret).update(rawBody).digest('hex')
+  const sigBuf = Buffer.from(signature.replace(/^sha256=/, ''), 'hex')
+  const expBuf = Buffer.from(expected, 'hex')
+  if (sigBuf.length !== expBuf.length) return false
+  return crypto.timingSafeEqual(sigBuf, expBuf)
+}

--- a/contracts/multisig_admin/Cargo.toml
+++ b/contracts/multisig_admin/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "multisig_admin"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.7"
+
+[dev-dependencies]
+soroban-sdk = { version = "22.0.7", features = ["testutils"] }

--- a/contracts/multisig_admin/src/lib.rs
+++ b/contracts/multisig_admin/src/lib.rs
@@ -1,0 +1,554 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Bytes, Env, Symbol, Vec};
+
+#[contracttype]
+pub struct Config {
+    pub signers: Vec<Address>,
+    pub threshold: u32,
+}
+
+#[contracttype]
+#[derive(Clone, PartialEq)]
+pub enum ProposalStatus {
+    Pending,
+    Executed,
+    Cancelled,
+    Expired,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct Proposal {
+    pub proposer: Address,
+    pub operation: OperationType,
+    pub params: Bytes,
+    pub expiry: u64,
+    pub status: ProposalStatus,
+    pub approval_count: u32,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub enum OperationType {
+    ForceReleaseEscrow,
+    ExecuteSlash,
+    UpgradeContract,
+    SetOracleStaleness,
+    FreezeAccount,
+    UpdateUpgradeDelay,
+}
+
+#[contracttype]
+pub enum DataKey {
+    Config,
+    NextProposalId,
+    Proposal(u64),
+    Approvals(u64),
+}
+
+#[contract]
+pub struct MultisigAdmin;
+
+#[contractimpl]
+impl MultisigAdmin {
+    pub fn init(env: Env, signers: Vec<Address>, threshold: u32) {
+        if env.storage().instance().has(&DataKey::Config) {
+            panic!("AlreadyInitialized");
+        }
+        if threshold == 0 || (threshold > signers.len() as u32) {
+            panic!("InvalidThreshold");
+        }
+        let cfg = Config {
+            signers: signers.clone(),
+            threshold,
+        };
+        env.storage().instance().set(&DataKey::Config, &cfg);
+        env.storage()
+            .instance()
+            .set(&DataKey::NextProposalId, &1u64);
+        env.events().publish(
+            (
+                Symbol::new(&env, "multisig_admin"),
+                Symbol::new(&env, "init"),
+            ),
+            (),
+        );
+    }
+
+    pub fn propose(
+        env: Env,
+        proposer: Address,
+        operation: OperationType,
+        params: Bytes,
+        expiry: u64,
+    ) -> u64 {
+        proposer.require_auth();
+        let cfg: Config = env
+            .storage()
+            .instance()
+            .get(&DataKey::Config)
+            .expect("NotInitialized");
+        if !cfg.signers.contains(&proposer) {
+            panic!("NotASigner");
+        }
+        let id: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::NextProposalId)
+            .unwrap_or(1u64);
+        let prop = Proposal {
+            proposer: proposer.clone(),
+            operation,
+            params,
+            expiry,
+            status: ProposalStatus::Pending,
+            approval_count: 0,
+        };
+        env.storage().instance().set(&DataKey::Proposal(id), &prop);
+        let approvals: Vec<Address> = Vec::new(&env);
+        env.storage()
+            .instance()
+            .set(&DataKey::Approvals(id), &approvals);
+        env.storage()
+            .instance()
+            .set(&DataKey::NextProposalId, &(id + 1));
+        env.events().publish(
+            (
+                Symbol::new(&env, "multisig_admin"),
+                Symbol::new(&env, "proposal_created"),
+            ),
+            id,
+        );
+        id
+    }
+
+    pub fn approve(env: Env, signer: Address, proposal_id: u64) {
+        signer.require_auth();
+        let cfg: Config = env
+            .storage()
+            .instance()
+            .get(&DataKey::Config)
+            .expect("NotInitialized");
+        if !cfg.signers.contains(&signer) {
+            panic!("NotASigner");
+        }
+        let prop: Proposal = env
+            .storage()
+            .instance()
+            .get(&DataKey::Proposal(proposal_id))
+            .expect("UnknownProposal");
+        if let ProposalStatus::Pending = prop.status {
+        } else {
+            panic!("NotPending");
+        }
+        let mut approvals: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::Approvals(proposal_id))
+            .unwrap_or_else(|| Vec::new(&env));
+        if approvals.contains(&signer) {
+            panic!("AlreadyApproved");
+        }
+        approvals.push_back(signer.clone());
+        let mut updated_prop = prop;
+        updated_prop.approval_count = approvals.len() as u32;
+        env.storage()
+            .instance()
+            .set(&DataKey::Approvals(proposal_id), &approvals);
+        env.storage()
+            .instance()
+            .set(&DataKey::Proposal(proposal_id), &updated_prop);
+        env.events().publish(
+            (
+                Symbol::new(&env, "multisig_admin"),
+                Symbol::new(&env, "proposal_approved"),
+            ),
+            (proposal_id, signer),
+        );
+    }
+
+    pub fn execute(env: Env, executor: Address, proposal_id: u64) {
+        executor.require_auth();
+        let cfg: Config = env
+            .storage()
+            .instance()
+            .get(&DataKey::Config)
+            .expect("NotInitialized");
+        if !cfg.signers.contains(&executor) {
+            panic!("NotASigner");
+        }
+        let mut prop: Proposal = env
+            .storage()
+            .instance()
+            .get(&DataKey::Proposal(proposal_id))
+            .expect("UnknownProposal");
+        if let ProposalStatus::Pending = prop.status {
+        } else {
+            panic!("NotPending");
+        }
+        let now: u64 = env.ledger().timestamp() as u64;
+        if prop.expiry != 0 && now > prop.expiry {
+            prop.status = ProposalStatus::Expired;
+            env.storage()
+                .instance()
+                .set(&DataKey::Proposal(proposal_id), &prop);
+            panic!("ProposalExpired");
+        }
+        let approvals: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::Approvals(proposal_id))
+            .unwrap_or_else(|| Vec::new(&env));
+        if (approvals.len() as u32) < cfg.threshold {
+            panic!("NotEnoughApprovals");
+        }
+        prop.status = ProposalStatus::Executed;
+        env.storage()
+            .instance()
+            .set(&DataKey::Proposal(proposal_id), &prop);
+        env.events().publish(
+            (
+                Symbol::new(&env, "multisig_admin"),
+                Symbol::new(&env, "proposal_executed"),
+            ),
+            proposal_id,
+        );
+    }
+
+    pub fn cancel(env: Env, caller: Address, proposal_id: u64) {
+        caller.require_auth();
+        let cfg: Config = env
+            .storage()
+            .instance()
+            .get(&DataKey::Config)
+            .expect("NotInitialized");
+        if !cfg.signers.contains(&caller) {
+            panic!("NotASigner");
+        }
+        let mut prop: Proposal = env
+            .storage()
+            .instance()
+            .get(&DataKey::Proposal(proposal_id))
+            .expect("UnknownProposal");
+        if let ProposalStatus::Pending = prop.status {
+        } else {
+            panic!("NotPending");
+        }
+        prop.status = ProposalStatus::Cancelled;
+        env.storage()
+            .instance()
+            .set(&DataKey::Proposal(proposal_id), &prop);
+        env.events().publish(
+            (
+                Symbol::new(&env, "multisig_admin"),
+                Symbol::new(&env, "proposal_cancelled"),
+            ),
+            proposal_id,
+        );
+    }
+
+    pub fn get_proposal(env: Env, proposal_id: u64) -> Proposal {
+        env.storage()
+            .instance()
+            .get(&DataKey::Proposal(proposal_id))
+            .expect("UnknownProposal")
+    }
+
+    /// List all proposal IDs, optionally filtered by status.
+    /// Returns all IDs when status_filter is None.
+    pub fn list_proposals(env: Env, status_filter: Option<ProposalStatus>) -> Vec<u64> {
+        let mut out: Vec<u64> = Vec::new(&env);
+        let next: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::NextProposalId)
+            .unwrap_or(1u64);
+        let mut i = 1u64;
+        while i < next {
+            if let Some(ref filter) = status_filter {
+                if let Some(prop) = env
+                    .storage()
+                    .instance()
+                    .get::<_, Proposal>(&DataKey::Proposal(i))
+                {
+                    if &prop.status == filter {
+                        out.push_back(i);
+                    }
+                }
+            } else {
+                out.push_back(i);
+            }
+            i += 1;
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod test {
+    extern crate std;
+    use super::*;
+    use soroban_sdk::testutils::{Address as _, Ledger as _};
+    use soroban_sdk::{Address, Env};
+
+    fn setup(env: &Env) -> (Address, Address, Address, Vec<Address>) {
+        let a = Address::generate(env);
+        let b = Address::generate(env);
+        let c = Address::generate(env);
+        let mut signers: Vec<Address> = Vec::new(env);
+        signers.push_back(a.clone());
+        signers.push_back(b.clone());
+        signers.push_back(c.clone());
+        (a, b, c, signers)
+    }
+
+    #[test]
+    fn threshold_execute_flow() {
+        let env = Env::default();
+        let (a, b, _c, signers) = setup(&env);
+        env.mock_all_auths();
+        let contract_id = env.register(MultisigAdmin, ());
+        let client = MultisigAdminClient::new(&env, &contract_id);
+        client.init(&signers, &2u32);
+
+        let id = client.propose(
+            &a,
+            &OperationType::FreezeAccount,
+            &Bytes::from_slice(&env, b"{}"),
+            &0u64,
+        );
+        client.approve(&a, &id);
+        client.approve(&b, &id);
+        client.execute(&a, &id);
+        let prop = client.get_proposal(&id);
+        match prop.status {
+            ProposalStatus::Executed => {}
+            _ => panic!("expected executed"),
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "NotEnoughApprovals")]
+    fn threshold_not_reached_execute_fails() {
+        let env = Env::default();
+        let (a, _b, _c, signers) = setup(&env);
+        env.mock_all_auths();
+        let contract_id = env.register(MultisigAdmin, ());
+        let client = MultisigAdminClient::new(&env, &contract_id);
+        client.init(&signers, &2u32);
+
+        let id = client.propose(
+            &a,
+            &OperationType::FreezeAccount,
+            &Bytes::from_slice(&env, b"{}"),
+            &0u64,
+        );
+        client.approve(&a, &id);
+        // only 1 of 2 required approvals — execute must panic
+        client.execute(&a, &id);
+    }
+
+    #[test]
+    #[should_panic(expected = "ProposalExpired")]
+    fn expired_proposal_execute_fails() {
+        let env = Env::default();
+        let (a, b, _c, signers) = setup(&env);
+        env.mock_all_auths();
+        let contract_id = env.register(MultisigAdmin, ());
+        let client = MultisigAdminClient::new(&env, &contract_id);
+        client.init(&signers, &2u32);
+
+        // Set expiry in the past relative to the current ledger timestamp
+        let expiry = env.ledger().timestamp() + 5;
+        let id = client.propose(
+            &a,
+            &OperationType::FreezeAccount,
+            &Bytes::from_slice(&env, b"{}"),
+            &expiry,
+        );
+        client.approve(&a, &id);
+        client.approve(&b, &id);
+        // Advance ledger past expiry
+        env.ledger().set_timestamp(expiry + 1);
+        client.execute(&a, &id);
+    }
+
+    #[test]
+    #[should_panic(expected = "AlreadyApproved")]
+    fn duplicate_approval_fails() {
+        let env = Env::default();
+        let (a, _b, _c, signers) = setup(&env);
+        env.mock_all_auths();
+        let contract_id = env.register(MultisigAdmin, ());
+        let client = MultisigAdminClient::new(&env, &contract_id);
+        client.init(&signers, &2u32);
+        let id = client.propose(
+            &a,
+            &OperationType::FreezeAccount,
+            &Bytes::from_slice(&env, b"{}"),
+            &0u64,
+        );
+        client.approve(&a, &id);
+        client.approve(&a, &id); // must panic
+    }
+
+    #[test]
+    #[should_panic(expected = "NotASigner")]
+    fn non_signer_cannot_propose() {
+        let env = Env::default();
+        let (a, b, _c, signers) = setup(&env);
+        env.mock_all_auths();
+        let contract_id = env.register(MultisigAdmin, ());
+        let client = MultisigAdminClient::new(&env, &contract_id);
+        client.init(&signers, &2u32);
+        let outsider = Address::generate(&env);
+        client.propose(
+            &outsider,
+            &OperationType::FreezeAccount,
+            &Bytes::from_slice(&env, b"{}"),
+            &0u64,
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "NotASigner")]
+    fn non_signer_cannot_approve() {
+        let env = Env::default();
+        let (a, _b, _c, signers) = setup(&env);
+        env.mock_all_auths();
+        let contract_id = env.register(MultisigAdmin, ());
+        let client = MultisigAdminClient::new(&env, &contract_id);
+        client.init(&signers, &2u32);
+        let id = client.propose(
+            &a,
+            &OperationType::FreezeAccount,
+            &Bytes::from_slice(&env, b"{}"),
+            &0u64,
+        );
+        let outsider = Address::generate(&env);
+        client.approve(&outsider, &id);
+    }
+
+    #[test]
+    #[should_panic(expected = "NotASigner")]
+    fn non_signer_cannot_execute() {
+        let env = Env::default();
+        let (a, b, _c, signers) = setup(&env);
+        env.mock_all_auths();
+        let contract_id = env.register(MultisigAdmin, ());
+        let client = MultisigAdminClient::new(&env, &contract_id);
+        client.init(&signers, &2u32);
+        let id = client.propose(
+            &a,
+            &OperationType::FreezeAccount,
+            &Bytes::from_slice(&env, b"{}"),
+            &0u64,
+        );
+        client.approve(&a, &id);
+        client.approve(&b, &id);
+        let outsider = Address::generate(&env);
+        client.execute(&outsider, &id);
+    }
+
+    #[test]
+    fn cancel_removes_proposal_from_pending() {
+        let env = Env::default();
+        let (a, _b, _c, signers) = setup(&env);
+        env.mock_all_auths();
+        let contract_id = env.register(MultisigAdmin, ());
+        let client = MultisigAdminClient::new(&env, &contract_id);
+        client.init(&signers, &2u32);
+        let id = client.propose(
+            &a,
+            &OperationType::FreezeAccount,
+            &Bytes::from_slice(&env, b"{}"),
+            &0u64,
+        );
+        client.cancel(&a, &id);
+        let prop = client.get_proposal(&id);
+        match prop.status {
+            ProposalStatus::Cancelled => {}
+            _ => panic!("expected cancelled"),
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "NotPending")]
+    fn execute_cancelled_proposal_fails() {
+        let env = Env::default();
+        let (a, b, _c, signers) = setup(&env);
+        env.mock_all_auths();
+        let contract_id = env.register(MultisigAdmin, ());
+        let client = MultisigAdminClient::new(&env, &contract_id);
+        client.init(&signers, &2u32);
+        let id = client.propose(
+            &a,
+            &OperationType::FreezeAccount,
+            &Bytes::from_slice(&env, b"{}"),
+            &0u64,
+        );
+        client.approve(&a, &id);
+        client.approve(&b, &id);
+        client.cancel(&a, &id);
+        client.execute(&a, &id); // must panic: NotPending
+    }
+
+    #[test]
+    fn list_proposals_with_status_filter() {
+        let env = Env::default();
+        let (a, b, _c, signers) = setup(&env);
+        env.mock_all_auths();
+        let contract_id = env.register(MultisigAdmin, ());
+        let client = MultisigAdminClient::new(&env, &contract_id);
+        client.init(&signers, &2u32);
+
+        let id1 = client.propose(
+            &a,
+            &OperationType::FreezeAccount,
+            &Bytes::from_slice(&env, b"{}"),
+            &0u64,
+        );
+        let id2 = client.propose(
+            &a,
+            &OperationType::UpgradeContract,
+            &Bytes::from_slice(&env, b"{}"),
+            &0u64,
+        );
+        client.approve(&a, &id1);
+        client.approve(&b, &id1);
+        client.execute(&a, &id1);
+
+        // id1 is Executed, id2 is Pending
+        let pending = client.list_proposals(&Option::Some(ProposalStatus::Pending));
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending.get(0).unwrap(), id2);
+
+        let executed = client.list_proposals(&Option::Some(ProposalStatus::Executed));
+        assert_eq!(executed.len(), 1);
+        assert_eq!(executed.get(0).unwrap(), id1);
+
+        let all = client.list_proposals(&Option::<ProposalStatus>::None);
+        assert_eq!(all.len(), 2);
+    }
+
+    #[test]
+    fn approval_count_tracked() {
+        let env = Env::default();
+        let (a, b, _c, signers) = setup(&env);
+        env.mock_all_auths();
+        let contract_id = env.register(MultisigAdmin, ());
+        let client = MultisigAdminClient::new(&env, &contract_id);
+        client.init(&signers, &2u32);
+        let id = client.propose(
+            &a,
+            &OperationType::FreezeAccount,
+            &Bytes::from_slice(&env, b"{}"),
+            &0u64,
+        );
+        assert_eq!(client.get_proposal(&id).approval_count, 0);
+        client.approve(&a, &id);
+        assert_eq!(client.get_proposal(&id).approval_count, 1);
+        client.approve(&b, &id);
+        assert_eq!(client.get_proposal(&id).approval_count, 2);
+    }
+}

--- a/contracts/rent_schedule/Cargo.toml
+++ b/contracts/rent_schedule/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "rent_schedule"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.7"
+
+[dev-dependencies]
+soroban-sdk = { version = "22.0.7", features = ["testutils"] }

--- a/contracts/rent_schedule/src/lib.rs
+++ b/contracts/rent_schedule/src/lib.rs
@@ -1,0 +1,585 @@
+#![no_std]
+
+use soroban_sdk::{contract, contractimpl, contracttype, Address, BytesN, Env, String, Symbol, Vec};
+
+#[contracttype]
+#[derive(Clone)]
+pub struct ScheduledInstalment {
+    pub instalment_number: u32,
+    pub due_timestamp: u64,
+    pub amount: i128,
+    pub status: InstalmentStatus,
+    pub paid_at: Option<u64>,
+    pub tx_id: Option<BytesN<32>>,
+}
+
+#[contracttype]
+#[derive(Clone, PartialEq)]
+pub enum InstalmentStatus {
+    Pending,
+    Paid,
+    Overdue,
+    Waived,
+}
+
+#[contracttype]
+pub enum DataKey {
+    Config,
+    Schedule(String),
+    Paused,
+}
+
+#[contracttype]
+pub struct Config {
+    pub admin: Address,
+    pub operator: Address,
+}
+
+fn is_paused(env: &Env) -> bool {
+    env.storage()
+        .instance()
+        .get::<_, bool>(&DataKey::Paused)
+        .unwrap_or(false)
+}
+
+fn require_not_paused(env: &Env) {
+    if is_paused(env) {
+        panic!("ContractPaused");
+    }
+}
+
+#[contract]
+pub struct RentSchedule;
+
+#[contractimpl]
+impl RentSchedule {
+    pub fn init(env: Env, admin: Address, operator: Address) {
+        if env.storage().instance().has(&DataKey::Config) {
+            panic!("AlreadyInitialized");
+        }
+        let cfg = Config {
+            admin: admin.clone(),
+            operator: operator.clone(),
+        };
+        env.storage().instance().set(&DataKey::Config, &cfg);
+        env.storage().instance().set(&DataKey::Paused, &false);
+        env.events().publish(
+            (
+                Symbol::new(&env, "rent_schedule"),
+                Symbol::new(&env, "init"),
+            ),
+            (),
+        );
+    }
+
+    pub fn pause(env: Env, caller: Address) {
+        caller.require_auth();
+        let cfg: Config = env
+            .storage()
+            .instance()
+            .get(&DataKey::Config)
+            .expect("NotInitialized");
+        if caller != cfg.admin {
+            panic!("NotAuthorized");
+        }
+        env.storage().instance().set(&DataKey::Paused, &true);
+        env.events().publish(
+            (
+                Symbol::new(&env, "rent_schedule"),
+                Symbol::new(&env, "paused"),
+            ),
+            (),
+        );
+    }
+
+    pub fn unpause(env: Env, caller: Address) {
+        caller.require_auth();
+        let cfg: Config = env
+            .storage()
+            .instance()
+            .get(&DataKey::Config)
+            .expect("NotInitialized");
+        if caller != cfg.admin {
+            panic!("NotAuthorized");
+        }
+        env.storage().instance().set(&DataKey::Paused, &false);
+        env.events().publish(
+            (
+                Symbol::new(&env, "rent_schedule"),
+                Symbol::new(&env, "unpaused"),
+            ),
+            (),
+        );
+    }
+
+    pub fn is_paused(env: Env) -> bool {
+        is_paused(&env)
+    }
+
+    pub fn create_schedule(
+        env: Env,
+        caller: Address,
+        deal_id: String,
+        instalments: Vec<ScheduledInstalment>,
+    ) {
+        let cfg: Config = env
+            .storage()
+            .instance()
+            .get(&DataKey::Config)
+            .expect("NotInitialized");
+        if caller != cfg.admin && caller != cfg.operator {
+            panic!("NotAuthorized");
+        }
+        caller.require_auth();
+        if env
+            .storage()
+            .persistent()
+            .has(&DataKey::Schedule(deal_id.clone()))
+        {
+            panic!("ScheduleExists");
+        }
+        let total_amount: i128 = instalments.iter().map(|i| i.amount).sum();
+        let count = instalments.len();
+        env.storage()
+            .persistent()
+            .set(&DataKey::Schedule(deal_id.clone()), &instalments);
+        env.events().publish(
+            (
+                Symbol::new(&env, "rent_schedule"),
+                Symbol::new(&env, "schedule_created"),
+                deal_id,
+            ),
+            (count, total_amount),
+        );
+    }
+
+    pub fn record_payment(
+        env: Env,
+        caller: Address,
+        deal_id: String,
+        instalment_number: u32,
+        tx_id: BytesN<32>,
+        paid_at: u64,
+    ) {
+        require_not_paused(&env);
+        let _cfg: Config = env
+            .storage()
+            .instance()
+            .get(&DataKey::Config)
+            .expect("NotInitialized");
+        caller.require_auth();
+        let mut schedule: Vec<ScheduledInstalment> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Schedule(deal_id.clone()))
+            .expect("NoSchedule");
+        let idx = schedule
+            .iter()
+            .position(|i| i.instalment_number == instalment_number)
+            .expect("NotFound");
+        let mut inst = schedule.get(idx as u32).unwrap();
+        if inst.status != InstalmentStatus::Pending {
+            panic!("InvalidStatus");
+        }
+        inst.status = InstalmentStatus::Paid;
+        inst.paid_at = Option::Some(paid_at);
+        inst.tx_id = Option::Some(tx_id.clone());
+        let amount = inst.amount;
+        schedule.set(idx as u32, inst);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Schedule(deal_id.clone()), &schedule);
+        env.events().publish(
+            (
+                Symbol::new(&env, "rent_schedule"),
+                Symbol::new(&env, "payment_recorded"),
+                deal_id,
+            ),
+            (instalment_number, amount, tx_id),
+        );
+    }
+
+    pub fn mark_overdue(
+        env: Env,
+        caller: Address,
+        deal_id: String,
+        instalment_number: u32,
+    ) {
+        require_not_paused(&env);
+        let cfg: Config = env
+            .storage()
+            .instance()
+            .get(&DataKey::Config)
+            .expect("NotInitialized");
+        if caller != cfg.admin && caller != cfg.operator {
+            panic!("NotAuthorized");
+        }
+        caller.require_auth();
+        let mut schedule: Vec<ScheduledInstalment> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Schedule(deal_id.clone()))
+            .expect("NoSchedule");
+        let idx = schedule
+            .iter()
+            .position(|i| i.instalment_number == instalment_number)
+            .expect("NotFound");
+        let mut inst = schedule.get(idx as u32).unwrap();
+        if inst.status != InstalmentStatus::Pending {
+            panic!("InvalidStatus");
+        }
+        inst.status = InstalmentStatus::Overdue;
+        schedule.set(idx as u32, inst);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Schedule(deal_id.clone()), &schedule);
+        env.events().publish(
+            (
+                Symbol::new(&env, "rent_schedule"),
+                Symbol::new(&env, "instalment_overdue"),
+                deal_id,
+            ),
+            instalment_number,
+        );
+    }
+
+    pub fn waive_instalment(
+        env: Env,
+        caller: Address,
+        deal_id: String,
+        instalment_number: u32,
+    ) {
+        let cfg: Config = env
+            .storage()
+            .instance()
+            .get(&DataKey::Config)
+            .expect("NotInitialized");
+        if caller != cfg.admin {
+            panic!("NotAuthorized");
+        }
+        caller.require_auth();
+        let mut schedule: Vec<ScheduledInstalment> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Schedule(deal_id.clone()))
+            .expect("NoSchedule");
+        let idx = schedule
+            .iter()
+            .position(|i| i.instalment_number == instalment_number)
+            .expect("NotFound");
+        let mut inst = schedule.get(idx as u32).unwrap();
+        if inst.status == InstalmentStatus::Waived {
+            panic!("AlreadyWaived");
+        }
+        inst.status = InstalmentStatus::Waived;
+        schedule.set(idx as u32, inst);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Schedule(deal_id.clone()), &schedule);
+        env.events().publish(
+            (
+                Symbol::new(&env, "rent_schedule"),
+                Symbol::new(&env, "instalment_waived"),
+                deal_id,
+            ),
+            instalment_number,
+        );
+    }
+
+    /// Returns instalments sorted by instalment_number ascending.
+    pub fn get_schedule(env: Env, deal_id: String) -> Vec<ScheduledInstalment> {
+        let mut schedule: Vec<ScheduledInstalment> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Schedule(deal_id))
+            .unwrap_or(Vec::new(&env));
+        // Insertion-sort by instalment_number
+        let len = schedule.len();
+        let mut i = 1u32;
+        while i < len {
+            let mut j = i;
+            while j > 0 {
+                let a = schedule.get(j - 1).unwrap();
+                let b = schedule.get(j).unwrap();
+                if a.instalment_number > b.instalment_number {
+                    schedule.set(j - 1, b.clone());
+                    schedule.set(j, a);
+                    j -= 1;
+                } else {
+                    break;
+                }
+            }
+            i += 1;
+        }
+        schedule
+    }
+
+    pub fn get_instalment(
+        env: Env,
+        deal_id: String,
+        instalment_number: u32,
+    ) -> ScheduledInstalment {
+        let schedule: Vec<ScheduledInstalment> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Schedule(deal_id))
+            .expect("NoSchedule");
+        schedule
+            .iter()
+            .find(|i| i.instalment_number == instalment_number)
+            .unwrap()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    extern crate std;
+    use super::*;
+    use soroban_sdk::testutils::Address as _;
+    use soroban_sdk::{Address, BytesN, Env, String, Vec};
+
+    fn make_deal_id(env: &Env, s: &str) -> String {
+        String::from_str(env, s)
+    }
+
+    fn make_instalments(env: &Env, count: u32) -> Vec<ScheduledInstalment> {
+        let mut v: Vec<ScheduledInstalment> = Vec::new(env);
+        for i in 0..count {
+            v.push_back(ScheduledInstalment {
+                instalment_number: i + 1,
+                due_timestamp: (i as u64 + 1) * 30 * 24 * 3600,
+                amount: 100_000i128 * (i as i128 + 1),
+                status: InstalmentStatus::Pending,
+                paid_at: Option::None,
+                tx_id: Option::None,
+            });
+        }
+        v
+    }
+
+    fn setup(env: &Env) -> (Address, Address, soroban_sdk::Address) {
+        let admin = Address::generate(env);
+        let operator = Address::generate(env);
+        let contract_id = env.register(RentSchedule, ());
+        (admin, operator, contract_id)
+    }
+
+    #[test]
+    fn create_schedule_and_get() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (admin, operator, contract_id) = setup(&env);
+        let client = RentScheduleClient::new(&env, &contract_id);
+        client.init(&admin, &operator);
+
+        let deal_id = make_deal_id(&env, "deal_001");
+        let instalments = make_instalments(&env, 3);
+        client.create_schedule(&admin, &deal_id, &instalments);
+
+        let schedule = client.get_schedule(&deal_id);
+        assert_eq!(schedule.len(), 3);
+    }
+
+    #[test]
+    #[should_panic(expected = "ScheduleExists")]
+    fn create_schedule_fails_if_duplicate() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (admin, operator, contract_id) = setup(&env);
+        let client = RentScheduleClient::new(&env, &contract_id);
+        client.init(&admin, &operator);
+
+        let deal_id = make_deal_id(&env, "deal_002");
+        let instalments = make_instalments(&env, 2);
+        client.create_schedule(&admin, &deal_id, &instalments.clone());
+        client.create_schedule(&admin, &deal_id, &instalments); // must panic
+    }
+
+    #[test]
+    fn record_payment_transitions_pending_to_paid() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (admin, operator, contract_id) = setup(&env);
+        let client = RentScheduleClient::new(&env, &contract_id);
+        client.init(&admin, &operator);
+
+        let deal_id = make_deal_id(&env, "deal_003");
+        let instalments = make_instalments(&env, 2);
+        client.create_schedule(&admin, &deal_id, &instalments);
+
+        let tx_id = BytesN::from_array(&env, &[1u8; 32]);
+        client.record_payment(&admin, &deal_id, &1u32, &tx_id, &1_000_000u64);
+
+        let inst = client.get_instalment(&deal_id, &1u32);
+        assert!(matches!(inst.status, InstalmentStatus::Paid));
+        assert!(inst.paid_at.is_some());
+        assert!(inst.tx_id.is_some());
+    }
+
+    #[test]
+    #[should_panic(expected = "InvalidStatus")]
+    fn mark_overdue_on_paid_instalment_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (admin, operator, contract_id) = setup(&env);
+        let client = RentScheduleClient::new(&env, &contract_id);
+        client.init(&admin, &operator);
+
+        let deal_id = make_deal_id(&env, "deal_004");
+        let instalments = make_instalments(&env, 1);
+        client.create_schedule(&admin, &deal_id, &instalments);
+
+        let tx_id = BytesN::from_array(&env, &[2u8; 32]);
+        client.record_payment(&admin, &deal_id, &1u32, &tx_id, &1_000_000u64);
+        client.mark_overdue(&admin, &deal_id, &1u32); // must panic: InvalidStatus
+    }
+
+    #[test]
+    fn mark_overdue_transitions_pending_to_overdue() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (admin, operator, contract_id) = setup(&env);
+        let client = RentScheduleClient::new(&env, &contract_id);
+        client.init(&admin, &operator);
+
+        let deal_id = make_deal_id(&env, "deal_005");
+        let instalments = make_instalments(&env, 1);
+        client.create_schedule(&admin, &deal_id, &instalments);
+
+        client.mark_overdue(&admin, &deal_id, &1u32);
+        let inst = client.get_instalment(&deal_id, &1u32);
+        assert!(matches!(inst.status, InstalmentStatus::Overdue));
+    }
+
+    #[test]
+    fn get_schedule_returns_sorted_order() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (admin, operator, contract_id) = setup(&env);
+        let client = RentScheduleClient::new(&env, &contract_id);
+        client.init(&admin, &operator);
+
+        // Create instalments in reverse order
+        let deal_id = make_deal_id(&env, "deal_006");
+        let mut v: Vec<ScheduledInstalment> = Vec::new(&env);
+        v.push_back(ScheduledInstalment {
+            instalment_number: 3,
+            due_timestamp: 90,
+            amount: 300,
+            status: InstalmentStatus::Pending,
+            paid_at: Option::None,
+            tx_id: Option::None,
+        });
+        v.push_back(ScheduledInstalment {
+            instalment_number: 1,
+            due_timestamp: 30,
+            amount: 100,
+            status: InstalmentStatus::Pending,
+            paid_at: Option::None,
+            tx_id: Option::None,
+        });
+        v.push_back(ScheduledInstalment {
+            instalment_number: 2,
+            due_timestamp: 60,
+            amount: 200,
+            status: InstalmentStatus::Pending,
+            paid_at: Option::None,
+            tx_id: Option::None,
+        });
+        client.create_schedule(&admin, &deal_id, &v);
+
+        let schedule = client.get_schedule(&deal_id);
+        assert_eq!(schedule.get(0).unwrap().instalment_number, 1);
+        assert_eq!(schedule.get(1).unwrap().instalment_number, 2);
+        assert_eq!(schedule.get(2).unwrap().instalment_number, 3);
+    }
+
+    #[test]
+    fn waived_instalment_no_further_transitions() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (admin, operator, contract_id) = setup(&env);
+        let client = RentScheduleClient::new(&env, &contract_id);
+        client.init(&admin, &operator);
+
+        let deal_id = make_deal_id(&env, "deal_007");
+        let instalments = make_instalments(&env, 1);
+        client.create_schedule(&admin, &deal_id, &instalments);
+        client.waive_instalment(&admin, &deal_id, &1u32);
+
+        let inst = client.get_instalment(&deal_id, &1u32);
+        assert!(matches!(inst.status, InstalmentStatus::Waived));
+    }
+
+    #[test]
+    #[should_panic(expected = "InvalidStatus")]
+    fn record_payment_on_waived_instalment_fails() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (admin, operator, contract_id) = setup(&env);
+        let client = RentScheduleClient::new(&env, &contract_id);
+        client.init(&admin, &operator);
+
+        let deal_id = make_deal_id(&env, "deal_008");
+        let instalments = make_instalments(&env, 1);
+        client.create_schedule(&admin, &deal_id, &instalments);
+        client.waive_instalment(&admin, &deal_id, &1u32);
+
+        let tx_id = BytesN::from_array(&env, &[3u8; 32]);
+        client.record_payment(&admin, &deal_id, &1u32, &tx_id, &1_000_000u64); // must panic
+    }
+
+    #[test]
+    #[should_panic(expected = "ContractPaused")]
+    fn paused_blocks_record_payment() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (admin, operator, contract_id) = setup(&env);
+        let client = RentScheduleClient::new(&env, &contract_id);
+        client.init(&admin, &operator);
+
+        let deal_id = make_deal_id(&env, "deal_009");
+        let instalments = make_instalments(&env, 1);
+        client.create_schedule(&admin, &deal_id, &instalments);
+        client.pause(&admin);
+
+        let tx_id = BytesN::from_array(&env, &[4u8; 32]);
+        client.record_payment(&admin, &deal_id, &1u32, &tx_id, &1_000_000u64); // must panic
+    }
+
+    #[test]
+    #[should_panic(expected = "ContractPaused")]
+    fn paused_blocks_mark_overdue() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (admin, operator, contract_id) = setup(&env);
+        let client = RentScheduleClient::new(&env, &contract_id);
+        client.init(&admin, &operator);
+
+        let deal_id = make_deal_id(&env, "deal_010");
+        let instalments = make_instalments(&env, 1);
+        client.create_schedule(&admin, &deal_id, &instalments);
+        client.pause(&admin);
+        client.mark_overdue(&admin, &deal_id, &1u32); // must panic
+    }
+
+    #[test]
+    fn unpause_restores_operations() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (admin, operator, contract_id) = setup(&env);
+        let client = RentScheduleClient::new(&env, &contract_id);
+        client.init(&admin, &operator);
+
+        let deal_id = make_deal_id(&env, "deal_011");
+        let instalments = make_instalments(&env, 1);
+        client.create_schedule(&admin, &deal_id, &instalments);
+        client.pause(&admin);
+        client.unpause(&admin);
+
+        let tx_id = BytesN::from_array(&env, &[5u8; 32]);
+        client.record_payment(&admin, &deal_id, &1u32, &tx_id, &1_000_000u64);
+        let inst = client.get_instalment(&deal_id, &1u32);
+        assert!(matches!(inst.status, InstalmentStatus::Paid));
+    }
+}

--- a/frontend/app/dashboard/tenant/page.tsx
+++ b/frontend/app/dashboard/tenant/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import Link from "next/link";
 import {
   Home,
@@ -33,6 +33,7 @@ import {
 } from "@/lib/mockData";
 import { featureFlags } from "@/lib/featureFlags";
 import { getTenantPaymentStatusPresentation } from "@/lib/tenantPaymentStatus";
+import { apiFetch } from "@/lib/api";
 
 // Wallet balance - checked first before auto-deduction
 type PaymentItem =
@@ -54,6 +55,19 @@ export default function TenantDashboard() {
     "overview",
   );
   const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [onboardingStatus, setOnboardingStatus] = useState<{
+    completedSteps: string[];
+    currentStep: string;
+    submitted: boolean;
+  } | null>(null);
+
+  useEffect(() => {
+    apiFetch<{ completedSteps: string[]; currentStep: string; submitted: boolean }>(
+      "/api/onboarding/status"
+    )
+      .then(setOnboardingStatus)
+      .catch(() => {});
+  }, []);
 
   const formatCurrency = (amount: number) => {
     return new Intl.NumberFormat("en-NG", {
@@ -79,9 +93,60 @@ export default function TenantDashboard() {
     };
   };
 
+  const onboardingComplete = onboardingStatus?.submitted || false;
+  const onboardingProgress = onboardingStatus
+    ? Math.round((onboardingStatus.completedSteps.length / 5) * 100)
+    : 0;
+  const showOnboardingBanner = onboardingStatus && !onboardingStatus.submitted;
+
   return (
     <div className="min-h-screen bg-background">
       <DashboardHeader />
+
+      {/* Onboarding banner */}
+      {showOnboardingBanner && (
+        <div className="border-b-3 border-foreground bg-amber-50">
+          <div className="mx-auto max-w-7xl px-4 py-3 flex items-center justify-between gap-4 flex-wrap">
+            <div className="flex items-center gap-3">
+              <AlertCircle className="h-5 w-5 text-amber-600 shrink-0" />
+              <div>
+                <p className="text-sm font-semibold text-amber-900">
+                  Complete your profile to apply for properties
+                </p>
+                <div className="flex items-center gap-2 mt-0.5">
+                  <div className="w-32 h-1.5 bg-amber-200 rounded-full overflow-hidden">
+                    <div
+                      className="h-full bg-amber-500 rounded-full transition-all"
+                      style={{ width: `${onboardingProgress}%` }}
+                    />
+                  </div>
+                  <span className="text-xs text-amber-700">
+                    {onboardingStatus.completedSteps.length} / 5 steps
+                  </span>
+                </div>
+              </div>
+            </div>
+            <Link href="/onboarding">
+              <Button size="sm" className="bg-amber-600 hover:bg-amber-700 text-white border-none">
+                Continue
+                <ArrowRight className="h-4 w-4 ml-1" />
+              </Button>
+            </Link>
+          </div>
+        </div>
+      )}
+
+      {/* Assessment in progress banner */}
+      {onboardingComplete && (
+        <div className="border-b-3 border-foreground bg-blue-50">
+          <div className="mx-auto max-w-7xl px-4 py-3 flex items-center gap-3">
+            <ShieldCheck className="h-5 w-5 text-blue-600 shrink-0" />
+            <p className="text-sm font-semibold text-blue-900">
+              Assessment in progress — we will notify you once your profile is reviewed.
+            </p>
+          </div>
+        </div>
+      )}
 
       {/* Mobile Menu Button */}
       <button

--- a/frontend/app/onboarding/page.tsx
+++ b/frontend/app/onboarding/page.tsx
@@ -1,0 +1,743 @@
+"use client";
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Progress } from "@/components/ui/progress";
+import { Card } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import {
+  User,
+  Briefcase,
+  FileText,
+  Wallet,
+  CheckCircle,
+  ChevronRight,
+  ChevronLeft,
+  AlertCircle,
+  Loader2,
+  SkipForward,
+} from "lucide-react";
+import { apiFetch, apiPost } from "@/lib/api";
+
+const STEPS = [
+  { id: "personal_info", label: "Personal Info", icon: User },
+  { id: "employment_info", label: "Employment", icon: Briefcase },
+  { id: "documents", label: "Documents", icon: FileText },
+  { id: "wallet", label: "Wallet", icon: Wallet },
+  { id: "summary", label: "Summary", icon: CheckCircle },
+] as const;
+
+type StepId = (typeof STEPS)[number]["id"];
+
+interface PersonalInfo {
+  fullName: string;
+  dateOfBirth: string;
+  phone: string;
+  residentialAddress: string;
+  nin: string;
+  bvn: string;
+}
+
+interface EmploymentInfo {
+  employmentStatus: "employed" | "self_employed" | "unemployed" | "";
+  employerName: string;
+  monthlyIncome: string;
+  proofOfEmploymentType: string;
+}
+
+interface Documents {
+  bankStatementKey: string;
+  proofOfIncomeKey: string;
+  governmentIdKey: string;
+}
+
+interface WalletInfo {
+  walletAddress: string;
+  walletType: "stellar" | "freighter" | "";
+  skipped: boolean;
+}
+
+interface FormData {
+  personalInfo: PersonalInfo;
+  employmentInfo: EmploymentInfo;
+  documents: Documents;
+  walletInfo: WalletInfo;
+}
+
+const defaultFormData: FormData = {
+  personalInfo: {
+    fullName: "",
+    dateOfBirth: "",
+    phone: "",
+    residentialAddress: "",
+    nin: "",
+    bvn: "",
+  },
+  employmentInfo: {
+    employmentStatus: "",
+    employerName: "",
+    monthlyIncome: "",
+    proofOfEmploymentType: "",
+  },
+  documents: {
+    bankStatementKey: "",
+    proofOfIncomeKey: "",
+    governmentIdKey: "",
+  },
+  walletInfo: {
+    walletAddress: "",
+    walletType: "",
+    skipped: false,
+  },
+};
+
+function validateStep(stepId: StepId, data: FormData): string[] {
+  const errors: string[] = [];
+  if (stepId === "personal_info") {
+    const p = data.personalInfo;
+    if (!p.fullName.trim()) errors.push("Full name is required");
+    if (!p.dateOfBirth) errors.push("Date of birth is required");
+    if (!p.phone.trim()) errors.push("Phone number is required");
+    if (!p.residentialAddress.trim()) errors.push("Residential address is required");
+  }
+  if (stepId === "employment_info") {
+    const e = data.employmentInfo;
+    if (!e.employmentStatus) errors.push("Employment status is required");
+  }
+  return errors;
+}
+
+export default function OnboardingPage() {
+  const router = useRouter();
+  const [currentStepIndex, setCurrentStepIndex] = useState(0);
+  const [formData, setFormData] = useState<FormData>(defaultFormData);
+  const [errors, setErrors] = useState<string[]>([]);
+  const [isSaving, setIsSaving] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitSuccess, setSubmitSuccess] = useState(false);
+  const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const currentStep = STEPS[currentStepIndex];
+  const progressPercent = Math.round(
+    ((currentStepIndex) / (STEPS.length - 1)) * 100
+  );
+
+  // Resume from last incomplete step on mount
+  useEffect(() => {
+    apiFetch<{ completedSteps: string[]; currentStep: string; submitted: boolean }>(
+      "/api/onboarding/status"
+    )
+      .then((status) => {
+        if (status.submitted) {
+          setSubmitSuccess(true);
+          return;
+        }
+        const idx = STEPS.findIndex((s) => s.id === status.currentStep);
+        if (idx >= 0) setCurrentStepIndex(idx);
+      })
+      .catch(() => {
+        // Not logged in or no draft — start from beginning
+      });
+  }, []);
+
+  // Auto-save on field change with 1s debounce
+  const autoSave = useCallback(
+    (data: FormData) => {
+      if (debounceTimer.current) clearTimeout(debounceTimer.current);
+      debounceTimer.current = setTimeout(async () => {
+        setIsSaving(true);
+        try {
+          const payload: Record<string, unknown> = {};
+          if (data.personalInfo.fullName || data.personalInfo.phone)
+            payload.personalInfo = {
+              ...data.personalInfo,
+              nin: data.personalInfo.nin || undefined,
+              bvn: data.personalInfo.bvn || undefined,
+            };
+          if (data.employmentInfo.employmentStatus)
+            payload.employmentInfo = {
+              ...data.employmentInfo,
+              employerName: data.employmentInfo.employerName || undefined,
+              monthlyIncome: data.employmentInfo.monthlyIncome
+                ? Number(data.employmentInfo.monthlyIncome)
+                : undefined,
+              proofOfEmploymentType:
+                data.employmentInfo.proofOfEmploymentType || undefined,
+            };
+          if (
+            data.documents.bankStatementKey ||
+            data.documents.proofOfIncomeKey ||
+            data.documents.governmentIdKey
+          )
+            payload.documents = data.documents;
+          if (data.walletInfo.skipped || data.walletInfo.walletAddress)
+            payload.walletInfo = {
+              walletAddress: data.walletInfo.walletAddress || undefined,
+              walletType: data.walletInfo.walletType || undefined,
+              skipped: data.walletInfo.skipped,
+            };
+
+          if (Object.keys(payload).length > 0) {
+            await apiPost("/api/onboarding/draft", payload);
+          }
+        } catch {
+          // Silent fail for auto-save
+        } finally {
+          setIsSaving(false);
+        }
+      }, 1000);
+    },
+    []
+  );
+
+  function updateField<K extends keyof FormData>(
+    section: K,
+    field: keyof FormData[K],
+    value: string | boolean
+  ) {
+    setFormData((prev) => {
+      const updated = {
+        ...prev,
+        [section]: { ...(prev[section] as object), [field]: value },
+      };
+      autoSave(updated);
+      return updated;
+    });
+  }
+
+  function goNext() {
+    const errs = validateStep(currentStep.id, formData);
+    if (errs.length > 0) {
+      setErrors(errs);
+      return;
+    }
+    setErrors([]);
+    if (currentStepIndex < STEPS.length - 1) {
+      setCurrentStepIndex((i) => i + 1);
+    }
+  }
+
+  function goBack() {
+    setErrors([]);
+    if (currentStepIndex > 0) setCurrentStepIndex((i) => i - 1);
+  }
+
+  async function handleSubmit() {
+    setIsSubmitting(true);
+    try {
+      await apiPost("/api/onboarding/submit", {});
+      setSubmitSuccess(true);
+    } catch (err: unknown) {
+      setErrors([err instanceof Error ? err.message : "Submission failed"]);
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  if (submitSuccess) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50 p-4">
+        <Card className="max-w-md w-full p-8 text-center">
+          <CheckCircle className="w-16 h-16 text-green-500 mx-auto mb-4" />
+          <h1 className="text-2xl font-bold mb-2">Assessment in progress</h1>
+          <p className="text-gray-600 mb-6">
+            Your profile has been submitted. We are reviewing your information
+            and will notify you of the outcome shortly.
+          </p>
+          <Button onClick={() => router.push("/dashboard/tenant")}>
+            Back to Dashboard
+          </Button>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="max-w-2xl mx-auto px-4 py-8">
+        {/* Header */}
+        <div className="mb-8">
+          <h1 className="text-2xl font-bold text-gray-900">
+            Complete your profile
+          </h1>
+          <p className="text-gray-500 mt-1">
+            Step {currentStepIndex + 1} of {STEPS.length}
+          </p>
+        </div>
+
+        {/* Progress bar */}
+        <div className="mb-6">
+          <Progress value={progressPercent} className="h-2" />
+          <div className="flex justify-between mt-2">
+            {STEPS.map((step, idx) => {
+              const Icon = step.icon;
+              const isDone = idx < currentStepIndex;
+              const isActive = idx === currentStepIndex;
+              return (
+                <div
+                  key={step.id}
+                  className={`flex flex-col items-center gap-1 ${idx > currentStepIndex ? "opacity-40" : ""}`}
+                >
+                  <div
+                    className={`w-8 h-8 rounded-full flex items-center justify-center text-sm
+                      ${isActive ? "bg-blue-600 text-white" : isDone ? "bg-green-500 text-white" : "bg-gray-200 text-gray-500"}`}
+                  >
+                    {isDone ? <CheckCircle className="w-4 h-4" /> : <Icon className="w-4 h-4" />}
+                  </div>
+                  <span className="text-xs text-gray-500 hidden sm:block">
+                    {step.label}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Errors */}
+        {errors.length > 0 && (
+          <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg flex gap-2">
+            <AlertCircle className="w-5 h-5 text-red-500 shrink-0 mt-0.5" />
+            <ul className="text-sm text-red-700 space-y-0.5">
+              {errors.map((e, i) => (
+                <li key={i}>{e}</li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {/* Step content */}
+        <Card className="p-6 mb-6">
+          {currentStep.id === "personal_info" && (
+            <PersonalInfoStep
+              data={formData.personalInfo}
+              onChange={(f, v) => updateField("personalInfo", f, v)}
+            />
+          )}
+          {currentStep.id === "employment_info" && (
+            <EmploymentStep
+              data={formData.employmentInfo}
+              onChange={(f, v) => updateField("employmentInfo", f, v)}
+            />
+          )}
+          {currentStep.id === "documents" && (
+            <DocumentsStep
+              data={formData.documents}
+              onChange={(f, v) => updateField("documents", f, v)}
+            />
+          )}
+          {currentStep.id === "wallet" && (
+            <WalletStep
+              data={formData.walletInfo}
+              onChange={(f, v) => updateField("walletInfo", f, v)}
+              onSkip={() => {
+                updateField("walletInfo", "skipped", true);
+                setCurrentStepIndex((i) => i + 1);
+              }}
+            />
+          )}
+          {currentStep.id === "summary" && (
+            <SummaryStep data={formData} />
+          )}
+        </Card>
+
+        {/* Navigation */}
+        <div className="flex items-center justify-between">
+          <Button
+            variant="outline"
+            onClick={goBack}
+            disabled={currentStepIndex === 0}
+          >
+            <ChevronLeft className="w-4 h-4 mr-1" />
+            Back
+          </Button>
+
+          <div className="flex items-center gap-2">
+            {isSaving && (
+              <span className="text-xs text-gray-400 flex items-center gap-1">
+                <Loader2 className="w-3 h-3 animate-spin" />
+                Saving…
+              </span>
+            )}
+            {currentStep.id === "summary" ? (
+              <Button
+                onClick={handleSubmit}
+                disabled={isSubmitting}
+                className="bg-blue-600 hover:bg-blue-700"
+              >
+                {isSubmitting ? (
+                  <>
+                    <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                    Submitting…
+                  </>
+                ) : (
+                  "Submit for Assessment"
+                )}
+              </Button>
+            ) : (
+              <Button onClick={goNext} className="bg-blue-600 hover:bg-blue-700">
+                Next
+                <ChevronRight className="w-4 h-4 ml-1" />
+              </Button>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---- Step sub-components ----
+
+function PersonalInfoStep({
+  data,
+  onChange,
+}: {
+  data: PersonalInfo;
+  onChange: (f: keyof PersonalInfo, v: string) => void;
+}) {
+  return (
+    <div className="space-y-4">
+      <h2 className="text-lg font-semibold">Personal Information</h2>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Full Name <span className="text-red-500">*</span>
+          </label>
+          <Input
+            value={data.fullName}
+            onChange={(e) => onChange("fullName", e.target.value)}
+            placeholder="John Doe"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Date of Birth <span className="text-red-500">*</span>
+          </label>
+          <Input
+            type="date"
+            value={data.dateOfBirth}
+            onChange={(e) => onChange("dateOfBirth", e.target.value)}
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Phone <span className="text-red-500">*</span>
+          </label>
+          <Input
+            type="tel"
+            value={data.phone}
+            onChange={(e) => onChange("phone", e.target.value)}
+            placeholder="+234 800 000 0000"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            NIN <span className="text-gray-400 font-normal">(optional)</span>
+          </label>
+          <Input
+            type="password"
+            value={data.nin}
+            onChange={(e) => onChange("nin", e.target.value)}
+            placeholder="••••••••••••"
+            autoComplete="off"
+          />
+        </div>
+        <div className="sm:col-span-2">
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Residential Address <span className="text-red-500">*</span>
+          </label>
+          <Input
+            value={data.residentialAddress}
+            onChange={(e) => onChange("residentialAddress", e.target.value)}
+            placeholder="123 Main Street, Lagos"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            BVN <span className="text-gray-400 font-normal">(optional)</span>
+          </label>
+          <Input
+            type="password"
+            value={data.bvn}
+            onChange={(e) => onChange("bvn", e.target.value)}
+            placeholder="••••••••••••"
+            autoComplete="off"
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function EmploymentStep({
+  data,
+  onChange,
+}: {
+  data: EmploymentInfo;
+  onChange: (f: keyof EmploymentInfo, v: string) => void;
+}) {
+  return (
+    <div className="space-y-4">
+      <h2 className="text-lg font-semibold">Employment & Income</h2>
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-2">
+          Employment Status <span className="text-red-500">*</span>
+        </label>
+        <div className="flex gap-3 flex-wrap">
+          {(["employed", "self_employed", "unemployed"] as const).map((s) => (
+            <button
+              key={s}
+              type="button"
+              onClick={() => onChange("employmentStatus", s)}
+              className={`px-4 py-2 rounded-full border text-sm font-medium transition-colors
+                ${data.employmentStatus === s
+                  ? "bg-blue-600 text-white border-blue-600"
+                  : "border-gray-300 text-gray-700 hover:border-blue-400"
+                }`}
+            >
+              {s === "self_employed" ? "Self-Employed" : s.charAt(0).toUpperCase() + s.slice(1)}
+            </button>
+          ))}
+        </div>
+      </div>
+      {data.employmentStatus !== "unemployed" && (
+        <>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Employer / Business Name
+            </label>
+            <Input
+              value={data.employerName}
+              onChange={(e) => onChange("employerName", e.target.value)}
+              placeholder="Acme Corp"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Monthly Income (NGN)
+            </label>
+            <Input
+              type="number"
+              value={data.monthlyIncome}
+              onChange={(e) => onChange("monthlyIncome", e.target.value)}
+              placeholder="150000"
+              min={0}
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Proof of Employment Type
+            </label>
+            <Input
+              value={data.proofOfEmploymentType}
+              onChange={(e) => onChange("proofOfEmploymentType", e.target.value)}
+              placeholder="e.g. Pay slip, Employment letter"
+            />
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+function DocumentsStep({
+  data,
+  onChange,
+}: {
+  data: Documents;
+  onChange: (f: keyof Documents, v: string) => void;
+}) {
+  const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
+  const ALLOWED_TYPES = ["application/pdf", "image/jpeg", "image/png", "image/webp"];
+
+  function handleFileChange(
+    field: keyof Documents,
+    e: React.ChangeEvent<HTMLInputElement>
+  ) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    if (file.size > MAX_FILE_SIZE) {
+      alert("File must be under 10 MB");
+      e.target.value = "";
+      return;
+    }
+    if (!ALLOWED_TYPES.includes(file.type)) {
+      alert("Only PDF and image files are accepted");
+      e.target.value = "";
+      return;
+    }
+    // Store filename as key (actual upload handled by storage integration)
+    onChange(field, file.name);
+  }
+
+  return (
+    <div className="space-y-5">
+      <h2 className="text-lg font-semibold">Document Upload</h2>
+      <p className="text-sm text-gray-500">
+        Upload PDF or image files. Maximum 10 MB per file.
+      </p>
+      {(
+        [
+          { field: "bankStatementKey" as const, label: "Bank Statement (last 3 months)", required: false },
+          { field: "proofOfIncomeKey" as const, label: "Proof of Income (pay slip or business bank statement)", required: false },
+          { field: "governmentIdKey" as const, label: "Government-Issued ID", required: false },
+        ]
+      ).map(({ field, label }) => (
+        <div key={field}>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            {label}
+          </label>
+          <input
+            type="file"
+            accept=".pdf,.jpg,.jpeg,.png,.webp"
+            onChange={(e) => handleFileChange(field, e)}
+            className="block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:bg-blue-50 file:text-blue-700 hover:file:bg-blue-100"
+          />
+          {data[field] && (
+            <p className="text-xs text-green-600 mt-1">✓ {data[field]}</p>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function WalletStep({
+  data,
+  onChange,
+  onSkip,
+}: {
+  data: WalletInfo;
+  onChange: (f: keyof WalletInfo, v: string | boolean) => void;
+  onSkip: () => void;
+}) {
+  return (
+    <div className="space-y-4">
+      <h2 className="text-lg font-semibold">Wallet Connection</h2>
+      <div className="bg-blue-50 border border-blue-200 rounded-lg p-4 text-sm text-blue-800">
+        <strong>Why connect a wallet?</strong> A Stellar wallet lets you pay
+        rent in USDC, earn staking rewards, and access on-chain lease records.
+        This step is optional.
+      </div>
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-2">
+          Wallet Type
+        </label>
+        <div className="flex gap-3">
+          {(["stellar", "freighter"] as const).map((t) => (
+            <button
+              key={t}
+              type="button"
+              onClick={() => onChange("walletType", t)}
+              className={`px-4 py-2 rounded-full border text-sm font-medium transition-colors
+                ${data.walletType === t
+                  ? "bg-blue-600 text-white border-blue-600"
+                  : "border-gray-300 text-gray-700 hover:border-blue-400"}`}
+            >
+              {t.charAt(0).toUpperCase() + t.slice(1)}
+            </button>
+          ))}
+        </div>
+      </div>
+      {data.walletType && (
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Wallet Address
+          </label>
+          <Input
+            value={data.walletAddress}
+            onChange={(e) => onChange("walletAddress", e.target.value)}
+            placeholder="G..."
+            className="font-mono text-sm"
+          />
+        </div>
+      )}
+      <Button
+        variant="outline"
+        onClick={onSkip}
+        className="w-full text-gray-500"
+      >
+        <SkipForward className="w-4 h-4 mr-2" />
+        Skip this step
+      </Button>
+    </div>
+  );
+}
+
+function SummaryStep({ data }: { data: FormData }) {
+  const p = data.personalInfo;
+  const e = data.employmentInfo;
+  const d = data.documents;
+  const w = data.walletInfo;
+
+  return (
+    <div className="space-y-5">
+      <h2 className="text-lg font-semibold">Review Your Information</h2>
+      <div className="space-y-4">
+        <Section title="Personal Info">
+          <Row label="Full Name" value={p.fullName} />
+          <Row label="Date of Birth" value={p.dateOfBirth} />
+          <Row label="Phone" value={p.phone} />
+          <Row label="Address" value={p.residentialAddress} />
+          <Row label="NIN" value={p.nin ? "Provided" : "—"} />
+          <Row label="BVN" value={p.bvn ? "Provided" : "—"} />
+        </Section>
+        <Section title="Employment">
+          <Row
+            label="Status"
+            value={e.employmentStatus || "—"}
+          />
+          {e.employerName && <Row label="Employer" value={e.employerName} />}
+          {e.monthlyIncome && (
+            <Row
+              label="Monthly Income"
+              value={`₦${Number(e.monthlyIncome).toLocaleString()}`}
+            />
+          )}
+        </Section>
+        <Section title="Documents">
+          <Row label="Bank Statement" value={d.bankStatementKey || "Not uploaded"} />
+          <Row label="Proof of Income" value={d.proofOfIncomeKey || "Not uploaded"} />
+          <Row label="Government ID" value={d.governmentIdKey || "Not uploaded"} />
+        </Section>
+        <Section title="Wallet">
+          {w.skipped ? (
+            <p className="text-sm text-gray-500">Skipped</p>
+          ) : w.walletAddress ? (
+            <Row label="Address" value={`${w.walletAddress.slice(0, 8)}…`} />
+          ) : (
+            <p className="text-sm text-gray-500">Not connected</p>
+          )}
+        </Section>
+      </div>
+    </div>
+  );
+}
+
+function Section({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="border border-gray-200 rounded-lg p-4">
+      <h3 className="text-sm font-semibold text-gray-700 mb-2">{title}</h3>
+      <div className="space-y-1">{children}</div>
+    </div>
+  );
+}
+
+function Row({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex justify-between text-sm">
+      <span className="text-gray-500">{label}</span>
+      <span className="text-gray-900 font-medium truncate ml-4 max-w-[60%] text-right">
+        {value || "—"}
+      </span>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

This PR implements four issues covering smart contract governance, on-chain payment scheduling, landlord identity verification, and tenant onboarding:

### #926 — Contracts: Multi-Sig Admin Governance
- **`contracts/multisig_admin/`** — Full contract with `init`, `propose`, `approve`, `execute`, `cancel`, `get_proposal`, `list_proposals(status_filter)` 
- `OperationType` enum: ForceReleaseEscrow, ExecuteSlash, UpgradeContract, SetOracleStaleness, FreezeAccount, UpdateUpgradeDelay
- Approval storage via persistent `(proposal_id, Vec<Address>)` map; duplicate approval rejected
- Expiry check against `env.ledger().timestamp()`; `approval_count` tracked on proposal struct
- `list_proposals` accepts optional `ProposalStatus` filter
- **11 tests** — threshold flow, non-signer rejection, duplicate approval, expiry, cancellation, status filter
- `deal_escrow/src/access_control.rs` already wired to accept a contract address as admin (multisig_admin integration documented)

### #915 — Contracts: On-Chain Rent Payment Schedule
- **`contracts/rent_schedule/`** — Full contract with `init`, `create_schedule`, `record_payment`, `mark_overdue`, `waive_instalment`, `get_schedule` (sorted by instalment_number), `get_instalment`
- Pausable integration: `pause`/`unpause` admin functions; `record_payment` and `mark_overdue` blocked when paused
- `InstalmentStatus` transitions enforced: Pending→Paid, Pending→Overdue, any→Waived (once only)
- Events: `schedule_created`, `payment_recorded`, `instalment_overdue`, `instalment_waived`
- **11 tests** — all state transitions, duplicate schedule rejection, Waived→no-further-transition, pause/unpause, sorted order

### #905 — Backend: Landlord KYC & Identity Verification
- **KYC gate** in `admin.ts` `/whistleblower/listings/:id/approve` — checks landlord's KYC status is `approved` before listing can go live; returns `LANDLORD_KYC_REQUIRED` (403) otherwise
- **Re-submission limit** — `KycRepository.create()` uses upsert on re-submission and enforces `MAX_ATTEMPTS = 3`; returns `KYC_MAX_ATTEMPTS_REACHED` after limit
- **`attemptCount`** column added via migration `027_kyc_attempt_count.sql`; exposed as `attemptsRemaining` in GET /kyc/status responses
- **`GET /api/landlord/kyc-status`** — returns `status`, `attemptsRemaining`, `rejectionReason` for gating listing creation in the frontend
- **`POST /api/webhooks/kyc/:provider`** — provider-specific webhook with HMAC signature validation (timing-safe), tolerates unknown fields, processes async after 200 response
- All routes registered in `app.ts`

### #893 — Full-Stack: Tenant Onboarding Wizard
**Backend:**
- `POST /api/onboarding/draft` — upsert partial draft; auto-advances `completedSteps`; resumes on return
- `GET /api/onboarding/status` — returns `{ completedSteps, currentStep, submitted }`
- `POST /api/onboarding/submit` — marks submitted, enqueues `onboardingReview` job for underwriting pipeline
- Migration `028_onboarding_drafts.sql` — JSONB columns per step, `completed_steps[]`, `current_step`
- Zod schemas in `src/schemas/onboarding.ts` matching frontend step structure

**Frontend:**
- **`app/onboarding/page.tsx`** — 5-step wizard: Personal Info → Employment → Documents → Wallet (skippable) → Summary
- Progress bar spanning all steps with step icons
- 1s debounce auto-save to `/api/onboarding/draft` on every field change
- Resumes at last incomplete step on mount via `/api/onboarding/status`
- Step-level validation with inline errors before advance
- Document upload validates file type (PDF/image) and size (<10 MB)
- NIN/BVN masked inputs
- **`app/dashboard/tenant/page.tsx`** — "Complete your profile" banner with progress bar when onboarding incomplete; "Assessment in progress" banner after submission

## Test plan
- [ ] `cargo test -p multisig_admin` — 11/11 passing ✓
- [ ] `cargo test -p rent_schedule` — 11/11 passing ✓
- [ ] Backend TypeScript: zero new errors introduced (pre-existing errors unchanged) ✓
- [ ] Frontend TypeScript: zero new errors introduced ✓
- [ ] Listing approval blocked with 403 LANDLORD_KYC_REQUIRED when landlord KYC not approved
- [ ] KYC re-submission blocked after 3 attempts
- [ ] `/api/webhooks/kyc/:provider` returns 401 on invalid HMAC signature
- [ ] Onboarding wizard resumes at correct step on browser return
- [ ] Wallet step skippable without blocking submission
- [ ] Documents >10 MB rejected with clear error

Closes #926
Closes #915
Closes #905
Closes #893