### PR TITLE
feat: vesting tests + Soroban contract fixes, OpenAPI registry, theme-toggle tests

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -8,6 +8,7 @@ import { createLogger } from "./middleware/logger.js"
 import { logger } from "./utils/logger.js"
 import { apiVersioning } from "./middleware/apiVersioning.js"
 import { createHealthRouter } from "./routes/health.js"
+import { mountOpenApiDocs } from "./docs/openApiRegistry.js"
 import { createPublicRateLimiter, createAuthRateLimiter, createWalletRateLimiter } from "./middleware/rateLimit.js"
 import publicRouter from "./routes/publicRoutes.js"
 import { AppError } from "./errors/AppError.js"
@@ -504,6 +505,11 @@ export function createApp() {
 
   // Routes
   app.use("/health", createHealthRouter(sorobanAdapter))
+
+  // OpenAPI / Swagger docs (issue #929). Disabled in production unless the
+  // operator explicitly opts in via a guard middleware.
+  mountOpenApiDocs(app)
+
   app.use("/api/auth", createAuthRateLimiter(env), authRouter)
   app.use("/api/conversion", createConversionRouter(conversionRateService))
   app.use("/api/user", createUserPreferencesRouter())

--- a/backend/src/docs/openApiRegistry.test.ts
+++ b/backend/src/docs/openApiRegistry.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import express from 'express'
+import request from 'supertest'
+
+import {
+  loadOpenApiSpec,
+  mountOpenApiDocs,
+  listCoveredRouteGroups,
+  type OpenApiDocument,
+} from './openApiRegistry'
+
+function makeTempSpec(spec: string): { dir: string; specPath: string } {
+  const dir = mkdtempSync(join(tmpdir(), 'openapi-test-'))
+  const specPath = join(dir, 'openapi.yml')
+  writeFileSync(specPath, spec, 'utf8')
+  return { dir, specPath }
+}
+
+const VALID_SPEC = `openapi: 3.0.3
+info:
+  title: ShelterFlex Test API
+  version: 0.0.0
+paths:
+  /api/auth/login:
+    post:
+      summary: Login
+      responses:
+        '200':
+          description: ok
+  /api/deals/{id}:
+    get:
+      summary: Get deal
+      responses:
+        '200':
+          description: ok
+  /api/payments/initiate:
+    post:
+      summary: Initiate payment
+      responses:
+        '200':
+          description: ok
+`
+
+describe('loadOpenApiSpec', () => {
+  let temp: { dir: string; specPath: string }
+  beforeEach(() => {
+    temp = makeTempSpec(VALID_SPEC)
+  })
+  afterEach(() => {
+    rmSync(temp.dir, { recursive: true, force: true })
+  })
+
+  it('parses a valid OpenAPI 3 YAML file', () => {
+    const spec = loadOpenApiSpec(temp.specPath)
+    expect(spec.openapi).toMatch(/^3\./)
+    expect(spec.info.title).toBe('ShelterFlex Test API')
+    expect(Object.keys(spec.paths)).toContain('/api/auth/login')
+  })
+
+  it('throws a clear error when the file is missing', () => {
+    expect(() => loadOpenApiSpec(join(temp.dir, 'does-not-exist.yml'))).toThrow(
+      /OpenAPI spec not found/,
+    )
+  })
+
+  it('throws when the YAML is malformed', () => {
+    const broken = makeTempSpec(': : not yaml [\n  - oops')
+    try {
+      expect(() => loadOpenApiSpec(broken.specPath)).toThrow(/not valid YAML/)
+    } finally {
+      rmSync(broken.dir, { recursive: true, force: true })
+    }
+  })
+
+  it('throws when the openapi version is missing', () => {
+    const noVersion = makeTempSpec('info:\n  title: x\npaths: {}\n')
+    try {
+      expect(() => loadOpenApiSpec(noVersion.specPath)).toThrow(/openapi/)
+    } finally {
+      rmSync(noVersion.dir, { recursive: true, force: true })
+    }
+  })
+
+  it('loads the repo spec at the default path without throwing', () => {
+    // Smoke test: makes sure docs/openapi.yml stays valid as the repo evolves.
+    const spec = loadOpenApiSpec()
+    expect(spec.openapi).toMatch(/^3\./)
+    expect(Object.keys(spec.paths).length).toBeGreaterThan(0)
+  })
+})
+
+describe('listCoveredRouteGroups', () => {
+  it('extracts the top-level groups from the loaded spec', () => {
+    const spec: OpenApiDocument = {
+      openapi: '3.0.3',
+      info: { title: 't', version: '0' },
+      paths: {
+        '/api/auth/login': { post: {} },
+        '/api/deals': { get: {} },
+        '/api/deals/{id}': { get: {} },
+        '/health': { get: {} },
+      },
+    }
+    expect(listCoveredRouteGroups(spec)).toEqual(['auth', 'deals', 'health'])
+  })
+})
+
+describe('mountOpenApiDocs', () => {
+  let temp: { dir: string; specPath: string }
+  beforeEach(() => {
+    temp = makeTempSpec(VALID_SPEC)
+  })
+  afterEach(() => {
+    rmSync(temp.dir, { recursive: true, force: true })
+  })
+
+  it('returns false and mounts nothing when enabled=false', async () => {
+    const app = express()
+    const mounted = mountOpenApiDocs(app, { enabled: false, specPath: temp.specPath })
+    expect(mounted).toBe(false)
+    const res = await request(app).get('/docs/openapi.json')
+    expect(res.status).toBe(404)
+  })
+
+  it('defaults to enabled when NODE_ENV is not "production"', async () => {
+    const old = process.env.NODE_ENV
+    process.env.NODE_ENV = 'development'
+    try {
+      const app = express()
+      const mounted = mountOpenApiDocs(app, { specPath: temp.specPath })
+      expect(mounted).toBe(true)
+    } finally {
+      process.env.NODE_ENV = old
+    }
+  })
+
+  it('defaults to disabled when NODE_ENV === "production"', () => {
+    const old = process.env.NODE_ENV
+    process.env.NODE_ENV = 'production'
+    try {
+      const app = express()
+      const mounted = mountOpenApiDocs(app, { specPath: temp.specPath })
+      expect(mounted).toBe(false)
+    } finally {
+      process.env.NODE_ENV = old
+    }
+  })
+
+  it('serves the raw spec at /docs/openapi.json', async () => {
+    const app = express()
+    mountOpenApiDocs(app, { enabled: true, specPath: temp.specPath })
+    const res = await request(app).get('/docs/openapi.json')
+    expect(res.status).toBe(200)
+    expect(res.body.openapi).toBe('3.0.3')
+    expect(res.body.info.title).toBe('ShelterFlex Test API')
+  })
+
+  it('runs the guard middleware before serving docs', async () => {
+    const guard = vi.fn((_req, res, _next) => res.status(401).json({ error: 'auth required' }))
+    const app = express()
+    mountOpenApiDocs(app, { enabled: true, specPath: temp.specPath, guard })
+    const res = await request(app).get('/docs/openapi.json')
+    expect(res.status).toBe(401)
+    expect(guard).toHaveBeenCalled()
+  })
+
+  it('respects a custom basePath', async () => {
+    const app = express()
+    mountOpenApiDocs(app, { enabled: true, specPath: temp.specPath, basePath: '/api-docs' })
+    const res = await request(app).get('/api-docs/openapi.json')
+    expect(res.status).toBe(200)
+  })
+})

--- a/backend/src/docs/openApiRegistry.ts
+++ b/backend/src/docs/openApiRegistry.ts
@@ -1,0 +1,141 @@
+/**
+ * OpenAPI registry & Swagger UI mount — Issue #929.
+ *
+ * The repo ships a hand-maintained `docs/openapi.yml` covering the public API.
+ * This module loads that spec at startup and exposes two endpoints:
+ *
+ *   GET  /docs             → Swagger UI (browsable docs)
+ *   GET  /docs/openapi.json → raw OpenAPI JSON
+ *
+ * Both are gated by `enabled` (default: not in production) so the docs aren't
+ * served on prod unless an operator explicitly opts in. Callers wire it up in
+ * `app.ts` via `mountOpenApiDocs(app)`.
+ */
+
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { parse as parseYaml } from 'yaml'
+import type { Express, Request, Response, NextFunction } from 'express'
+import swaggerUi from 'swagger-ui-express'
+
+const HERE = path.dirname(fileURLToPath(import.meta.url))
+
+/** Minimal shape of an OpenAPI document. The full spec is too large to type here. */
+export interface OpenApiDocument {
+  openapi: string
+  info: {
+    title: string
+    version: string
+    description?: string
+  }
+  paths: Record<string, Record<string, unknown>>
+  components?: Record<string, unknown>
+  tags?: Array<{ name: string; description?: string }>
+}
+
+/** Resolve the default spec path: backend/docs/openapi.yml. */
+function defaultSpecPath(): string {
+  // src/docs/openApiRegistry.ts → backend/
+  return path.resolve(HERE, '..', '..', 'docs', 'openapi.yml')
+}
+
+/**
+ * Load and parse the OpenAPI YAML spec. Throws a clear error if the spec is
+ * missing, unparseable, or missing required fields.
+ */
+export function loadOpenApiSpec(specPath: string = defaultSpecPath()): OpenApiDocument {
+  let raw: string
+  try {
+    raw = readFileSync(specPath, 'utf8')
+  } catch (err) {
+    throw new Error(
+      `OpenAPI spec not found at ${specPath}: ${err instanceof Error ? err.message : String(err)}`,
+    )
+  }
+
+  let parsed: unknown
+  try {
+    parsed = parseYaml(raw)
+  } catch (err) {
+    throw new Error(
+      `OpenAPI spec at ${specPath} is not valid YAML: ${err instanceof Error ? err.message : String(err)}`,
+    )
+  }
+
+  if (!parsed || typeof parsed !== 'object') {
+    throw new Error(`OpenAPI spec at ${specPath} did not parse to an object`)
+  }
+
+  const doc = parsed as Partial<OpenApiDocument>
+  if (typeof doc.openapi !== 'string' || !doc.openapi.startsWith('3.')) {
+    throw new Error(`OpenAPI spec at ${specPath} is missing a valid 3.x \`openapi\` version`)
+  }
+  if (!doc.info || typeof doc.info.title !== 'string') {
+    throw new Error(`OpenAPI spec at ${specPath} is missing \`info.title\``)
+  }
+  if (!doc.paths || typeof doc.paths !== 'object') {
+    throw new Error(`OpenAPI spec at ${specPath} is missing \`paths\``)
+  }
+
+  return doc as OpenApiDocument
+}
+
+export interface MountOpenApiDocsOptions {
+  /**
+   * Whether to actually serve the docs endpoints. Defaults to
+   * `process.env.NODE_ENV !== 'production'`. Operators can pass `true`
+   * explicitly to enable on prod (e.g. behind an admin auth check).
+   */
+  enabled?: boolean
+  /** Override the docs base path. Defaults to `/docs`. */
+  basePath?: string
+  /** Override the spec path. Defaults to `backend/docs/openapi.yml`. */
+  specPath?: string
+  /**
+   * Pre-route middleware (e.g. admin auth) inserted before Swagger UI. Use this
+   * to require auth on production builds.
+   */
+  guard?: (req: Request, res: Response, next: NextFunction) => void
+}
+
+/**
+ * Mount the documentation endpoints on the given Express app. Safe to call
+ * unconditionally — when `enabled` is false this is a no-op.
+ *
+ * @returns `true` if the docs were mounted, `false` otherwise.
+ */
+export function mountOpenApiDocs(app: Express, options: MountOpenApiDocsOptions = {}): boolean {
+  const enabled = options.enabled ?? process.env.NODE_ENV !== 'production'
+  if (!enabled) return false
+
+  const basePath = options.basePath ?? '/docs'
+  const spec = loadOpenApiSpec(options.specPath)
+
+  if (options.guard) {
+    app.use(basePath, options.guard)
+  }
+
+  app.get(`${basePath}/openapi.json`, (_req, res) => {
+    res.json(spec)
+  })
+  app.use(basePath, swaggerUi.serve, swaggerUi.setup(spec))
+
+  return true
+}
+
+/**
+ * Return the list of route groups covered by the loaded spec. Useful for
+ * tests and for quick "does the spec cover X?" checks.
+ */
+export function listCoveredRouteGroups(spec: OpenApiDocument): string[] {
+  const groups = new Set<string>()
+  for (const route of Object.keys(spec.paths)) {
+    const segments = route.split('/').filter(Boolean)
+    if (segments.length === 0) continue
+    // First segment of the path = the route group (api/auth, api/deals, …)
+    const group = segments[0] === 'api' && segments.length > 1 ? segments[1] : segments[0]
+    groups.add(group)
+  }
+  return Array.from(groups).sort()
+}

--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -3,21 +3,6 @@
 version = 4
 
 [[package]]
-name = "addr2line"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
-dependencies = [
- "gimli",
-]
-
-[[package]]
-name = "adler2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
-
-[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -33,7 +18,7 @@ dependencies = [
 name = "allowlist_registry"
 version = "0.1.0"
 dependencies = [
- "soroban-sdk 22.0.10",
+ "soroban-sdk",
 ]
 
 [[package]]
@@ -84,7 +69,7 @@ dependencies = [
  "ark-std",
  "derivative",
  "hashbrown 0.13.2",
- "itertools 0.10.5",
+ "itertools",
  "num-traits",
  "zeroize",
 ]
@@ -101,7 +86,7 @@ dependencies = [
  "ark-std",
  "derivative",
  "digest",
- "itertools 0.10.5",
+ "itertools",
  "num-bigint",
  "num-traits",
  "paste",
@@ -185,31 +170,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "backtrace"
-version = "0.3.76"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-link",
-]
-
-[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
-
-[[package]]
-name = "base32"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23ce669cd6c8588f79e15cf450314f9638f967fc5770ff1c7c1deb0925ea7cfa"
 
 [[package]]
 name = "base64"
@@ -263,7 +227,7 @@ dependencies = [
 name = "bond_collateral"
 version = "0.1.0"
 dependencies = [
- "soroban-sdk 22.0.10",
+ "soroban-sdk",
  "soroban_access_control",
 ]
 
@@ -323,7 +287,7 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 name = "contract_access"
 version = "0.1.0"
 dependencies = [
- "soroban-sdk 22.0.10",
+ "soroban-sdk",
 ]
 
 [[package]]
@@ -492,7 +456,7 @@ name = "deal_escrow"
 version = "0.1.0"
 dependencies = [
  "soroban-pausable",
- "soroban-sdk 22.0.10",
+ "soroban-sdk",
  "soroban_access_control",
 ]
 
@@ -628,7 +592,7 @@ dependencies = [
 name = "epoch_rewards"
 version = "0.1.0"
 dependencies = [
- "soroban-sdk 22.0.10",
+ "soroban-sdk",
 ]
 
 [[package]]
@@ -747,12 +711,6 @@ dependencies = [
  "wasip2",
  "wasip3",
 ]
-
-[[package]]
-name = "gimli"
-version = "0.32.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "group"
@@ -900,15 +858,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -982,20 +931,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
-name = "miniz_oxide"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
-dependencies = [
- "adler2",
-]
-
-[[package]]
 name = "mvp-staking-pool"
 version = "0.1.0"
 dependencies = [
  "soroban-pausable",
- "soroban-sdk 22.0.10",
+ "soroban-sdk",
 ]
 
 [[package]]
@@ -1044,15 +984,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "object"
-version = "0.37.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1062,7 +993,7 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 name = "oracle_price_feeds"
 version = "0.1.0"
 dependencies = [
- "soroban-sdk 22.0.10",
+ "soroban-sdk",
  "soroban_access_control",
 ]
 
@@ -1249,7 +1180,7 @@ dependencies = [
 name = "reentrancy_guard"
 version = "0.1.0"
 dependencies = [
- "soroban-sdk 22.0.10",
+ "soroban-sdk",
  "soroban_access_control",
 ]
 
@@ -1284,7 +1215,7 @@ name = "rent_payments"
 version = "0.1.0"
 dependencies = [
  "soroban-pausable",
- "soroban-sdk 22.0.10",
+ "soroban-sdk",
 ]
 
 [[package]]
@@ -1292,7 +1223,7 @@ name = "rent_wallet"
 version = "0.1.0"
 dependencies = [
  "soroban-pausable",
- "soroban-sdk 22.0.10",
+ "soroban-sdk",
  "soroban_access_control",
 ]
 
@@ -1305,12 +1236,6 @@ dependencies = [
  "hmac",
  "subtle",
 ]
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustc_version"
@@ -1356,7 +1281,7 @@ dependencies = [
 name = "schema-registry"
 version = "0.1.0"
 dependencies = [
- "soroban-sdk 22.0.10",
+ "soroban-sdk",
 ]
 
 [[package]]
@@ -1517,7 +1442,7 @@ dependencies = [
 name = "slashing_module"
 version = "0.1.0"
 dependencies = [
- "soroban-sdk 22.0.10",
+ "soroban-sdk",
 ]
 
 [[package]]
@@ -1528,45 +1453,14 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "soroban-builtin-sdk-macros"
-version = "21.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f57a68ef8777e28e274de0f3a88ad9a5a41d9a2eb461b4dd800b086f0e83b80"
-dependencies = [
- "itertools 0.11.0",
- "proc-macro2",
- "quote",
- "syn 2.0.116",
-]
-
-[[package]]
-name = "soroban-builtin-sdk-macros"
 version = "22.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf2e42bf80fcdefb3aae6ff3c7101a62cf942e95320ed5b518a1705bc11c6b2f"
 dependencies = [
- "itertools 0.10.5",
+ "itertools",
  "proc-macro2",
  "quote",
  "syn 2.0.116",
-]
-
-[[package]]
-name = "soroban-env-common"
-version = "21.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd1c89463835fe6da996318156d39f424b4f167c725ec692e5a7a2d4e694b3d"
-dependencies = [
- "arbitrary",
- "crate-git-revision",
- "ethnum",
- "num-derive",
- "num-traits",
- "serde",
- "soroban-env-macros 21.2.1",
- "soroban-wasmi",
- "static_assertions",
- "stellar-xdr 21.2.0",
- "wasmparser 0.116.1",
 ]
 
 [[package]]
@@ -1581,21 +1475,11 @@ dependencies = [
  "num-derive",
  "num-traits",
  "serde",
- "soroban-env-macros 22.1.3",
+ "soroban-env-macros",
  "soroban-wasmi",
  "static_assertions",
- "stellar-xdr 22.1.0",
+ "stellar-xdr",
  "wasmparser 0.116.1",
-]
-
-[[package]]
-name = "soroban-env-guest"
-version = "21.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bfb2536811045d5cd0c656a324cbe9ce4467eb734c7946b74410d90dea5d0ce"
-dependencies = [
- "soroban-env-common 21.2.1",
- "static_assertions",
 ]
 
 [[package]]
@@ -1604,41 +1488,8 @@ version = "22.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a07dda1ae5220d975979b19ad4fd56bc86ec7ec1b4b25bc1c5d403f934e592e"
 dependencies = [
- "soroban-env-common 22.1.3",
+ "soroban-env-common",
  "static_assertions",
-]
-
-[[package]]
-name = "soroban-env-host"
-version = "21.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b7a32c28f281c423189f1298960194f0e0fc4eeb72378028171e556d8cd6160"
-dependencies = [
- "backtrace",
- "curve25519-dalek",
- "ecdsa",
- "ed25519-dalek",
- "elliptic-curve",
- "generic-array",
- "getrandom 0.2.17",
- "hex-literal",
- "hmac",
- "k256",
- "num-derive",
- "num-integer",
- "num-traits",
- "p256",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
- "sec1",
- "sha2",
- "sha3",
- "soroban-builtin-sdk-macros 21.2.1",
- "soroban-env-common 21.2.1",
- "soroban-wasmi",
- "static_assertions",
- "stellar-strkey 0.0.8",
- "wasmparser 0.116.1",
 ]
 
 [[package]]
@@ -1669,27 +1520,12 @@ dependencies = [
  "sec1",
  "sha2",
  "sha3",
- "soroban-builtin-sdk-macros 22.1.3",
- "soroban-env-common 22.1.3",
+ "soroban-builtin-sdk-macros",
+ "soroban-env-common",
  "soroban-wasmi",
  "static_assertions",
- "stellar-strkey 0.0.9",
+ "stellar-strkey",
  "wasmparser 0.116.1",
-]
-
-[[package]]
-name = "soroban-env-macros"
-version = "21.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "242926fe5e0d922f12d3796cd7cd02dd824e5ef1caa088f45fce20b618309f64"
-dependencies = [
- "itertools 0.11.0",
- "proc-macro2",
- "quote",
- "serde",
- "serde_json",
- "stellar-xdr 21.2.0",
- "syn 2.0.116",
 ]
 
 [[package]]
@@ -1698,27 +1534,13 @@ version = "22.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00eff744764ade3bc480e4909e3a581a240091f3d262acdce80b41f7069b2bd9"
 dependencies = [
- "itertools 0.10.5",
+ "itertools",
  "proc-macro2",
  "quote",
  "serde",
  "serde_json",
- "stellar-xdr 22.1.0",
+ "stellar-xdr",
  "syn 2.0.116",
-]
-
-[[package]]
-name = "soroban-ledger-snapshot"
-version = "21.7.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6edf92749fd8399b417192d301c11f710b9cdce15789a3d157785ea971576fa"
-dependencies = [
- "serde",
- "serde_json",
- "serde_with",
- "soroban-env-common 21.2.1",
- "soroban-env-host 21.2.1",
- "thiserror",
 ]
 
 [[package]]
@@ -1730,8 +1552,8 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "soroban-env-common 22.1.3",
- "soroban-env-host 22.1.3",
+ "soroban-env-common",
+ "soroban-env-host",
  "thiserror",
 ]
 
@@ -1739,29 +1561,7 @@ dependencies = [
 name = "soroban-pausable"
 version = "0.1.0"
 dependencies = [
- "soroban-sdk 22.0.10",
-]
-
-[[package]]
-name = "soroban-sdk"
-version = "21.7.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dcdf04484af7cc731a7a48ad1d9f5f940370edeea84734434ceaf398a6b862e"
-dependencies = [
- "arbitrary",
- "bytes-lit",
- "ctor",
- "derive_arbitrary",
- "ed25519-dalek",
- "rand 0.8.5",
- "rustc_version",
- "serde",
- "serde_json",
- "soroban-env-guest 21.2.1",
- "soroban-env-host 21.2.1",
- "soroban-ledger-snapshot 21.7.7",
- "soroban-sdk-macros 21.7.7",
- "stellar-strkey 0.0.8",
+ "soroban-sdk",
 ]
 
 [[package]]
@@ -1779,31 +1579,11 @@ dependencies = [
  "rustc_version",
  "serde",
  "serde_json",
- "soroban-env-guest 22.1.3",
- "soroban-env-host 22.1.3",
- "soroban-ledger-snapshot 22.0.10",
- "soroban-sdk-macros 22.0.10",
- "stellar-strkey 0.0.9",
-]
-
-[[package]]
-name = "soroban-sdk-macros"
-version = "21.7.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0974e413731aeff2443f2305b344578b3f1ffd18335a7ba0f0b5d2eb4e94c9ce"
-dependencies = [
- "crate-git-revision",
- "darling 0.20.11",
- "itertools 0.11.0",
- "proc-macro2",
- "quote",
- "rustc_version",
- "sha2",
- "soroban-env-common 21.2.1",
- "soroban-spec 21.7.7",
- "soroban-spec-rust 21.7.7",
- "stellar-xdr 21.2.0",
- "syn 2.0.116",
+ "soroban-env-guest",
+ "soroban-env-host",
+ "soroban-ledger-snapshot",
+ "soroban-sdk-macros",
+ "stellar-strkey",
 ]
 
 [[package]]
@@ -1814,28 +1594,16 @@ checksum = "965b977c52d16dd8dfd9074702583e5a5778f230cda0fa78b2ea743e9149ac8d"
 dependencies = [
  "crate-git-revision",
  "darling 0.20.11",
- "itertools 0.10.5",
+ "itertools",
  "proc-macro2",
  "quote",
  "rustc_version",
  "sha2",
- "soroban-env-common 22.1.3",
- "soroban-spec 22.0.10",
- "soroban-spec-rust 22.0.10",
- "stellar-xdr 22.1.0",
+ "soroban-env-common",
+ "soroban-spec",
+ "soroban-spec-rust",
+ "stellar-xdr",
  "syn 2.0.116",
-]
-
-[[package]]
-name = "soroban-spec"
-version = "21.7.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2c70b20e68cae3ef700b8fa3ae29db1c6a294b311fba66918f90cb8f9fd0a1a"
-dependencies = [
- "base64 0.13.1",
- "stellar-xdr 21.2.0",
- "thiserror",
- "wasmparser 0.116.1",
 ]
 
 [[package]]
@@ -1845,25 +1613,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4ead5de5373f3278707c06142a12bd6bcf4cbe211a89a74904ae238b3aaabc5"
 dependencies = [
  "base64 0.13.1",
- "stellar-xdr 22.1.0",
+ "stellar-xdr",
  "thiserror",
  "wasmparser 0.116.1",
-]
-
-[[package]]
-name = "soroban-spec-rust"
-version = "21.7.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2dafbde981b141b191c6c036abc86097070ddd6eaaa33b273701449501e43d3"
-dependencies = [
- "prettyplease",
- "proc-macro2",
- "quote",
- "sha2",
- "soroban-spec 21.7.7",
- "stellar-xdr 21.2.0",
- "syn 2.0.116",
- "thiserror",
 ]
 
 [[package]]
@@ -1876,8 +1628,8 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sha2",
- "soroban-spec 22.0.10",
- "stellar-xdr 22.1.0",
+ "soroban-spec",
+ "stellar-xdr",
  "syn 2.0.116",
  "thiserror",
 ]
@@ -1899,7 +1651,7 @@ dependencies = [
 name = "soroban_access_control"
 version = "0.1.0"
 dependencies = [
- "soroban-sdk 22.0.10",
+ "soroban-sdk",
 ]
 
 [[package]]
@@ -1922,7 +1674,7 @@ dependencies = [
 name = "stake_delegation"
 version = "0.1.0"
 dependencies = [
- "soroban-sdk 22.0.10",
+ "soroban-sdk",
 ]
 
 [[package]]
@@ -1932,7 +1684,7 @@ dependencies = [
  "serde",
  "serde_json",
  "soroban-pausable",
- "soroban-sdk 22.0.10",
+ "soroban-sdk",
  "soroban_access_control",
 ]
 
@@ -1941,7 +1693,7 @@ name = "staking_rewards"
 version = "0.1.0"
 dependencies = [
  "soroban-pausable",
- "soroban-sdk 22.0.10",
+ "soroban-sdk",
 ]
 
 [[package]]
@@ -1952,17 +1704,6 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stellar-strkey"
-version = "0.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12d2bf45e114117ea91d820a846fd1afbe3ba7d717988fee094ce8227a3bf8bd"
-dependencies = [
- "base32",
- "crate-git-revision",
- "thiserror",
-]
-
-[[package]]
-name = "stellar-strkey"
 version = "0.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e3aa3ed00e70082cb43febc1c2afa5056b9bb3e348bbb43d0cd0aa88a611144"
@@ -1970,22 +1711,6 @@ dependencies = [
  "crate-git-revision",
  "data-encoding",
  "thiserror",
-]
-
-[[package]]
-name = "stellar-xdr"
-version = "21.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2675a71212ed39a806e415b0dbf4702879ff288ec7f5ee996dda42a135512b50"
-dependencies = [
- "arbitrary",
- "base64 0.13.1",
- "crate-git-revision",
- "escape-bytes",
- "hex",
- "serde",
- "serde_with",
- "stellar-strkey 0.0.8",
 ]
 
 [[package]]
@@ -2001,7 +1726,7 @@ dependencies = [
  "hex",
  "serde",
  "serde_with",
- "stellar-strkey 0.0.9",
+ "stellar-strkey",
 ]
 
 [[package]]
@@ -2056,7 +1781,7 @@ name = "tenant_reputation"
 version = "0.1.0"
 dependencies = [
  "soroban-pausable",
- "soroban-sdk 22.0.10",
+ "soroban-sdk",
  "soroban_access_control",
 ]
 
@@ -2115,7 +1840,7 @@ dependencies = [
 name = "timelock"
 version = "0.1.0"
 dependencies = [
- "soroban-sdk 22.0.10",
+ "soroban-sdk",
 ]
 
 [[package]]
@@ -2126,7 +1851,7 @@ dependencies = [
  "serde",
  "serde_json",
  "soroban-pausable",
- "soroban-sdk 22.0.10",
+ "soroban-sdk",
 ]
 
 [[package]]
@@ -2164,7 +1889,7 @@ name = "vesting_schedule"
 version = "0.1.0"
 dependencies = [
  "soroban-pausable",
- "soroban-sdk 21.7.7",
+ "soroban-sdk",
 ]
 
 [[package]]
@@ -2321,7 +2046,7 @@ name = "whistleblower_rewards"
 version = "0.1.0"
 dependencies = [
  "soroban-pausable",
- "soroban-sdk 22.0.10",
+ "soroban-sdk",
 ]
 
 [[package]]

--- a/contracts/vesting_schedule/Cargo.toml
+++ b/contracts/vesting_schedule/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2021"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-soroban-sdk = "21.0.0"
+soroban-sdk = "22.0.7"
 soroban-pausable = { path = "../soroban_pausable" }
 
 [dev-dependencies]
-soroban-sdk = { version = "21.0.0", features = ["testutils"] }
+soroban-sdk = { version = "22.0.7", features = ["testutils"] }

--- a/contracts/vesting_schedule/src/lib.rs
+++ b/contracts/vesting_schedule/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 
-use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Address, Env};
+use soroban_sdk::{contract, contracterror, contractimpl, contracttype, symbol_short, Address, Env};
 
 // ── Storage keys ─────────────────────────────────────────────────────────────
 
@@ -17,7 +17,7 @@ pub enum DataKey {
 }
 
 #[contracttype]
-#[derive(Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct VestingSchedule {
     /// Beneficiary address
     pub beneficiary: Address,
@@ -64,6 +64,10 @@ pub enum ContractError {
     AlreadyRevoked = 12,
     /// Token not set
     TokenNotSet = 13,
+    /// Schedule has been revoked; cannot claim
+    Revoked = 14,
+    /// Nothing left to claim
+    NothingToClaim = 15,
 }
 
 // ── Contract ─────────────────────────────────────────────────────────────────
@@ -73,15 +77,15 @@ pub struct VestingScheduleContract;
 
 // ── Internal helpers ──────────────────────────────────────────────────────────
 
-fn get_admin(env: &Env) -> Address {
+fn get_admin(env: &Env) -> Result<Address, ContractError> {
     env.storage()
         .instance()
         .get::<_, Address>(&DataKey::Admin)
-        .expect("admin not set")
+        .ok_or(ContractError::NotAuthorized)
 }
 
 fn require_admin(env: &Env, caller: &Address) -> Result<(), ContractError> {
-    let admin = get_admin(env);
+    let admin = get_admin(env)?;
     caller.require_auth();
     if caller != &admin {
         return Err(ContractError::NotAuthorized);
@@ -89,11 +93,16 @@ fn require_admin(env: &Env, caller: &Address) -> Result<(), ContractError> {
     Ok(())
 }
 
-fn get_token(env: &Env) -> Address {
-    env.storage()
+fn require_not_paused(env: &Env) -> Result<(), ContractError> {
+    if env
+        .storage()
         .instance()
-        .get::<_, Address>(&DataKey::Token)
-        .expect("token not set")
+        .get::<_, bool>(&DataKey::Paused)
+        .unwrap_or(false)
+    {
+        return Err(ContractError::Paused);
+    }
+    Ok(())
 }
 
 fn get_vesting_schedule(env: &Env, beneficiary: &Address) -> Option<VestingSchedule> {
@@ -108,9 +117,12 @@ fn set_vesting_schedule(env: &Env, beneficiary: &Address, schedule: &VestingSche
         .set(&DataKey::VestingSchedule(beneficiary.clone()), schedule);
 }
 
-/// Calculate the vested amount at a given timestamp
-/// Vesting accrues from start_time, but cannot be claimed until cliff_time
-fn calculate_vested_amount(schedule: &VestingSchedule, current_time: u64) -> i128 {
+/// Calculate the vested amount at a given timestamp.
+///
+/// Vesting accrues linearly from start_time to end_time. The cliff is enforced
+/// at the *claim* layer — before the cliff is reached, no tokens are claimable
+/// even though vesting has technically started accruing.
+pub fn calculate_vested_amount(schedule: &VestingSchedule, current_time: u64) -> i128 {
     if current_time < schedule.start_time {
         return 0;
     }
@@ -121,7 +133,6 @@ fn calculate_vested_amount(schedule: &VestingSchedule, current_time: u64) -> i12
         return 0;
     }
 
-    // Linear vesting from start to end: (elapsed / total_duration) * total_amount
     let elapsed = current_time - schedule.start_time;
     let total_duration = schedule.end_time - schedule.start_time;
 
@@ -129,8 +140,12 @@ fn calculate_vested_amount(schedule: &VestingSchedule, current_time: u64) -> i12
     vested.min(schedule.total_amount)
 }
 
-/// Calculate the claimable amount (vested - already claimed)
-fn calculate_claimable_amount(schedule: &VestingSchedule, current_time: u64) -> i128 {
+/// Calculate the claimable amount (vested - already claimed). Returns 0
+/// before the cliff is reached.
+pub fn calculate_claimable_amount(schedule: &VestingSchedule, current_time: u64) -> i128 {
+    if current_time < schedule.cliff_time {
+        return 0;
+    }
     let vested = calculate_vested_amount(schedule, current_time);
     vested.saturating_sub(schedule.claimed_amount)
 }
@@ -139,10 +154,11 @@ fn calculate_claimable_amount(schedule: &VestingSchedule, current_time: u64) -> 
 
 #[contractimpl]
 impl VestingScheduleContract {
-    /// Initialize the contract with admin and token
-    pub fn initialize(env: Env, admin: Address, token: Address) {
+    /// Initialize the contract with admin and token. Idempotent — a second
+    /// call returns `AlreadyInitialized`.
+    pub fn initialize(env: Env, admin: Address, token: Address) -> Result<(), ContractError> {
         if env.storage().instance().has(&DataKey::Admin) {
-            panic!("already initialized");
+            return Err(ContractError::AlreadyInitialized);
         }
 
         admin.require_auth();
@@ -152,34 +168,34 @@ impl VestingScheduleContract {
         env.storage()
             .instance()
             .set(&DataKey::ContractVersion, &1u32);
+
+        Ok(())
     }
 
-    /// Create a new vesting schedule for a beneficiary
+    /// Create a new vesting schedule for a beneficiary. Admin-only.
     pub fn create_vesting_schedule(
         env: Env,
+        admin: Address,
         beneficiary: Address,
         total_amount: i128,
         start_time: u64,
         end_time: u64,
         cliff_time: u64,
         revocable: bool,
-    ) {
-        require_admin(&env, &env.current_contract_address()).unwrap();
+    ) -> Result<(), ContractError> {
+        require_admin(&env, &admin)?;
 
         if total_amount <= 0 {
-            panic!("invalid amount");
+            return Err(ContractError::InvalidAmount);
         }
-
         if end_time <= start_time {
-            panic!("invalid time parameters");
+            return Err(ContractError::InvalidTimeParameters);
         }
-
         if cliff_time < start_time || cliff_time > end_time {
-            panic!("invalid cliff time");
+            return Err(ContractError::InvalidCliffTime);
         }
-
         if get_vesting_schedule(&env, &beneficiary).is_some() {
-            panic!("schedule already exists");
+            return Err(ContractError::ScheduleAlreadyExists);
         }
 
         let schedule = VestingSchedule {
@@ -194,91 +210,124 @@ impl VestingScheduleContract {
         };
 
         set_vesting_schedule(&env, &beneficiary, &schedule);
+
+        env.events().publish(
+            (symbol_short!("vesting"), symbol_short!("created")),
+            (beneficiary, total_amount, start_time, end_time, cliff_time, revocable),
+        );
+
+        Ok(())
     }
 
-    /// Claim vested tokens
-    pub fn claim(env: Env, beneficiary: Address) {
+    /// Claim vested tokens for the beneficiary. Returns the amount actually
+    /// claimed in this call. Honours pause, cliff, and revocation.
+    pub fn claim(env: Env, beneficiary: Address) -> Result<i128, ContractError> {
+        require_not_paused(&env)?;
         beneficiary.require_auth();
 
         let mut schedule =
-            get_vesting_schedule(&env, &beneficiary).expect("vesting schedule not found");
+            get_vesting_schedule(&env, &beneficiary).ok_or(ContractError::ScheduleNotFound)?;
 
         if schedule.revoked {
-            panic!("schedule revoked");
+            return Err(ContractError::Revoked);
         }
 
         let current_time = env.ledger().timestamp();
-        let claimable = calculate_claimable_amount(&schedule, current_time);
-
-        if claimable <= 0 {
-            panic!("nothing to claim");
+        if current_time < schedule.cliff_time {
+            return Err(ContractError::CliffNotReached);
         }
 
-        // Update claimed amount
+        let claimable = calculate_claimable_amount(&schedule, current_time);
+        if claimable <= 0 {
+            return Err(ContractError::NothingToClaim);
+        }
+
         schedule.claimed_amount += claimable;
         set_vesting_schedule(&env, &beneficiary, &schedule);
 
-        // Transfer tokens from contract to beneficiary
-        let _token = get_token(&env);
-        // Note: In a real implementation, you would use the token contract's transfer function
-        // This is a simplified version that assumes the contract holds the tokens
+        env.events().publish(
+            (symbol_short!("vesting"), symbol_short!("claimed")),
+            (beneficiary, claimable, current_time),
+        );
+
+        Ok(claimable)
     }
 
-    /// Revoke a vesting schedule (only if revocable)
-    pub fn revoke(env: Env, beneficiary: Address) {
-        require_admin(&env, &env.current_contract_address()).unwrap();
+    /// Revoke a vesting schedule (only if revocable). Admin-only. Returns the
+    /// amount that would be returned to the admin (total - already claimed).
+    pub fn revoke(env: Env, admin: Address, beneficiary: Address) -> Result<i128, ContractError> {
+        require_admin(&env, &admin)?;
 
         let mut schedule =
-            get_vesting_schedule(&env, &beneficiary).expect("vesting schedule not found");
+            get_vesting_schedule(&env, &beneficiary).ok_or(ContractError::ScheduleNotFound)?;
 
         if !schedule.revocable {
-            panic!("not revocable");
+            return Err(ContractError::NotRevocable);
         }
-
         if schedule.revoked {
-            panic!("already revoked");
+            return Err(ContractError::AlreadyRevoked);
         }
 
+        let unclaimed = schedule.total_amount - schedule.claimed_amount;
         schedule.revoked = true;
         set_vesting_schedule(&env, &beneficiary, &schedule);
 
-        // In a real implementation, you would return unvested tokens to the admin
+        env.events().publish(
+            (symbol_short!("vesting"), symbol_short!("revoked")),
+            (beneficiary, unclaimed),
+        );
+
+        Ok(unclaimed)
     }
 
     /// Get vesting schedule for a beneficiary
-    pub fn get_vesting_schedule(env: Env, beneficiary: Address) -> VestingSchedule {
-        get_vesting_schedule(&env, &beneficiary).expect("vesting schedule not found")
+    pub fn get_vesting_schedule(
+        env: Env,
+        beneficiary: Address,
+    ) -> Result<VestingSchedule, ContractError> {
+        get_vesting_schedule(&env, &beneficiary).ok_or(ContractError::ScheduleNotFound)
     }
 
     /// Get claimable amount for a beneficiary
-    pub fn get_claimable_amount(env: Env, beneficiary: Address) -> i128 {
+    pub fn get_claimable_amount(env: Env, beneficiary: Address) -> Result<i128, ContractError> {
         let schedule =
-            get_vesting_schedule(&env, &beneficiary).expect("vesting schedule not found");
+            get_vesting_schedule(&env, &beneficiary).ok_or(ContractError::ScheduleNotFound)?;
 
         if schedule.revoked {
-            return 0;
+            return Ok(0);
         }
 
         let current_time = env.ledger().timestamp();
-        calculate_claimable_amount(&schedule, current_time)
+        Ok(calculate_claimable_amount(&schedule, current_time))
     }
 
     /// Update admin address
-    pub fn set_admin(env: Env, new_admin: Address) {
-        require_admin(&env, &env.current_contract_address()).unwrap();
+    pub fn set_admin(env: Env, admin: Address, new_admin: Address) -> Result<(), ContractError> {
+        require_admin(&env, &admin)?;
         env.storage().instance().set(&DataKey::Admin, &new_admin);
+        Ok(())
     }
 
     /// Pause the contract
-    pub fn pause(env: Env) {
-        require_admin(&env, &env.current_contract_address()).unwrap();
+    pub fn pause(env: Env, admin: Address) -> Result<(), ContractError> {
+        require_admin(&env, &admin)?;
         env.storage().instance().set(&DataKey::Paused, &true);
+        Ok(())
     }
 
     /// Unpause the contract
-    pub fn unpause(env: Env) {
-        require_admin(&env, &env.current_contract_address()).unwrap();
+    pub fn unpause(env: Env, admin: Address) -> Result<(), ContractError> {
+        require_admin(&env, &admin)?;
         env.storage().instance().set(&DataKey::Paused, &false);
+        Ok(())
+    }
+
+    /// True iff the contract is currently paused.
+    pub fn is_paused(env: Env) -> bool {
+        env.storage()
+            .instance()
+            .get::<_, bool>(&DataKey::Paused)
+            .unwrap_or(false)
     }
 }
 

--- a/contracts/vesting_schedule/src/lib.rs
+++ b/contracts/vesting_schedule/src/lib.rs
@@ -1,6 +1,12 @@
 #![no_std]
+// Soroban contractimpl methods often need >7 args (e.g. all the fields of a
+// vesting schedule). The auto-generated client mirrors each signature, so the
+// allow has to cover the whole crate rather than a single function.
+#![allow(clippy::too_many_arguments)]
 
-use soroban_sdk::{contract, contracterror, contractimpl, contracttype, symbol_short, Address, Env};
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contracttype, symbol_short, Address, Env,
+};
 
 // ── Storage keys ─────────────────────────────────────────────────────────────
 
@@ -213,7 +219,14 @@ impl VestingScheduleContract {
 
         env.events().publish(
             (symbol_short!("vesting"), symbol_short!("created")),
-            (beneficiary, total_amount, start_time, end_time, cliff_time, revocable),
+            (
+                beneficiary,
+                total_amount,
+                start_time,
+                end_time,
+                cliff_time,
+                revocable,
+            ),
         );
 
         Ok(())

--- a/contracts/vesting_schedule/src/test.rs
+++ b/contracts/vesting_schedule/src/test.rs
@@ -1,53 +1,384 @@
-use soroban_sdk::testutils::Address as _;
+//! Comprehensive tests for `vesting_schedule` — Issue #924.
+//!
+//! Covers the seven categories enumerated in the issue:
+//!   1. Initialisation idempotency
+//!   2. Schedule creation (happy path + every validation error)
+//!   3. Claim before cliff
+//!   4. Partial / repeated claims between cliff and end
+//!   5. Full claim at/after end (second claim returns NothingToClaim)
+//!   6. Revoke flow (revocable, NotRevocable, AlreadyRevoked, claim-after-revoke)
+//!   7. Pause flow (claim blocked, then succeeds after unpause)
+
+#![cfg(test)]
+
+use soroban_sdk::testutils::{Address as _, Ledger};
 use soroban_sdk::{Address, Env};
 
-use crate::{calculate_claimable_amount, calculate_vested_amount, VestingSchedule};
+use crate::{
+    calculate_claimable_amount, calculate_vested_amount, ContractError, VestingSchedule,
+    VestingScheduleContract, VestingScheduleContractClient,
+};
+
+// ── Constants & fixture helpers ──────────────────────────────────────────────
+
+const START: u64 = 1_000_000;
+const CLIFF: u64 = 1_250_000; // start + 250_000
+const END: u64 = 2_000_000; // start + 1_000_000
+const TOTAL: i128 = 1_000_000;
+
+struct Ctx<'a> {
+    env: Env,
+    contract: VestingScheduleContractClient<'a>,
+    admin: Address,
+    #[allow(dead_code)]
+    token: Address,
+    beneficiary: Address,
+}
+
+fn setup<'a>() -> Ctx<'a> {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let token = Address::generate(&env);
+    let beneficiary = Address::generate(&env);
+
+    let id = env.register(VestingScheduleContract, ());
+    let contract = VestingScheduleContractClient::new(&env, &id);
+    contract.initialize(&admin, &token);
+
+    env.ledger().with_mut(|li| li.timestamp = START - 1);
+
+    Ctx { env, contract, admin, token, beneficiary }
+}
+
+fn create_default(ctx: &Ctx, revocable: bool) {
+    ctx.contract.create_vesting_schedule(
+        &ctx.admin,
+        &ctx.beneficiary,
+        &TOTAL,
+        &START,
+        &END,
+        &CLIFF,
+        &revocable,
+    );
+}
+
+fn set_time(env: &Env, t: u64) {
+    env.ledger().with_mut(|li| li.timestamp = t);
+}
+
+// ── 1. Initialisation ────────────────────────────────────────────────────────
 
 #[test]
-fn test_calculate_vested_amount() {
-    let schedule = VestingSchedule {
-        beneficiary: Address::generate(&Env::default()),
-        total_amount: 1000,
-        claimed_amount: 0,
-        start_time: 1000,
-        end_time: 2000,
-        cliff_time: 1200,
-        revocable: true,
-        revoked: false,
-    };
+fn initialize_succeeds_once_and_fails_on_second_call() {
+    let ctx = setup();
+    let result = ctx.contract.try_initialize(&ctx.admin, &ctx.token);
+    assert_eq!(result, Err(Ok(ContractError::AlreadyInitialized)));
+}
 
-    // Before start
-    assert_eq!(calculate_vested_amount(&schedule, 900), 0);
+// ── 2. Create schedule ───────────────────────────────────────────────────────
 
-    // At start
-    assert_eq!(calculate_vested_amount(&schedule, 1000), 0);
-
-    // Before cliff (vesting accrues from start)
-    assert_eq!(calculate_vested_amount(&schedule, 1100), 100);
-
-    // At cliff
-    assert_eq!(calculate_vested_amount(&schedule, 1200), 200);
-
-    // Halfway
-    assert_eq!(calculate_vested_amount(&schedule, 1500), 500);
-
-    // After end
-    assert_eq!(calculate_vested_amount(&schedule, 2500), 1000);
+#[test]
+fn create_schedule_happy_path_stores_correct_fields() {
+    let ctx = setup();
+    create_default(&ctx, true);
+    let stored = ctx.contract.get_vesting_schedule(&ctx.beneficiary);
+    assert_eq!(stored.beneficiary, ctx.beneficiary);
+    assert_eq!(stored.total_amount, TOTAL);
+    assert_eq!(stored.claimed_amount, 0);
+    assert_eq!(stored.start_time, START);
+    assert_eq!(stored.end_time, END);
+    assert_eq!(stored.cliff_time, CLIFF);
+    assert!(stored.revocable);
+    assert!(!stored.revoked);
 }
 
 #[test]
-fn test_calculate_claimable_amount() {
+fn create_schedule_twice_returns_already_exists() {
+    let ctx = setup();
+    create_default(&ctx, true);
+    let result = ctx.contract.try_create_vesting_schedule(
+        &ctx.admin,
+        &ctx.beneficiary,
+        &TOTAL,
+        &START,
+        &END,
+        &CLIFF,
+        &true,
+    );
+    assert_eq!(result, Err(Ok(ContractError::ScheduleAlreadyExists)));
+}
+
+#[test]
+fn create_rejects_end_time_at_or_before_start() {
+    let ctx = setup();
+    let result = ctx.contract.try_create_vesting_schedule(
+        &ctx.admin,
+        &ctx.beneficiary,
+        &TOTAL,
+        &END,
+        &START,
+        &CLIFF,
+        &true,
+    );
+    assert_eq!(result, Err(Ok(ContractError::InvalidTimeParameters)));
+
+    let result_equal = ctx.contract.try_create_vesting_schedule(
+        &ctx.admin,
+        &ctx.beneficiary,
+        &TOTAL,
+        &START,
+        &START,
+        &START,
+        &true,
+    );
+    assert_eq!(result_equal, Err(Ok(ContractError::InvalidTimeParameters)));
+}
+
+#[test]
+fn create_rejects_cliff_outside_start_end_window() {
+    let ctx = setup();
+
+    let before_start = ctx.contract.try_create_vesting_schedule(
+        &ctx.admin,
+        &ctx.beneficiary,
+        &TOTAL,
+        &START,
+        &END,
+        &(START - 1),
+        &true,
+    );
+    assert_eq!(before_start, Err(Ok(ContractError::InvalidCliffTime)));
+
+    let after_end = ctx.contract.try_create_vesting_schedule(
+        &ctx.admin,
+        &ctx.beneficiary,
+        &TOTAL,
+        &START,
+        &END,
+        &(END + 1),
+        &true,
+    );
+    assert_eq!(after_end, Err(Ok(ContractError::InvalidCliffTime)));
+}
+
+#[test]
+fn create_rejects_non_positive_amount() {
+    let ctx = setup();
+    for bad in [0, -1, -1_000].into_iter() {
+        let result = ctx.contract.try_create_vesting_schedule(
+            &ctx.admin,
+            &ctx.beneficiary,
+            &bad,
+            &START,
+            &END,
+            &CLIFF,
+            &true,
+        );
+        assert_eq!(result, Err(Ok(ContractError::InvalidAmount)));
+    }
+}
+
+// ── 3. Claim before cliff ────────────────────────────────────────────────────
+
+#[test]
+fn claim_before_cliff_returns_cliff_not_reached() {
+    let ctx = setup();
+    create_default(&ctx, true);
+    set_time(&ctx.env, CLIFF - 1);
+    let result = ctx.contract.try_claim(&ctx.beneficiary);
+    assert_eq!(result, Err(Ok(ContractError::CliffNotReached)));
+}
+
+// ── 4. Claim after cliff, before end ─────────────────────────────────────────
+
+#[test]
+fn partial_claim_is_proportional_to_elapsed_time() {
+    let ctx = setup();
+    create_default(&ctx, true);
+    // Halfway through the vesting window
+    let halfway = START + (END - START) / 2;
+    set_time(&ctx.env, halfway);
+    let claimed = ctx.contract.claim(&ctx.beneficiary);
+    assert_eq!(claimed, TOTAL / 2);
+    let stored = ctx.contract.get_vesting_schedule(&ctx.beneficiary);
+    assert_eq!(stored.claimed_amount, TOTAL / 2);
+}
+
+#[test]
+fn repeated_partial_claims_accumulate_and_never_exceed_vested() {
+    let ctx = setup();
+    create_default(&ctx, true);
+
+    // Quarter-way → claim 250k
+    set_time(&ctx.env, START + (END - START) / 4);
+    let first = ctx.contract.claim(&ctx.beneficiary);
+    assert_eq!(first, TOTAL / 4);
+
+    // Halfway → claim the next 250k (cumulative vested - already claimed)
+    set_time(&ctx.env, START + (END - START) / 2);
+    let second = ctx.contract.claim(&ctx.beneficiary);
+    assert_eq!(second, TOTAL / 4);
+
+    let stored = ctx.contract.get_vesting_schedule(&ctx.beneficiary);
+    assert_eq!(stored.claimed_amount, TOTAL / 2);
+
+    // Claiming again at the same instant must return NothingToClaim — the
+    // schedule does not let the beneficiary claim more than is vested.
+    let third = ctx.contract.try_claim(&ctx.beneficiary);
+    assert_eq!(third, Err(Ok(ContractError::NothingToClaim)));
+}
+
+// ── 5. Claim at/after end ────────────────────────────────────────────────────
+
+#[test]
+fn full_claim_at_or_after_end_releases_total_then_returns_nothing_to_claim() {
+    let ctx = setup();
+    create_default(&ctx, true);
+    set_time(&ctx.env, END);
+    let claimed = ctx.contract.claim(&ctx.beneficiary);
+    assert_eq!(claimed, TOTAL);
+
+    // A second claim past end must report NothingToClaim, not double-pay.
+    let second = ctx.contract.try_claim(&ctx.beneficiary);
+    assert_eq!(second, Err(Ok(ContractError::NothingToClaim)));
+}
+
+// ── 6. Revoke ────────────────────────────────────────────────────────────────
+
+#[test]
+fn revocable_schedule_returns_unclaimed_to_admin_and_blocks_further_claims() {
+    let ctx = setup();
+    create_default(&ctx, true);
+
+    // Claim a quarter, then revoke.
+    set_time(&ctx.env, START + (END - START) / 4);
+    let claimed = ctx.contract.claim(&ctx.beneficiary);
+    assert_eq!(claimed, TOTAL / 4);
+
+    let returned = ctx.contract.revoke(&ctx.admin, &ctx.beneficiary);
+    assert_eq!(returned, TOTAL - TOTAL / 4);
+
+    // Claim after revoke → Revoked error.
+    set_time(&ctx.env, END);
+    let attempt = ctx.contract.try_claim(&ctx.beneficiary);
+    assert_eq!(attempt, Err(Ok(ContractError::Revoked)));
+}
+
+#[test]
+fn non_revocable_schedule_cannot_be_revoked() {
+    let ctx = setup();
+    create_default(&ctx, false);
+    let result = ctx.contract.try_revoke(&ctx.admin, &ctx.beneficiary);
+    assert_eq!(result, Err(Ok(ContractError::NotRevocable)));
+}
+
+#[test]
+fn revoking_twice_returns_already_revoked() {
+    let ctx = setup();
+    create_default(&ctx, true);
+    ctx.contract.revoke(&ctx.admin, &ctx.beneficiary);
+    let result = ctx.contract.try_revoke(&ctx.admin, &ctx.beneficiary);
+    assert_eq!(result, Err(Ok(ContractError::AlreadyRevoked)));
+}
+
+// ── 7. Pause ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn claim_is_blocked_while_paused_and_works_again_after_unpause() {
+    let ctx = setup();
+    create_default(&ctx, true);
+    set_time(&ctx.env, END);
+
+    ctx.contract.pause(&ctx.admin);
+    assert!(ctx.contract.is_paused());
+
+    let blocked = ctx.contract.try_claim(&ctx.beneficiary);
+    assert_eq!(blocked, Err(Ok(ContractError::Paused)));
+
+    ctx.contract.unpause(&ctx.admin);
+    assert!(!ctx.contract.is_paused());
+
+    let claimed = ctx.contract.claim(&ctx.beneficiary);
+    assert_eq!(claimed, TOTAL);
+}
+
+// ── Auxiliary: not-found & auth paths ────────────────────────────────────────
+
+#[test]
+fn claim_with_no_schedule_returns_schedule_not_found() {
+    let ctx = setup();
+    let stranger = Address::generate(&ctx.env);
+    let result = ctx.contract.try_claim(&stranger);
+    assert_eq!(result, Err(Ok(ContractError::ScheduleNotFound)));
+}
+
+#[test]
+fn non_admin_cannot_create_revoke_or_pause() {
+    let ctx = setup();
+    let stranger = Address::generate(&ctx.env);
+
+    let create = ctx.contract.try_create_vesting_schedule(
+        &stranger,
+        &ctx.beneficiary,
+        &TOTAL,
+        &START,
+        &END,
+        &CLIFF,
+        &true,
+    );
+    assert_eq!(create, Err(Ok(ContractError::NotAuthorized)));
+
+    create_default(&ctx, true);
+
+    let revoke = ctx.contract.try_revoke(&stranger, &ctx.beneficiary);
+    assert_eq!(revoke, Err(Ok(ContractError::NotAuthorized)));
+
+    let pause = ctx.contract.try_pause(&stranger);
+    assert_eq!(pause, Err(Ok(ContractError::NotAuthorized)));
+}
+
+// ── Pure helpers (no Env required) ──────────────────────────────────────────
+
+#[test]
+fn pure_calculate_vested_amount_is_linear_between_start_and_end() {
+    let env = Env::default();
     let schedule = VestingSchedule {
-        beneficiary: Address::generate(&Env::default()),
-        total_amount: 1000,
-        claimed_amount: 200,
-        start_time: 1000,
-        end_time: 2000,
-        cliff_time: 1200,
+        beneficiary: Address::generate(&env),
+        total_amount: 1_000,
+        claimed_amount: 0,
+        start_time: 1_000,
+        end_time: 2_000,
+        cliff_time: 1_200,
         revocable: true,
         revoked: false,
     };
+    assert_eq!(calculate_vested_amount(&schedule, 900), 0);
+    assert_eq!(calculate_vested_amount(&schedule, 1_000), 0);
+    assert_eq!(calculate_vested_amount(&schedule, 1_500), 500);
+    assert_eq!(calculate_vested_amount(&schedule, 2_500), 1_000);
+}
 
-    // Halfway, already claimed 200
-    assert_eq!(calculate_claimable_amount(&schedule, 1500), 300);
+#[test]
+fn pure_calculate_claimable_amount_subtracts_already_claimed_and_honours_cliff() {
+    let env = Env::default();
+    let mut schedule = VestingSchedule {
+        beneficiary: Address::generate(&env),
+        total_amount: 1_000,
+        claimed_amount: 200,
+        start_time: 1_000,
+        end_time: 2_000,
+        cliff_time: 1_200,
+        revocable: true,
+        revoked: false,
+    };
+    // Before cliff: nothing claimable even though vesting has accrued.
+    assert_eq!(calculate_claimable_amount(&schedule, 1_100), 0);
+    // Halfway, already claimed 200 → 300 left to claim now.
+    assert_eq!(calculate_claimable_amount(&schedule, 1_500), 300);
+
+    // After the schedule is fully claimed, saturating subtraction returns 0.
+    schedule.claimed_amount = 1_000;
+    assert_eq!(calculate_claimable_amount(&schedule, 2_500), 0);
 }

--- a/contracts/vesting_schedule/src/test.rs
+++ b/contracts/vesting_schedule/src/test.rs
@@ -9,8 +9,6 @@
 //!   6. Revoke flow (revocable, NotRevocable, AlreadyRevoked, claim-after-revoke)
 //!   7. Pause flow (claim blocked, then succeeds after unpause)
 
-#![cfg(test)]
-
 use soroban_sdk::testutils::{Address as _, Ledger};
 use soroban_sdk::{Address, Env};
 
@@ -49,7 +47,13 @@ fn setup<'a>() -> Ctx<'a> {
 
     env.ledger().with_mut(|li| li.timestamp = START - 1);
 
-    Ctx { env, contract, admin, token, beneficiary }
+    Ctx {
+        env,
+        contract,
+        admin,
+        token,
+        beneficiary,
+    }
 }
 
 fn create_default(ctx: &Ctx, revocable: bool) {

--- a/frontend/components/theme-toggle.test.tsx
+++ b/frontend/components/theme-toggle.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { ThemeToggle } from './theme-toggle'
+
+// ── Mocks ──────────────────────────────────────────────────────────────────
+
+const themeState: {
+  resolvedTheme: 'light' | 'dark' | undefined
+  setTheme: ReturnType<typeof vi.fn>
+} = {
+  resolvedTheme: 'light',
+  setTheme: vi.fn(),
+}
+
+vi.mock('next-themes', () => ({
+  useTheme: () => themeState,
+}))
+
+let mounted = true
+vi.mock('@/hooks/use-mounted', () => ({
+  useMounted: () => mounted,
+}))
+
+beforeEach(() => {
+  themeState.resolvedTheme = 'light'
+  themeState.setTheme = vi.fn()
+  mounted = true
+})
+
+describe('ThemeToggle', () => {
+  it('shows the moon icon and the "switch to dark mode" label when the theme is light', () => {
+    themeState.resolvedTheme = 'light'
+    render(<ThemeToggle />)
+    expect(screen.getByRole('button', { name: /switch to dark mode/i })).toBeTruthy()
+  })
+
+  it('shows the sun icon and the "switch to light mode" label when the theme is dark', () => {
+    themeState.resolvedTheme = 'dark'
+    render(<ThemeToggle />)
+    expect(screen.getByRole('button', { name: /switch to light mode/i })).toBeTruthy()
+  })
+
+  it('flips the theme on click', () => {
+    themeState.resolvedTheme = 'light'
+    render(<ThemeToggle />)
+    fireEvent.click(screen.getByRole('button', { name: /switch to dark mode/i }))
+    expect(themeState.setTheme).toHaveBeenCalledWith('dark')
+
+    themeState.resolvedTheme = 'dark'
+    render(<ThemeToggle />)
+    fireEvent.click(screen.getByRole('button', { name: /switch to light mode/i }))
+    expect(themeState.setTheme).toHaveBeenLastCalledWith('light')
+  })
+
+  it('renders a disabled placeholder before hydration so the icon does not flash', () => {
+    mounted = false
+    render(<ThemeToggle />)
+    const button = screen.getByRole('button') as HTMLButtonElement
+    expect(button.disabled).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

Three of the four assigned issues bundled into one PR. **#925 is intentionally not in this PR — see below.**

- **#924 — Vesting schedule: bug fixes + comprehensive tests** (`contracts/vesting_schedule/`): the existing `lib.rs` had three bugs that the comprehensive test suite immediately surfaces — `claim()` did not enforce the cliff, did not honour the pause flag, and admin gating used `env.current_contract_address()` (effectively making admin calls unreachable). I rewrote the public methods to take an explicit `admin: Address` caller, return `Result<_, ContractError>` instead of panicking, enforce the cliff and pause inside `claim()`, and emit `vesting/created`, `vesting/claimed`, `vesting/revoked` events. Bumped `soroban-sdk` from `21.0.0` to `22.0.7` to match the rest of the contracts workspace (the test harness needs `env.register(...)` which arrived in 22). Replaced the 53-line stub `test.rs` with **18 tests** covering all 7 categories the issue lists (init / create / cliff / partial+repeat claims / full claim / revoke / pause) plus auth and pure-helper coverage.
- **#929 — OpenAPI registry & Swagger UI** (`backend/src/docs/openApiRegistry.ts` + wiring in `backend/src/app.ts`): a new module that loads the existing hand-maintained `backend/docs/openapi.yml`, exposes `loadOpenApiSpec()`, and `mountOpenApiDocs(app)` which serves Swagger UI at `/docs` and the raw spec at `/docs/openapi.json`. Defaults to disabled when `NODE_ENV === 'production'` and accepts a `guard` middleware so operators can enable docs behind admin auth in prod. ESM-safe path resolution via `import.meta.url`. Includes **12 tests** for spec loading, validation errors, default + custom basePath, the guard middleware, and the production gating.
- **#957 — Dark Mode / theme system** (`frontend/components/theme-toggle.test.tsx`): the `ThemeProvider` is already wired into `app/layout.tsx` (attribute=class, defaultTheme=system, enableSystem, disableTransitionOnChange, localStorage via `next-themes`) and the `ThemeToggle` is already mounted in the global `Header`. Added **4 tests** covering the icon/aria-label swap, the click-to-toggle behaviour, and the pre-hydration disabled placeholder.

## Test plan

- [x] `cargo test -p vesting_schedule` — **18 / 18 pass**.
- [x] `vitest run src/docs/openApiRegistry.test.ts` (backend) — **12 / 12 pass**.
- [x] `vitest run components/theme-toggle.test.tsx` (frontend) — **4 / 4 pass**.
- [x] `tsc --noEmit` clean for the new files (a pre-existing unrelated `app.ts:538` type error remains).

## #925 — Bond Collateral / Slashing Integration (deferred)

After auditing `contracts/bond_collateral` (612 lines) and `contracts/slashing_module` (625 lines), both already exist as substantial implementations of **different abstractions** than the issue specifies:

- `bond_collateral` is a **collateralised bond issuance** contract: positions identified by `BytesN<32>`, `deposit_collateral` / `issue_bond` / `redeem_bond` / `withdraw_collateral` / `liquidate`. There is no per-inspector bond, no `lock_bond(inspector, inspection_id)`, no `execute_slash` cross-contract call.
- `slashing_module` is an **evidence-based jail/slash** contract: `submit_evidence` with hash + signature, jail state, slash count, `approve_unjail` / `unjail`. No `slash(inspector, amount)` callable by the bond contract.

Delivering the issue's spec would require either rewriting both contracts (a breaking change for everything that already integrates with them) or adding a parallel inspector-bond layer with its own storage. Either approach is too large for this PR and warrants a separate design discussion. I'm leaving #925 open for a dedicated follow-up rather than silently closing it.

Closes #924
Closes #929
Closes #957