### PR TITLE
fix: Docker Compose setup for local full-stack development

### DIFF
--- a/.env.docker
+++ b/.env.docker
@@ -1,0 +1,55 @@
+# Docker Compose environment for local full-stack development.
+# Usage: docker compose --env-file .env.docker up
+
+# --- Database ---
+DATABASE_URL=postgresql://postgres:postgres@postgres:5432/shelterflex_dev
+
+# --- Frontend ---
+NEXT_PUBLIC_BACKEND_URL=http://localhost:4000
+
+# --- Backend server ---
+PORT=4000
+NODE_ENV=development
+CORS_ORIGINS=http://localhost:3000
+
+# Required at startup (see backend/src/index.ts)
+WEBHOOK_KEY=dev-webhook-key-not-for-production
+
+# Encryption (min 32 characters per env schema)
+ENCRYPTION_KEY=dev-docker-encryption-key-32chars-min
+
+# Redis is optional; enable via docker-compose.override.yml
+REDIS_DISABLED=true
+REDIS_URL=redis://redis:6379
+
+# Rate limiting
+RATE_LIMIT_WINDOW_MS=60000
+RATE_LIMIT_MAX_REQUESTS=100
+
+# Soroban / Stellar (uses public testnet by default)
+SOROBAN_NETWORK=testnet
+SOROBAN_RPC_URL=https://soroban-testnet.stellar.org
+SOROBAN_NETWORK_PASSPHRASE=Test SDF Network ; September 2015
+
+# Custodial / wallet (dev defaults)
+CUSTODIAL_MODE_ENABLED=true
+CUSTODIAL_SIGNING_PAUSED=false
+
+# OTP delivery (console logs codes in dev)
+OTP_DELIVERY_PROVIDER=console
+
+# NGN → USDC conversion
+FX_RATE_NGN_PER_USDC=1600
+CONVERSION_PROVIDER=stub
+
+# Metrics & tracing (optional in dev)
+PROMETHEUS_PORT=9464
+OTEL_SERVICE_NAME=shelterflex-backend
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318/v1/traces
+OTEL_SAMPLING_RATIO=1.0
+
+# Indexer
+INDEXER_POLL_MS=5000
+
+# Audit logs
+AUDIT_LOG_DIR=./logs

--- a/README.md
+++ b/README.md
@@ -106,6 +106,53 @@ stellar contract build
 
 - See [`contracts/README.md`](contracts/README.md) for deployment instructions
 
+### Option D: Full Stack (Docker Compose)
+
+Run the frontend, backend, and PostgreSQL together with hot-reload — no local Node.js or Postgres install required.
+
+**Prerequisites:** [Docker Desktop 4+](https://www.docker.com/products/docker-desktop/) with ports **3000**, **4000**, and **5432** available.
+
+```bash
+# From the repository root
+docker compose --env-file .env.docker up --build
+```
+
+| Service | URL |
+|---|---|
+| Frontend | http://localhost:3000 |
+| Backend API | http://localhost:4000 |
+| Health check | http://localhost:4000/health |
+| PostgreSQL | `localhost:5432` (user/password/db: `postgres` / `postgres` / `shelterflex_dev`) |
+
+**Database migrations** run automatically when the backend starts. After adding new SQL files to `backend/migrations/`, restart the backend:
+
+```bash
+docker compose restart backend
+```
+
+**Optional services** (included via `docker-compose.override.yml`):
+
+- **Redis** — enables real Redis instead of the in-memory mock (`REDIS_DISABLED=false`)
+- **pgAdmin** — http://localhost:5050 (login: `admin@shelterflex.local` / `admin`)
+
+To include a local Soroban sandbox (Stellar Quickstart):
+
+```bash
+docker compose --env-file .env.docker --profile contracts up
+```
+
+Stellar Quickstart runs at http://localhost:8000.
+
+**Contract tests** still require a local Rust toolchain and Soroban CLI — WASM compilation is not run inside these dev containers. See [Option C](#option-c-contracts-only) for setup.
+
+**Tear down** (removes containers and volumes):
+
+```bash
+docker compose down -v
+```
+
+**Hot-reload:** Edit files under `frontend/` or `backend/` on the host; changes are picked up inside the containers via volume mounts. On macOS, file polling is enabled (`WATCHPACK_POLLING=true`) for reliable Next.js reloads.
+
 ## Contributing to Contracts
 
 For details on proposing and approving contract upgrades, see **[Contract Upgrade Process](docs/contracts/UPGRADE_PROCESS.md)**.

--- a/backend/Dockerfile.dev
+++ b/backend/Dockerfile.dev
@@ -1,0 +1,8 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+CMD ["npm", "run", "dev"]

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,35 @@
+# Optional dev-only services. Docker Compose merges this file automatically.
+# To skip these services: docker compose -f docker-compose.yml up
+
+services:
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  backend:
+    environment:
+      REDIS_DISABLED: "false"
+      REDIS_URL: redis://redis:6379
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+
+  pgadmin:
+    image: dpage/pgadmin4:latest
+    environment:
+      PGADMIN_DEFAULT_EMAIL: admin@shelterflex.local
+      PGADMIN_DEFAULT_PASSWORD: admin
+      PGADMIN_CONFIG_SERVER_MODE: "False"
+    ports:
+      - "5050:80"
+    depends_on:
+      postgres:
+        condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,62 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: shelterflex_dev
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d shelterflex_dev"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
+  backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile.dev
+    env_file:
+      - .env.docker
+    environment:
+      DATABASE_URL: postgresql://postgres:postgres@postgres:5432/shelterflex_dev
+    volumes:
+      - ./backend:/app
+      - /app/node_modules
+    ports:
+      - "4000:4000"
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile.dev
+    env_file:
+      - .env.docker
+    environment:
+      HOSTNAME: "0.0.0.0"
+      WATCHPACK_POLLING: "true"
+    volumes:
+      - ./frontend:/app
+      - /app/node_modules
+      - /app/.next
+    ports:
+      - "3000:3000"
+    depends_on:
+      - backend
+
+  stellar-quickstart:
+    profiles: ["contracts"]
+    image: stellar/quickstart:latest
+    command: --standalone --enable-soroban-rpc
+    ports:
+      - "8000:8000"
+
+volumes:
+  postgres_data:

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -1,0 +1,8 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+CMD ["npm", "run", "dev", "--", "-H", "0.0.0.0"]


### PR DESCRIPTION
## Summary
Adds a Docker Compose-based local development stack so contributors can run the full frontend + backend + PostgreSQL with a single command, without installing Node.js or Postgres locally.

## Purpose / Motivation
New contributors previously had to manually install and configure Node.js 20+, PostgreSQL, and project dependencies before running any part of the stack. This PR removes that friction: `docker compose --env-file .env.docker up` starts a hot-reloading dev environment on macOS or Linux.

## Changes Made
- **`docker-compose.yml`** — PostgreSQL 16 (health-checked), backend (`backend/Dockerfile.dev`), frontend (`frontend/Dockerfile.dev`), and optional Stellar Quickstart (`--profile contracts`)
- **`backend/Dockerfile.dev`** / **`frontend/Dockerfile.dev`** — Node 20 Alpine images with cached `npm ci`; source mounted as volumes with anonymous `node_modules` shadow volumes
- **`.env.docker`** — Pre-configured dev environment variables (database URL, backend URL, webhook key, encryption key, etc.)
- **`docker-compose.override.yml`** — Optional Redis and pgAdmin for extended local dev
- **`README.md`** — New "Option D: Full Stack (Docker Compose)" section with setup, migrations, contracts profile, and teardown instructions

## How to Test
1. Ensure Docker Desktop 4+ is running and ports 3000, 4000, and 5432 are free.
2. From the repo root: `docker compose --env-file .env.docker up --build`
3. Wait for all services to become healthy; verify:
   - Frontend loads at http://localhost:3000
   - `curl http://localhost:4000/health` returns 200
4. Edit a `.tsx` file under `frontend/` — browser should hot-reload without rebuilding the container.
5. Edit a `.ts` file under `backend/` — backend should restart via `tsx watch`.
6. Run `docker compose down -v` — all containers and volumes should be removed cleanly.
7. (Optional) `docker compose --env-file .env.docker --profile contracts up` — Stellar Quickstart on port 8000.
8. (Optional) With override: Redis on 6379, pgAdmin on http://localhost:5050.

## Breaking Changes
None.

## Related Issues
Closes Shelterflex/monorepo#930