### PR TITLE
feat(backend): AI-based tenant risk scoring integration

### DIFF
--- a/backend/migrations/033_underwriting_ai_risk_score.sql
+++ b/backend/migrations/033_underwriting_ai_risk_score.sql
@@ -1,0 +1,7 @@
+-- AI risk score on underwriting decision traces (advisory signal audit trail)
+
+ALTER TABLE underwriting_decision_traces
+  ADD COLUMN IF NOT EXISTS ai_risk_score JSONB;
+
+COMMENT ON COLUMN underwriting_decision_traces.ai_risk_score IS
+  'Optional AI tenant risk score (score, confidence, riskBand, contributingFactors, modelVersion)';

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "shelterflex-backend",
       "version": "0.1.0",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.57.0",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/exporter-prometheus": "^0.214.0",
         "@opentelemetry/exporter-trace-otlp-http": "^0.214.0",
@@ -67,6 +68,15 @@
       "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
       "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==",
       "license": "MIT"
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.57.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.57.0.tgz",
+      "integrity": "sha512-z5LMy0MWu0+w2hflUgj4RlJr1R+0BxKXL7ldXTO8FasU8fu599STghO+QKwId2dAD0d464aHtU+ChWuRHw4FNw==",
+      "license": "MIT",
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -1017,6 +1027,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -2156,6 +2167,7 @@
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -3200,6 +3212,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
       "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3356,6 +3369,7 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -3657,6 +3671,7 @@
       "integrity": "sha512-CGJ25bc8fRi8Lod/3GHSvXRKi7nBo3kxh0ApW4yCjmrWmRmlT53B5E08XRSZRliygG0aVNxLrBEqPYdz/KcCtQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.0.18",
         "fflate": "^0.8.2",
@@ -3718,6 +3733,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3779,6 +3795,7 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -4465,6 +4482,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
@@ -4895,6 +4913,7 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5237,6 +5256,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
       "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -6360,6 +6380,7 @@
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -6702,6 +6723,7 @@
       "integrity": "sha512-UczzB+0nnwGotYSgllfARAqWCJ5e/skuV2K/l+Zyck/H6pJIhLXuBnz+6vn2i211o7DtbE78HQtsYEKICHGI+g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mobx"
@@ -7362,6 +7384,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -7542,6 +7565,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7908,6 +7932,7 @@
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7918,6 +7943,7 @@
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -8735,6 +8761,7 @@
       "integrity": "sha512-ADu2dF53esUzzM4I0ewxhxFtsDd6v4V6dNkg3vG0iFKhnt06sJneTZnRvujAosZwW0XD58IKgGMQoqri4wHRqg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emotion/is-prop-valid": "1.4.0",
         "css-to-react-native": "3.2.0",
@@ -9098,6 +9125,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -9164,6 +9192,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9301,6 +9330,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -9376,6 +9406,7 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",

--- a/backend/package.json
+++ b/backend/package.json
@@ -22,6 +22,7 @@
     "test:integration:watch": "SOROBAN_INTEGRATION_TESTS=true vitest src/soroban/real-adapter.integration.test.ts"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.57.0",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/exporter-prometheus": "^0.214.0",
     "@opentelemetry/exporter-trace-otlp-http": "^0.214.0",
@@ -41,9 +42,9 @@
     "express": "^4.19.2",
     "express-rate-limit": "^8.2.1",
     "ioredis": "^5.10.1",
-    "multer": "^2.0.2",
     "lru-cache": "^11.2.7",
     "morgan": "^1.10.0",
+    "multer": "^2.0.2",
     "pg": "^8.19.0",
     "prom-client": "^15.1.3",
     "resend": "^6.9.4",
@@ -56,8 +57,8 @@
     "@redocly/cli": "^1.34.0",
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
-    "@types/multer": "^1.4.12",
     "@types/morgan": "^1.9.9",
+    "@types/multer": "^1.4.12",
     "@types/node": "^22.19.15",
     "@types/pg": "^8.18.0",
     "@types/supertest": "^7.2.0",

--- a/backend/src/config/aiScoring.ts
+++ b/backend/src/config/aiScoring.ts
@@ -1,0 +1,36 @@
+/**
+ * AI tenant risk scoring configuration (env-driven).
+ */
+
+export type AiScoringProviderName = 'claude' | 'stub'
+
+export interface AiScoringConfig {
+  enabled: boolean
+  provider: AiScoringProviderName
+  model: string
+  cacheTtlMs: number
+  anthropicApiKey?: string
+}
+
+const DEFAULT_MODEL = 'claude-sonnet-4-6'
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000
+
+function readBool(name: string, fallback: boolean): boolean {
+  const raw = process.env[name]
+  if (raw === undefined || raw === '') return fallback
+  return raw === '1' || raw.toLowerCase() === 'true'
+}
+
+export function getAiScoringConfig(): AiScoringConfig {
+  const providerRaw = (process.env.AI_SCORING_PROVIDER ?? 'stub').toLowerCase()
+  const provider: AiScoringProviderName =
+    providerRaw === 'claude' ? 'claude' : 'stub'
+
+  return {
+    enabled: readBool('AI_SCORING_ENABLED', false),
+    provider,
+    model: process.env.AI_SCORING_MODEL ?? DEFAULT_MODEL,
+    cacheTtlMs: CACHE_TTL_MS,
+    anthropicApiKey: process.env.ANTHROPIC_API_KEY,
+  }
+}

--- a/backend/src/models/underwritingDecisionTrace.ts
+++ b/backend/src/models/underwritingDecisionTrace.ts
@@ -4,6 +4,7 @@
  */
 
 import { UnderwritingDecision, RuleEvaluation } from '../services/underwritingRuleEngine.js'
+import type { AiRiskScoreResult } from '../services/aiRiskScoreProvider.js'
 
 export interface UnderwritingDecisionTrace {
   id: string
@@ -15,6 +16,7 @@ export interface UnderwritingDecisionTrace {
   triggeredRules: RuleEvaluation[]
   decisionReason: string
   ruleConfigVersion: string
+  aiRiskScore?: AiRiskScoreResult
   evaluatedAt: string
   createdAt: string
 }
@@ -28,6 +30,7 @@ export interface CreateUnderwritingDecisionTraceInput {
   triggeredRules: RuleEvaluation[]
   decisionReason: string
   ruleConfigVersion: string
+  aiRiskScore?: AiRiskScoreResult
   evaluatedAt: string
 }
 

--- a/backend/src/models/underwritingDecisionTraceStore.ts
+++ b/backend/src/models/underwritingDecisionTraceStore.ts
@@ -83,8 +83,8 @@ export class PostgresUnderwritingDecisionTraceStore implements UnderwritingDecis
     const result = await pool.query(
       `INSERT INTO underwriting_decision_traces (
         application_id, user_id, decision, total_score, max_score,
-        triggered_rules, decision_reason, rule_config_version, evaluated_at, created_at
-      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, NOW())
+        triggered_rules, decision_reason, rule_config_version, ai_risk_score, evaluated_at, created_at
+      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, NOW())
       RETURNING *`,
       [
         input.applicationId,
@@ -95,6 +95,7 @@ export class PostgresUnderwritingDecisionTraceStore implements UnderwritingDecis
         JSON.stringify(input.triggeredRules),
         input.decisionReason,
         input.ruleConfigVersion,
+        input.aiRiskScore ? JSON.stringify(input.aiRiskScore) : null,
         input.evaluatedAt,
       ],
     )
@@ -183,6 +184,7 @@ export class PostgresUnderwritingDecisionTraceStore implements UnderwritingDecis
       triggeredRules: row.triggered_rules,
       decisionReason: row.decision_reason,
       ruleConfigVersion: row.rule_config_version,
+      aiRiskScore: row.ai_risk_score ?? undefined,
       evaluatedAt: row.evaluated_at.toISOString(),
       createdAt: row.created_at.toISOString(),
     }

--- a/backend/src/services/aiRiskScoreProvider.ts
+++ b/backend/src/services/aiRiskScoreProvider.ts
@@ -1,0 +1,57 @@
+/**
+ * AI tenant risk scoring provider interface and shared types.
+ */
+
+export type AiRiskBand = 'low' | 'medium' | 'high' | 'very_high'
+
+export interface TenantRiskProfile {
+  tenantId: string
+  dataVersion: number
+  monthlyIncome: number
+  incomeToRentRatio: number
+  employmentTenureMonths: number
+  bankMetrics: {
+    averageBalance: number
+    nsfCount: number
+    incomeRegularity: number
+  }
+  existingDebtObligations: number
+}
+
+export interface AiRiskScoreResult {
+  score: number
+  confidence: number
+  riskBand: AiRiskBand
+  contributingFactors: string[]
+  modelVersion: string
+}
+
+export interface AiRiskScoreProvider {
+  score(profile: TenantRiskProfile): Promise<AiRiskScoreResult>
+}
+
+export function cacheKeyForProfile(profile: TenantRiskProfile): string {
+  return `${profile.tenantId}:${profile.dataVersion}`
+}
+
+export function normalizeAiRiskScoreResult(raw: {
+  score: number
+  confidence: number
+  riskBand: string
+  contributingFactors: string[]
+  modelVersion: string
+}): AiRiskScoreResult {
+  const score = Math.max(0, Math.min(100, Number(raw.score)))
+  const confidence = Math.max(0, Math.min(1, Number(raw.confidence)))
+  const riskBand = raw.riskBand as AiRiskBand
+  if (!['low', 'medium', 'high', 'very_high'].includes(riskBand)) {
+    throw new Error(`Invalid AI risk band: ${raw.riskBand}`)
+  }
+  return {
+    score,
+    confidence,
+    riskBand,
+    contributingFactors: raw.contributingFactors,
+    modelVersion: raw.modelVersion,
+  }
+}

--- a/backend/src/services/aiRiskScoring.integration.test.ts
+++ b/backend/src/services/aiRiskScoring.integration.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { tenantOnboardingDataStore } from '../models/tenantOnboardingDataStore.js'
+import { tenantApplicationStore } from '../models/tenantApplicationStore.js'
+import { underwritingDecisionTraceStore } from '../models/underwritingDecisionTraceStore.js'
+import { UnderwritingService } from './underwritingService.js'
+import { UnderwritingRuleEngine, DEFAULT_RULE_CONFIG } from './underwritingRuleEngine.js'
+import {
+  AiRiskScoringService,
+  applyAiRiskOverride,
+  shouldRequestAiScore,
+} from './aiRiskScoringService.js'
+import { StubAiRiskScoreProvider } from './stubAiRiskScoreProvider.js'
+import type { AiRiskScoreProvider, AiRiskScoreResult, TenantRiskProfile } from './aiRiskScoreProvider.js'
+
+const TENANT = 'ai-risk-tenant'
+
+function seedStrongOnboarding(incomeToRent = 5) {
+  const monthlyRent = 100_000
+  tenantOnboardingDataStore.upsert(TENANT, {
+    statedMonthlyIncome: monthlyRent * incomeToRent,
+    monthlyRent,
+    employmentStatus: 'employed',
+    employerName: 'Acme Corp',
+    employmentProofText: 'Employment letter from Acme Corp',
+    bankStatementLines: [
+      { date: '2026-01-01', description: 'Salary payroll credit', amount: monthlyRent * incomeToRent },
+      { date: '2026-02-01', description: 'Salary payroll credit', amount: monthlyRent * incomeToRent },
+      { date: '2026-03-01', description: 'Salary payroll credit', amount: monthlyRent * incomeToRent },
+    ],
+  })
+}
+
+class VeryHighRiskMockProvider implements AiRiskScoreProvider {
+  async score(_profile: TenantRiskProfile): Promise<AiRiskScoreResult> {
+    return {
+      score: 92,
+      confidence: 0.92,
+      riskBand: 'very_high',
+      contributingFactors: ['mock very high risk'],
+      modelVersion: 'mock-v1',
+    }
+  }
+}
+
+describe('AI risk scoring integration', () => {
+  beforeEach(async () => {
+    tenantOnboardingDataStore.clear()
+    await (tenantApplicationStore as { clear?: () => Promise<void> }).clear?.()
+    await (underwritingDecisionTraceStore as { clear?: () => Promise<void> }).clear?.()
+    vi.stubEnv('AI_SCORING_ENABLED', 'true')
+    vi.stubEnv('AI_SCORING_PROVIDER', 'stub')
+  })
+
+  it('uses stub provider without external API', async () => {
+    seedStrongOnboarding(5)
+    const aiService = new AiRiskScoringService(new StubAiRiskScoreProvider(), {
+      enabled: true,
+      provider: 'stub',
+      model: 'claude-sonnet-4-6',
+      cacheTtlMs: 86_400_000,
+    })
+    const underwriting = new UnderwritingService(
+      new UnderwritingRuleEngine(DEFAULT_RULE_CONFIG),
+      undefined,
+      aiService,
+    )
+
+    const application = await tenantApplicationStore.create({
+      userId: TENANT,
+      propertyId: 1,
+      annualRent: 1_200_000,
+      deposit: 360_000,
+      duration: 12,
+      hasAgreedToTerms: true,
+    })
+
+    const result = await underwriting.evaluateApplication({
+      applicationId: application.applicationId,
+    })
+
+    expect(result.aiRiskScore?.riskBand).toBe('low')
+    const traces = await underwritingDecisionTraceStore.findByApplicationId(application.applicationId)
+    expect(traces[0].aiRiskScore?.modelVersion).toContain('stub')
+  })
+
+  it('overrides APPROVE to REVIEW when AI is very_high with high confidence', async () => {
+    seedStrongOnboarding(5)
+    const aiService = new AiRiskScoringService(new VeryHighRiskMockProvider(), {
+      enabled: true,
+      provider: 'stub',
+      model: 'claude-sonnet-4-6',
+      cacheTtlMs: 86_400_000,
+    })
+    const underwriting = new UnderwritingService(
+      new UnderwritingRuleEngine(DEFAULT_RULE_CONFIG),
+      undefined,
+      aiService,
+    )
+
+    const application = await tenantApplicationStore.create({
+      userId: TENANT,
+      propertyId: 1,
+      annualRent: 1_200_000,
+      deposit: 360_000,
+      duration: 12,
+      hasAgreedToTerms: true,
+    })
+
+    const result = await underwriting.evaluateApplication({
+      applicationId: application.applicationId,
+      paymentHistory: {
+        onTimePaymentRate: 0.98,
+        missedPayments: 0,
+        totalPayments: 24,
+      },
+    })
+
+    expect(result.decision).toBe('REVIEW')
+    expect(result.result.decisionReason).toContain('escalated to manual review')
+    const traces = await underwritingDecisionTraceStore.findByApplicationId(application.applicationId)
+    expect(traces[0].decision).toBe('REVIEW')
+    expect(traces[0].aiRiskScore?.riskBand).toBe('very_high')
+  })
+
+  it('does not request AI scoring when deterministic decision is REJECT', async () => {
+    seedStrongOnboarding(1.2)
+    const scoreSpy = vi.fn()
+    const provider: AiRiskScoreProvider = {
+      score: scoreSpy,
+    }
+    const aiService = new AiRiskScoringService(provider, {
+      enabled: true,
+      provider: 'stub',
+      model: 'claude-sonnet-4-6',
+      cacheTtlMs: 86_400_000,
+    })
+    const underwriting = new UnderwritingService(
+      new UnderwritingRuleEngine(DEFAULT_RULE_CONFIG),
+      undefined,
+      aiService,
+    )
+
+    const application = await tenantApplicationStore.create({
+      userId: TENANT,
+      propertyId: 1,
+      annualRent: 1_200_000,
+      deposit: 10_000,
+      duration: 12,
+      hasAgreedToTerms: true,
+    })
+
+    await underwriting.evaluateApplication({ applicationId: application.applicationId })
+    expect(scoreSpy).not.toHaveBeenCalled()
+  })
+
+  it('returns cached score without second provider call within TTL', async () => {
+    seedStrongOnboarding(2.5)
+    const scoreSpy = vi.fn(async (profile: TenantRiskProfile) => {
+      const stub = new StubAiRiskScoreProvider()
+      return stub.score(profile)
+    })
+    const provider: AiRiskScoreProvider = { score: scoreSpy }
+    const aiService = new AiRiskScoringService(provider, {
+      enabled: true,
+      provider: 'stub',
+      model: 'claude-sonnet-4-6',
+      cacheTtlMs: 86_400_000,
+    })
+
+    const profile = aiService.buildProfile(TENANT)!
+    await aiService.scoreProfile(profile)
+    await aiService.scoreProfile(profile)
+
+    expect(scoreSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('applyAiRiskOverride escalates only for very_high + confidence > 0.85', () => {
+    expect(shouldRequestAiScore('REJECT')).toBe(false)
+    expect(shouldRequestAiScore('APPROVE')).toBe(true)
+
+    const low = applyAiRiskOverride('APPROVE', {
+      score: 20,
+      confidence: 0.95,
+      riskBand: 'low',
+      contributingFactors: [],
+      modelVersion: 'x',
+    })
+    expect(low.decision).toBe('APPROVE')
+    expect(low.overridden).toBe(false)
+
+    const escalated = applyAiRiskOverride('APPROVE', {
+      score: 90,
+      confidence: 0.9,
+      riskBand: 'very_high',
+      contributingFactors: [],
+      modelVersion: 'x',
+    })
+    expect(escalated.decision).toBe('REVIEW')
+    expect(escalated.overridden).toBe(true)
+  })
+})

--- a/backend/src/services/aiRiskScoringService.ts
+++ b/backend/src/services/aiRiskScoringService.ts
@@ -1,0 +1,137 @@
+/**
+ * Orchestrates AI risk scoring: provider selection, 24h cache, override rules.
+ */
+
+import { LRUCache } from 'lru-cache'
+import type { UnderwritingDecision } from './underwritingRuleEngine.js'
+import { getAiScoringConfig, type AiScoringConfig } from '../config/aiScoring.js'
+import {
+  type AiRiskScoreProvider,
+  type AiRiskScoreResult,
+  type TenantRiskProfile,
+  cacheKeyForProfile,
+} from './aiRiskScoreProvider.js'
+import { StubAiRiskScoreProvider } from './stubAiRiskScoreProvider.js'
+import { OpenAiRiskScoreProvider } from './openAiRiskScoreProvider.js'
+import { buildTenantRiskProfile } from './tenantRiskProfileBuilder.js'
+
+export interface AiRiskOverrideResult {
+  decision: UnderwritingDecision
+  overridden: boolean
+  aiRiskScore?: AiRiskScoreResult
+}
+
+export function shouldRequestAiScore(decision: UnderwritingDecision): boolean {
+  return decision !== 'REJECT'
+}
+
+export function applyAiRiskOverride(
+  decision: UnderwritingDecision,
+  aiResult?: AiRiskScoreResult,
+): AiRiskOverrideResult {
+  if (
+    decision === 'APPROVE' &&
+    aiResult?.riskBand === 'very_high' &&
+    aiResult.confidence > 0.85
+  ) {
+    return { decision: 'REVIEW', overridden: true, aiRiskScore: aiResult }
+  }
+  return { decision, overridden: false, aiRiskScore: aiResult }
+}
+
+export function createAiRiskScoreProvider(config: AiScoringConfig = getAiScoringConfig()): AiRiskScoreProvider {
+  if (config.provider === 'claude') {
+    return new OpenAiRiskScoreProvider(config)
+  }
+  return new StubAiRiskScoreProvider()
+}
+
+export class AiRiskScoringService {
+  private config: AiScoringConfig
+  private provider: AiRiskScoreProvider
+  private cache: LRUCache<string, AiRiskScoreResult>
+
+  constructor(
+    provider?: AiRiskScoreProvider,
+    config: AiScoringConfig = getAiScoringConfig(),
+  ) {
+    this.config = config
+    this.provider = provider ?? createAiRiskScoreProvider(config)
+    this.cache = new LRUCache<string, AiRiskScoreResult>({
+      max: 10_000,
+      ttl: config.cacheTtlMs,
+    })
+  }
+
+  isEnabled(): boolean {
+    return this.config.enabled
+  }
+
+  buildProfile(tenantId: string): TenantRiskProfile | undefined {
+    return buildTenantRiskProfile(tenantId)
+  }
+
+  async scoreProfile(profile: TenantRiskProfile): Promise<AiRiskScoreResult> {
+    const key = cacheKeyForProfile(profile)
+    const cached = this.cache.get(key)
+    if (cached) return cached
+
+    const result = await this.provider.score(profile)
+    this.cache.set(key, result)
+    return result
+  }
+
+  /** @internal test helper */
+  clearCache(): void {
+    this.cache.clear()
+  }
+
+  /**
+   * Score tenant when enabled and deterministic decision is not REJECT.
+   */
+  async evaluateForUnderwriting(
+    tenantId: string,
+    deterministicDecision: UnderwritingDecision,
+  ): Promise<AiRiskOverrideResult> {
+    if (!this.config.enabled || !shouldRequestAiScore(deterministicDecision)) {
+      return { decision: deterministicDecision, overridden: false }
+    }
+
+    const profile = this.buildProfile(tenantId)
+    if (!profile) {
+      return { decision: deterministicDecision, overridden: false }
+    }
+
+    const aiResult = await this.scoreProfile(profile)
+    const override = applyAiRiskOverride(deterministicDecision, aiResult)
+
+    if (override.overridden) {
+      console.info(
+        JSON.stringify({
+          event: 'ai_risk_override',
+          tenantId,
+          aiScore: aiResult.score,
+          aiRiskBand: aiResult.riskBand,
+          aiConfidence: aiResult.confidence,
+          fromDecision: deterministicDecision,
+          toDecision: override.decision,
+        }),
+      )
+    } else if (aiResult) {
+      console.info(
+        JSON.stringify({
+          event: 'ai_risk_scored',
+          tenantId,
+          aiScore: aiResult.score,
+          aiRiskBand: aiResult.riskBand,
+          aiConfidence: aiResult.confidence,
+          deterministicDecision,
+        }),
+      )
+    }
+
+    return override
+  }
+}
+
+export const aiRiskScoringService = new AiRiskScoringService()

--- a/backend/src/services/openAiRiskScoreProvider.ts
+++ b/backend/src/services/openAiRiskScoreProvider.ts
@@ -1,0 +1,72 @@
+/**
+ * Claude-based AI risk scorer (Anthropic SDK, structured tool output).
+ */
+
+import Anthropic from '@anthropic-ai/sdk'
+import type { AiScoringConfig } from '../config/aiScoring.js'
+import {
+  RISK_SCORING_SYSTEM_PROMPT,
+  RISK_SCORING_TOOL_NAME,
+  RISK_SCORING_TOOL_INPUT_SCHEMA,
+  buildRiskScoringUserMessage,
+} from '../templates/ai/riskScoringPrompt.js'
+import type {
+  AiRiskScoreProvider,
+  AiRiskScoreResult,
+  TenantRiskProfile,
+} from './aiRiskScoreProvider.js'
+import { normalizeAiRiskScoreResult } from './aiRiskScoreProvider.js'
+
+export class OpenAiRiskScoreProvider implements AiRiskScoreProvider {
+  private client: Anthropic
+  private model: string
+
+  constructor(config: AiScoringConfig) {
+    if (!config.anthropicApiKey) {
+      throw new Error('ANTHROPIC_API_KEY is required when AI_SCORING_PROVIDER=claude')
+    }
+    this.client = new Anthropic({ apiKey: config.anthropicApiKey })
+    this.model = config.model
+  }
+
+  async score(profile: TenantRiskProfile): Promise<AiRiskScoreResult> {
+    const response = await this.client.messages.create({
+      model: this.model,
+      max_tokens: 1024,
+      system: [
+        {
+          type: 'text',
+          text: RISK_SCORING_SYSTEM_PROMPT,
+          cache_control: { type: 'ephemeral' },
+        },
+      ],
+      messages: [{ role: 'user', content: buildRiskScoringUserMessage(profile) }],
+      tools: [
+        {
+          name: RISK_SCORING_TOOL_NAME,
+          description: 'Structured tenant risk assessment output',
+          input_schema: RISK_SCORING_TOOL_INPUT_SCHEMA,
+        },
+      ],
+      tool_choice: { type: 'tool', name: RISK_SCORING_TOOL_NAME },
+    })
+
+    const toolBlock = response.content.find(
+      (block): block is Anthropic.Messages.ToolUseBlock => block.type === 'tool_use',
+    )
+    if (!toolBlock || toolBlock.name !== RISK_SCORING_TOOL_NAME) {
+      throw new Error('Claude risk scoring response missing expected tool_use block')
+    }
+
+    const input = toolBlock.input as Record<string, unknown>
+    return normalizeAiRiskScoreResult({
+      score: Number(input.score),
+      confidence: Number(input.confidence),
+      riskBand: String(input.riskBand),
+      contributingFactors: Array.isArray(input.contributingFactors)
+        ? (input.contributingFactors as string[])
+        : [],
+      modelVersion: String(input.modelVersion ?? this.model),
+    })
+  }
+}

--- a/backend/src/services/stubAiRiskScoreProvider.ts
+++ b/backend/src/services/stubAiRiskScoreProvider.ts
@@ -1,0 +1,46 @@
+/**
+ * Deterministic AI risk scorer for tests and local dev (no external API).
+ */
+
+import type {
+  AiRiskScoreProvider,
+  AiRiskScoreResult,
+  TenantRiskProfile,
+} from './aiRiskScoreProvider.js'
+import { normalizeAiRiskScoreResult } from './aiRiskScoreProvider.js'
+
+const STUB_MODEL_VERSION = 'stub-income-ratio-v1'
+
+export class StubAiRiskScoreProvider implements AiRiskScoreProvider {
+  async score(profile: TenantRiskProfile): Promise<AiRiskScoreResult> {
+    const ratio = profile.incomeToRentRatio
+    let score: number
+    let riskBand: 'low' | 'medium' | 'high' | 'very_high'
+    const factors: string[] = [`income-to-rent ratio ${ratio.toFixed(2)}`]
+
+    if (ratio >= 3) {
+      score = 18
+      riskBand = 'low'
+      factors.push('strong income cushion vs rent')
+    } else if (ratio >= 2) {
+      score = 42
+      riskBand = 'medium'
+    } else if (ratio >= 1.5) {
+      score = 68
+      riskBand = 'high'
+      factors.push('thin income buffer')
+    } else {
+      score = 88
+      riskBand = 'very_high'
+      factors.push('income below safe rent multiple')
+    }
+
+    return normalizeAiRiskScoreResult({
+      score,
+      confidence: 0.9,
+      riskBand,
+      contributingFactors: factors,
+      modelVersion: STUB_MODEL_VERSION,
+    })
+  }
+}

--- a/backend/src/services/tenantRiskProfileBuilder.ts
+++ b/backend/src/services/tenantRiskProfileBuilder.ts
@@ -1,0 +1,59 @@
+/**
+ * Builds TenantRiskProfile from onboarding verification data.
+ */
+
+import { tenantOnboardingDataStore } from '../models/tenantOnboardingDataStore.js'
+import { analyzeBankStatement } from './bankStatementAnalysis.js'
+import type { TenantRiskProfile } from './aiRiskScoreProvider.js'
+
+function employmentTenureMonths(status: string): number {
+  const s = status.toLowerCase()
+  if (s === 'unemployed' || s === 'none') return 0
+  if (s === 'self_employed') return 12
+  if (s === 'employed') return 24
+  return 6
+}
+
+function estimateMonthlyDebtObligations(
+  recurringDebitCount: number,
+  averageMonthlyBalance: number,
+): number {
+  if (recurringDebitCount <= 0) return 0
+  const perDebit = averageMonthlyBalance > 0 ? averageMonthlyBalance * 0.05 : 15_000
+  return Math.round(recurringDebitCount * perDebit)
+}
+
+export function buildTenantRiskProfile(tenantId: string): TenantRiskProfile | undefined {
+  const data = tenantOnboardingDataStore.findByTenantId(tenantId)
+  if (!data) return undefined
+
+  const monthlyIncome = data.statedMonthlyIncome
+  const incomeToRentRatio =
+    data.monthlyRent > 0 ? monthlyIncome / data.monthlyRent : 0
+
+  const analysis = analyzeBankStatement(data.bankStatementLines)
+  const recurringDebitPattern = /\b(loan|emi|repayment|debit order)\b/i
+  let recurringDebitCount = 0
+  for (const line of data.bankStatementLines) {
+    if (line.amount < 0 && recurringDebitPattern.test(line.description)) {
+      recurringDebitCount += 1
+    }
+  }
+
+  return {
+    tenantId,
+    dataVersion: data.dataVersion,
+    monthlyIncome,
+    incomeToRentRatio,
+    employmentTenureMonths: employmentTenureMonths(data.employmentStatus),
+    bankMetrics: {
+      averageBalance: analysis.averageMonthlyBalance,
+      nsfCount: analysis.nsfCount,
+      incomeRegularity: analysis.incomeRegularityScore,
+    },
+    existingDebtObligations: estimateMonthlyDebtObligations(
+      recurringDebitCount,
+      analysis.averageMonthlyBalance,
+    ),
+  }
+}

--- a/backend/src/services/underwritingService.ts
+++ b/backend/src/services/underwritingService.ts
@@ -20,6 +20,11 @@ import {
 import { decisionFromCreditBand } from "../models/tenantCreditScore.js";
 import { creditBureauService } from "./creditBureauService.js";
 import type { TenantCreditScore } from "../models/tenantCreditScore.js";
+import {
+  AiRiskScoringService,
+  aiRiskScoringService,
+} from "./aiRiskScoringService.js";
+import type { AiRiskScoreResult } from "./aiRiskScoreProvider.js";
 
 export interface UnderwritingEvaluationInput {
   applicationId: string;
@@ -39,6 +44,7 @@ export interface UnderwritingEvaluationOutput {
   creditScore?: TenantCreditScore;
   creditBandDecision?: string;
   externalCreditScore?: number;
+  aiRiskScore?: AiRiskScoreResult;
   evaluatedAt: string;
 }
 
@@ -69,14 +75,17 @@ function mergeUnderwritingDecisions(
 export class UnderwritingService {
   private ruleEngine: UnderwritingRuleEngine;
   private creditScoring: TenantCreditScoringService;
+  private aiRiskScoring: AiRiskScoringService;
 
   constructor(
     ruleEngine?: UnderwritingRuleEngine,
     creditScoring?: TenantCreditScoringService,
+    aiRiskScoring?: AiRiskScoringService,
   ) {
     this.ruleEngine =
       ruleEngine || new UnderwritingRuleEngine(DEFAULT_RULE_CONFIG);
     this.creditScoring = creditScoring || tenantCreditScoringService;
+    this.aiRiskScoring = aiRiskScoring || aiRiskScoringService;
   }
 
   /**
@@ -132,15 +141,29 @@ export class UnderwritingService {
 
     const result = this.ruleEngine.evaluate(context);
 
-    const finalDecision =
+    let finalDecision =
       creditDecision !== undefined
         ? mergeUnderwritingDecisions(creditDecision, result.decision)
         : result.decision;
 
-    const decisionReason =
+    const aiEvaluation = await this.aiRiskScoring.evaluateForUnderwriting(
+      application.userId,
+      finalDecision,
+    );
+    finalDecision = aiEvaluation.decision;
+
+    let decisionReason =
       creditScore !== undefined
         ? `${result.decisionReason}; credit band ${creditScore.band} (${creditScore.score}/1000) → ${creditDecision}, final ${finalDecision}`
         : result.decisionReason;
+
+    if (aiEvaluation.aiRiskScore) {
+      const ai = aiEvaluation.aiRiskScore;
+      decisionReason += `; AI risk ${ai.riskBand} (score ${ai.score}, confidence ${ai.confidence})`
+      if (aiEvaluation.overridden) {
+        decisionReason += ' → escalated to manual review'
+      }
+    }
 
     await underwritingDecisionTraceStore.create({
       applicationId: application.applicationId,
@@ -151,6 +174,7 @@ export class UnderwritingService {
       triggeredRules: result.triggeredRules,
       decisionReason,
       ruleConfigVersion: this.ruleEngine.getConfig().version,
+      aiRiskScore: aiEvaluation.aiRiskScore,
       evaluatedAt: result.evaluatedAt,
     });
 
@@ -163,6 +187,7 @@ export class UnderwritingService {
       creditBandDecision: creditScore
         ? decisionFromCreditBand(creditScore.band)
         : undefined,
+      aiRiskScore: aiEvaluation.aiRiskScore,
       evaluatedAt: result.evaluatedAt,
     };
   }

--- a/backend/src/templates/ai/riskScoringPrompt.ts
+++ b/backend/src/templates/ai/riskScoringPrompt.ts
@@ -1,0 +1,67 @@
+/**
+ * Prompt templates for AI tenant risk scoring (Anthropic structured output).
+ */
+
+import type { TenantRiskProfile } from '../../services/aiRiskScoreProvider.js'
+
+export const RISK_SCORING_SYSTEM_PROMPT = `You are a tenant underwriting risk analyst for a rental platform.
+Assess repayment risk from the structured tenant profile only. Do not invent facts.
+
+Scoring guidelines:
+- score: 0 (lowest risk) to 100 (highest risk)
+- confidence: 0 to 1 reflecting data completeness and consistency
+- riskBand: low | medium | high | very_high aligned with score
+- contributingFactors: short bullet strings citing profile signals
+
+Risk band mapping:
+- low: score 0-25
+- medium: score 26-50
+- high: score 51-75
+- very_high: score 76-100
+
+Advisory only: escalate ambiguous very high risk; never auto-approve unsafe tenants.
+
+Few-shot examples:
+
+LOW RISK profile:
+- monthlyIncome: 500000, incomeToRentRatio: 5, employmentTenureMonths: 36
+- avgBalance: 200000, nsfCount: 0, incomeRegularity: 90, existingDebtObligations: 20000
+→ score ~15, confidence ~0.9, riskBand low
+
+MEDIUM RISK profile:
+- monthlyIncome: 180000, incomeToRentRatio: 2.2, employmentTenureMonths: 12
+- avgBalance: 40000, nsfCount: 1, incomeRegularity: 65, existingDebtObligations: 45000
+→ score ~45, confidence ~0.75, riskBand medium
+
+HIGH RISK profile:
+- monthlyIncome: 110000, incomeToRentRatio: 1.3, employmentTenureMonths: 3
+- avgBalance: 8000, nsfCount: 2, incomeRegularity: 40, existingDebtObligations: 60000
+→ score ~72, confidence ~0.8, riskBand high`
+
+export const RISK_SCORING_TOOL_NAME = 'tenant_risk_assessment'
+
+export const RISK_SCORING_TOOL_INPUT_SCHEMA = {
+  type: 'object' as const,
+  properties: {
+    score: { type: 'number', description: 'Risk score 0-100' },
+    confidence: { type: 'number', description: 'Confidence 0-1' },
+    riskBand: {
+      type: 'string',
+      enum: ['low', 'medium', 'high', 'very_high'],
+    },
+    contributingFactors: {
+      type: 'array',
+      items: { type: 'string' },
+    },
+    modelVersion: { type: 'string' },
+  },
+  required: ['score', 'confidence', 'riskBand', 'contributingFactors', 'modelVersion'],
+}
+
+export function buildRiskScoringUserMessage(profile: TenantRiskProfile): string {
+  return `Assess tenant risk for the following profile (JSON):
+
+${JSON.stringify(profile, null, 2)}
+
+Return your assessment using the ${RISK_SCORING_TOOL_NAME} tool.`
+}


### PR DESCRIPTION
## Summary

Integrates advisory AI-based tenant risk scoring into the underwriting pipeline. Scores are computed via a pluggable provider (Claude or deterministic stub), cached for 24 hours per tenant data version, and persisted on underwriting decision traces.

## Purpose / Motivation

The rule engine alone can miss non-obvious repayment risk signals. This adds an ML-style assessment from onboarding verification data that can escalate borderline approvals to manual review without auto-rejecting tenants.

## Changes Made

- Added `AiRiskScoreProvider` interface, `TenantRiskProfile` builder, stub and Claude (`OpenAiRiskScoreProvider`) implementations
- Added `AiRiskScoringService` with 24h LRU cache keyed by `(tenantId, dataVersion)`
- Wired AI scoring into `UnderwritingService` after deterministic/credit merge; skips scoring when decision is already `REJECT`
- Override: `APPROVE` + AI `very_high` with `confidence > 0.85` → `REVIEW`
- Extended `underwriting_decision_traces` with optional `ai_risk_score` JSONB column (migration `033`)
- Env: `AI_SCORING_ENABLED`, `AI_SCORING_PROVIDER` (`claude` | `stub`), `AI_SCORING_MODEL`, `ANTHROPIC_API_KEY`

## How to Test

1. In `backend/`, run `npm test -- src/services/aiRiskScoring.integration.test.ts`
2. Set `AI_SCORING_ENABLED=true` and `AI_SCORING_PROVIDER=stub`, submit tenant onboarding, then evaluate underwriting — trace should include `aiRiskScore`
3. With mock/high-risk provider (see integration test), confirm `APPROVE` escalates to `REVIEW` in trace and response
4. Confirm `REJECT` applications do not invoke the provider (spy test)
5. Call scoring twice with same profile — provider invoked once (cache test)

## Breaking Changes

None. AI scoring is off by default (`AI_SCORING_ENABLED` unset/false).

## Related Issues

Closes Shelterflex/monorepo#936

## Checklist

- [x] Code builds successfully
- [x] Tests added/updated
- [x] No secrets committed
- [ ] Documentation updated (if needed)