### PR TITLE
fix(ci): parallelise pipeline with caching and contract tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,15 +8,39 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  frontend:
-    name: Frontend (lint, build)
+  test-frontend:
+    name: test-frontend
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: frontend
     steps:
       - uses: actions/checkout@v4
+
+      - name: Record job start
+        run: echo "JOB_START_EPOCH=$(date +%s)" >> "$GITHUB_ENV"
+
+      - name: Cache pnpm store
+        id: cache-pnpm-frontend
+        uses: actions/cache@v4
+        with:
+          path: ~/.local/share/pnpm/store
+          key: pnpm-frontend-${{ runner.os }}-${{ hashFiles('frontend/pnpm-lock.yaml') }}
+          restore-keys: |
+            pnpm-frontend-${{ runner.os }}-
+
+      - name: Print cache status
+        run: |
+          if [ "${{ steps.cache-pnpm-frontend.outputs.cache-hit }}" = "true" ]; then
+            echo "pnpm cache: HIT (key pnpm-frontend-${{ runner.os }}-${{ hashFiles('frontend/pnpm-lock.yaml') }})"
+          else
+            echo "pnpm cache: MISS (key pnpm-frontend-${{ runner.os }}-${{ hashFiles('frontend/pnpm-lock.yaml') }})"
+          fi
 
       - uses: actions/setup-node@v4
         with:
@@ -29,14 +53,21 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Lint
-        run: pnpm run lint
+      - name: Test
+        run: pnpm run test --if-present
 
       - name: Build
         run: pnpm run build
 
-  backend:
-    name: Backend (lint, test)
+      - name: Report job duration
+        if: always()
+        run: |
+          END=$(date +%s)
+          DURATION=$((END - JOB_START_EPOCH))
+          echo "### test-frontend: ${DURATION}s" >> "$GITHUB_STEP_SUMMARY"
+
+  test-backend:
+    name: test-backend
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -44,17 +75,32 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Record job start
+        run: echo "JOB_START_EPOCH=$(date +%s)" >> "$GITHUB_ENV"
+
+      - name: Cache npm
+        id: cache-npm-backend
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: npm-backend-${{ runner.os }}-${{ hashFiles('backend/package-lock.json') }}
+          restore-keys: |
+            npm-backend-${{ runner.os }}-
+
+      - name: Print cache status
+        run: |
+          if [ "${{ steps.cache-npm-backend.outputs.cache-hit }}" = "true" ]; then
+            echo "npm cache: HIT (key npm-backend-${{ runner.os }}-${{ hashFiles('backend/package-lock.json') }})"
+          else
+            echo "npm cache: MISS (key npm-backend-${{ runner.os }}-${{ hashFiles('backend/package-lock.json') }})"
+          fi
+
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-          cache: npm
-          cache-dependency-path: backend/package-lock.json
 
       - name: Install dependencies
         run: npm ci
-
-      - name: Lint
-        run: npm run lint
 
       - name: Unit tests
         run: npm run test:ci --if-present
@@ -62,8 +108,15 @@ jobs:
       - name: Validate OpenAPI spec
         run: npm run openapi:validate
 
-  contracts:
-    name: Contracts (fmt, clippy, test)
+      - name: Report job duration
+        if: always()
+        run: |
+          END=$(date +%s)
+          DURATION=$((END - JOB_START_EPOCH))
+          echo "### test-backend: ${DURATION}s" >> "$GITHUB_STEP_SUMMARY"
+
+  test-contracts:
+    name: test-contracts
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -71,22 +124,251 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Rust (stable + fmt/clippy)
-        uses: dtolnay/rust-toolchain@stable
+      - name: Record job start
+        run: echo "JOB_START_EPOCH=$(date +%s)" >> "$GITHUB_ENV"
+
+      - name: Cache Cargo registry, git, and target deps
+        id: cache-cargo-contracts
+        uses: actions/cache@v4
         with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            contracts/target/incremental
+            contracts/target/deps
+          key: cargo-contracts-${{ hashFiles('contracts/Cargo.lock') }}
+          restore-keys: |
+            cargo-contracts-
+
+      - name: Print cache status
+        run: |
+          if [ "${{ steps.cache-cargo-contracts.outputs.cache-hit }}" = "true" ]; then
+            echo "cargo cache: HIT (key cargo-contracts-${{ hashFiles('contracts/Cargo.lock') }})"
+          else
+            echo "cargo cache: MISS (key cargo-contracts-${{ hashFiles('contracts/Cargo.lock') }})"
+          fi
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
           components: rustfmt, clippy
 
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: |
-            contracts -> target
+      - name: Run contract tests
+        run: cargo test --workspace
+
+      - name: Run Clippy (warnings as errors)
+        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 
       - name: Check formatting
         run: cargo fmt --all -- --check
 
-      - name: Clippy
-        run: cargo clippy --workspace --all-targets --all-features
+      - name: Report job duration
+        if: always()
+        run: |
+          END=$(date +%s)
+          DURATION=$((END - JOB_START_EPOCH))
+          echo "### test-contracts: ${DURATION}s" >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Tests
-        run: cargo test --workspace
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Record job start
+        run: echo "JOB_START_EPOCH=$(date +%s)" >> "$GITHUB_ENV"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - uses: pnpm/action-setup@v3
+        with:
+          version: 9.15.5
+
+      - name: Cache pnpm (lint frontend)
+        id: cache-pnpm-lint
+        uses: actions/cache@v4
+        with:
+          path: ~/.local/share/pnpm/store
+          key: pnpm-lint-${{ runner.os }}-${{ hashFiles('frontend/pnpm-lock.yaml') }}
+          restore-keys: |
+            pnpm-lint-${{ runner.os }}-
+
+      - name: Print frontend cache status
+        run: |
+          if [ "${{ steps.cache-pnpm-lint.outputs.cache-hit }}" = "true" ]; then
+            echo "pnpm cache: HIT"
+          else
+            echo "pnpm cache: MISS"
+          fi
+
+      - name: Lint frontend
+        working-directory: frontend
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm run lint
+
+      - name: Cache npm (lint backend)
+        id: cache-npm-lint
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: npm-lint-${{ runner.os }}-${{ hashFiles('backend/package-lock.json') }}
+          restore-keys: |
+            npm-lint-${{ runner.os }}-
+
+      - name: Print backend cache status
+        run: |
+          if [ "${{ steps.cache-npm-lint.outputs.cache-hit }}" = "true" ]; then
+            echo "npm cache: HIT"
+          else
+            echo "npm cache: MISS"
+          fi
+
+      - name: Lint backend
+        working-directory: backend
+        run: |
+          npm ci
+          npm run lint
+
+      - name: Report job duration
+        if: always()
+        run: |
+          END=$(date +%s)
+          DURATION=$((END - JOB_START_EPOCH))
+          echo "### lint: ${DURATION}s" >> "$GITHUB_STEP_SUMMARY"
+
+  type-check:
+    name: type-check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Record job start
+        run: echo "JOB_START_EPOCH=$(date +%s)" >> "$GITHUB_ENV"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - uses: pnpm/action-setup@v3
+        with:
+          version: 9.15.5
+
+      - name: Type-check frontend
+        working-directory: frontend
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm exec tsc --noEmit
+
+      - name: Type-check backend
+        working-directory: backend
+        run: |
+          npm ci
+          npm run typecheck
+
+      - name: Report job duration
+        if: always()
+        run: |
+          END=$(date +%s)
+          DURATION=$((END - JOB_START_EPOCH))
+          echo "### type-check: ${DURATION}s" >> "$GITHUB_STEP_SUMMARY"
+
+  security-scan:
+    name: security-scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Record job start
+        run: echo "JOB_START_EPOCH=$(date +%s)" >> "$GITHUB_ENV"
+
+      - name: Cache npm (security-scan backend)
+        id: cache-npm-security
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: npm-security-${{ runner.os }}-${{ hashFiles('backend/package-lock.json') }}
+          restore-keys: |
+            npm-security-${{ runner.os }}-
+
+      - name: Print npm cache status
+        run: |
+          if [ "${{ steps.cache-npm-security.outputs.cache-hit }}" = "true" ]; then
+            echo "npm cache: HIT"
+          else
+            echo "npm cache: MISS"
+          fi
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Audit backend dependencies
+        working-directory: backend
+        run: |
+          npm ci
+          npm audit --audit-level=critical
+
+      - name: Report high backend vulnerabilities (informational)
+        working-directory: backend
+        run: npm audit --audit-level=high
+        continue-on-error: true
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked
+
+      - name: Audit contract dependencies
+        working-directory: contracts
+        run: cargo audit
+
+      - name: Report job duration
+        if: always()
+        run: |
+          END=$(date +%s)
+          DURATION=$((END - JOB_START_EPOCH))
+          echo "### security-scan: ${DURATION}s" >> "$GITHUB_STEP_SUMMARY"
+
+  ci-summary:
+    name: ci-summary
+    runs-on: ubuntu-latest
+    needs:
+      - test-frontend
+      - test-backend
+      - test-contracts
+      - lint
+      - type-check
+      - security-scan
+    if: always()
+    steps:
+      - name: CI timing overview
+        run: |
+          echo "## CI job timing" >> "$GITHUB_STEP_SUMMARY"
+          echo "Per-job durations are recorded above by each parallel job." >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Job | Result |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|-----|--------|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| test-frontend | ${{ needs.test-frontend.result }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| test-backend | ${{ needs.test-backend.result }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| test-contracts | ${{ needs.test-contracts.result }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| lint | ${{ needs.lint.result }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| type-check | ${{ needs.type-check.result }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| security-scan | ${{ needs.security-scan.result }} |" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Fail if a required job failed
+        run: |
+          for result in \
+            "${{ needs.test-frontend.result }}" \
+            "${{ needs.test-backend.result }}" \
+            "${{ needs.test-contracts.result }}" \
+            "${{ needs.lint.result }}" \
+            "${{ needs.type-check.result }}" \
+            "${{ needs.security-scan.result }}"; do
+            if [ "$result" = "failure" ] || [ "$result" = "cancelled" ]; then
+              echo "A required CI job did not succeed."
+              exit 1
+            fi
+          done

--- a/contracts/rent_schedule/src/lib.rs
+++ b/contracts/rent_schedule/src/lib.rs
@@ -1,6 +1,8 @@
 #![no_std]
 
-use soroban_sdk::{contract, contractimpl, contracttype, Address, BytesN, Env, String, Symbol, Vec};
+use soroban_sdk::{
+    contract, contractimpl, contracttype, Address, BytesN, Env, String, Symbol, Vec,
+};
 
 #[contracttype]
 #[derive(Clone)]
@@ -199,12 +201,7 @@ impl RentSchedule {
         );
     }
 
-    pub fn mark_overdue(
-        env: Env,
-        caller: Address,
-        deal_id: String,
-        instalment_number: u32,
-    ) {
+    pub fn mark_overdue(env: Env, caller: Address, deal_id: String, instalment_number: u32) {
         require_not_paused(&env);
         let cfg: Config = env
             .storage()
@@ -243,12 +240,7 @@ impl RentSchedule {
         );
     }
 
-    pub fn waive_instalment(
-        env: Env,
-        caller: Address,
-        deal_id: String,
-        instalment_number: u32,
-    ) {
+    pub fn waive_instalment(env: Env, caller: Address, deal_id: String, instalment_number: u32) {
         let cfg: Config = env
             .storage()
             .instance()

--- a/contracts/rent_wallet/src/monthly_cap.rs
+++ b/contracts/rent_wallet/src/monthly_cap.rs
@@ -63,9 +63,10 @@ pub fn record_monthly_spent(env: &Env, user: &Address, additional: i128) {
         .persistent()
         .get::<_, i128>(&crate::DataKey::MonthlySpent(user.clone(), key))
         .unwrap_or(0);
-    env.storage()
-        .persistent()
-        .set(&crate::DataKey::MonthlySpent(user.clone(), key), &(current + additional));
+    env.storage().persistent().set(
+        &crate::DataKey::MonthlySpent(user.clone(), key),
+        &(current + additional),
+    );
 }
 
 /// Called from `debit()` before the balance is modified.
@@ -92,7 +93,10 @@ pub fn check_and_record_debit(
 
 pub fn emit_monthly_cap_set(env: &Env, user: Option<Address>, cap: i128) {
     env.events().publish(
-        (Symbol::new(env, "monthly_cap"), Symbol::new(env, "monthly_cap_set")),
+        (
+            Symbol::new(env, "monthly_cap"),
+            Symbol::new(env, "monthly_cap_set"),
+        ),
         (user, cap),
     );
 }

--- a/contracts/rent_wallet/src/monthly_cap_tests.rs
+++ b/contracts/rent_wallet/src/monthly_cap_tests.rs
@@ -22,9 +22,8 @@ mod monthly_cap_tests {
         env.mock_all_auths();
 
         let contract_id = env.register(RentWallet, ());
-        let client: RentWalletClient<'static> = unsafe {
-            std::mem::transmute(RentWalletClient::new(&env, &contract_id))
-        };
+        let client: RentWalletClient<'static> =
+            unsafe { std::mem::transmute(RentWalletClient::new(&env, &contract_id)) };
 
         let admin = Address::generate(&env);
         let user = Address::generate(&env);
@@ -33,7 +32,10 @@ mod monthly_cap_tests {
         env.ledger().set_timestamp(MONTH_SECS); // put us in month 1
 
         // Fund user
-        client.try_credit(&admin, &user, &10_000i128).unwrap().unwrap();
+        client
+            .try_credit(&admin, &user, &10_000i128)
+            .unwrap()
+            .unwrap();
 
         (env, contract_id, client, admin, user)
     }
@@ -88,7 +90,10 @@ mod monthly_cap_tests {
             .unwrap()
             .unwrap();
 
-        client.try_debit(&admin, &user, &1_000i128).unwrap().unwrap();
+        client
+            .try_debit(&admin, &user, &1_000i128)
+            .unwrap()
+            .unwrap();
         // 1000 spent, 500 remaining
         client.try_debit(&admin, &user, &500i128).unwrap().unwrap();
         // 1500 spent — exactly at cap; next debit must fail

--- a/contracts/src/governance.rs
+++ b/contracts/src/governance.rs
@@ -20,15 +20,15 @@ impl GovernanceContract {
         if env.ledger().timestamp() < proposal.deadline {
             panic!("Too early");
         }
-        
+
         if proposal.votes_for < quorum {
             panic!("No quorum");
         }
-        
+
         if proposal.vetoed {
             panic!("Vetoed");
         }
-        
+
         // Execute logic here
     }
 }

--- a/contracts/src/multisig.rs
+++ b/contracts/src/multisig.rs
@@ -29,7 +29,9 @@ impl MultisigContract {
         }
 
         approvals.push_back(signer);
-        env.storage().persistent().set(&DataKey::Approvals(op_id), &approvals);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Approvals(op_id), &approvals);
     }
 
     pub fn execute(env: Env, op_id: u64, threshold: u32) {
@@ -42,7 +44,7 @@ impl MultisigContract {
         if approvals.len() < threshold {
             panic!("Not enough approvals");
         }
-        
+
         // Execute logic here
     }
 
@@ -59,7 +61,9 @@ impl MultisigContract {
                 new_approvals.push_back(s);
             }
         }
-        
-        env.storage().persistent().set(&DataKey::Approvals(op_id), &new_approvals);
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Approvals(op_id), &new_approvals);
     }
 }

--- a/contracts/upgradeable_proxy/src/lib.rs
+++ b/contracts/upgradeable_proxy/src/lib.rs
@@ -22,10 +22,10 @@
 //! - The confirmed hash must match the proposed hash (prevents TOCTOU).
 //! - Admin can be transferred via the same two-step flow.
 
+use soroban_sdk::Address;
 use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, BytesN, Env, Map, String, Symbol,
 };
-use soroban_sdk::Address;
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Storage keys
@@ -108,11 +108,7 @@ impl UpgradeableProxy {
 
     /// Initialise the proxy with an admin and a second approver.
     /// Can only be called once.
-    pub fn init(
-        env: Env,
-        admin: Address,
-        second_approver: Address,
-    ) -> Result<(), ProxyError> {
+    pub fn init(env: Env, admin: Address, second_approver: Address) -> Result<(), ProxyError> {
         if env.storage().instance().has(&DataKey::Admin) {
             return Err(ProxyError::AlreadyInitialized);
         }
@@ -201,10 +197,13 @@ impl UpgradeableProxy {
 
         let old_version = get_version(&env);
         let new_version = old_version + 1;
-        env.storage().instance().set(&DataKey::Version, &new_version);
+        env.storage()
+            .instance()
+            .set(&DataKey::Version, &new_version);
 
         // Swap the WASM — all storage above is preserved.
-        env.deployer().update_current_contract_wasm(new_wasm_hash.clone());
+        env.deployer()
+            .update_current_contract_wasm(new_wasm_hash.clone());
 
         env.events().publish(
             (
@@ -244,11 +243,7 @@ impl UpgradeableProxy {
     /// Transfer admin rights. Requires current admin auth; new admin takes
     /// effect immediately (single-step for simplicity — extend to two-step
     /// if desired).
-    pub fn transfer_admin(
-        env: Env,
-        admin: Address,
-        new_admin: Address,
-    ) -> Result<(), ProxyError> {
+    pub fn transfer_admin(env: Env, admin: Address, new_admin: Address) -> Result<(), ProxyError> {
         admin.require_auth();
 
         if admin != get_admin(&env) {

--- a/contracts/whistleblower_rewards/src/upgrade_governance_tests.rs
+++ b/contracts/whistleblower_rewards/src/upgrade_governance_tests.rs
@@ -50,10 +50,15 @@ mod upgrade_governance_tests {
 
         // Leak the Env to give it 'static lifetime so Ctx can own client
         let env: Env = unsafe { std::mem::transmute(env) };
-        let client: WhistleblowerRewardsClient<'static> =
-            unsafe { std::mem::transmute(client) };
+        let client: WhistleblowerRewardsClient<'static> = unsafe { std::mem::transmute(client) };
 
-        Ctx { env, contract_id, client, admin, operator }
+        Ctx {
+            env,
+            contract_id,
+            client,
+            admin,
+            operator,
+        }
     }
 
     // ── Helper: leaks Env to 'static so the struct is self-contained ─────────
@@ -122,10 +127,7 @@ mod upgrade_governance_tests {
     fn proposing_while_upgrade_pending_fails() {
         let (env, _contract_id, client, admin, _operator) = make_env_and_client();
         let hash = zeroed_hash(&env);
-        client
-            .try_propose_upgrade(&admin, &hash)
-            .unwrap()
-            .unwrap();
+        client.try_propose_upgrade(&admin, &hash).unwrap().unwrap();
 
         let err = client
             .try_propose_upgrade(&admin, &alt_hash(&env))
@@ -149,17 +151,11 @@ mod upgrade_governance_tests {
 
         env.ledger().set_timestamp(1_000);
         let hash = zeroed_hash(&env);
-        client
-            .try_propose_upgrade(&admin, &hash)
-            .unwrap()
-            .unwrap();
+        client.try_propose_upgrade(&admin, &hash).unwrap().unwrap();
 
         // Advance to just before delay expires
         env.ledger().set_timestamp(1_000 + delay_secs - 1);
-        let err = client
-            .try_execute_upgrade(&admin)
-            .unwrap()
-            .unwrap_err();
+        let err = client.try_execute_upgrade(&admin).unwrap().unwrap_err();
         assert_eq!(err, ContractError::UpgradeDelayNotMet);
     }
 
@@ -174,10 +170,7 @@ mod upgrade_governance_tests {
 
         env.ledger().set_timestamp(1_000);
         let hash = zeroed_hash(&env);
-        client
-            .try_propose_upgrade(&admin, &hash)
-            .unwrap()
-            .unwrap();
+        client.try_propose_upgrade(&admin, &hash).unwrap().unwrap();
 
         env.ledger().set_timestamp(1_000 + delay_secs);
         // execute_upgrade calls env.deployer().update_current_contract_wasm — this will
@@ -205,10 +198,7 @@ mod upgrade_governance_tests {
         // Default delay is 0 — propose+execute should pass immediately
         env.ledger().set_timestamp(500);
         let hash = zeroed_hash(&env);
-        client
-            .try_propose_upgrade(&admin, &hash)
-            .unwrap()
-            .unwrap();
+        client.try_propose_upgrade(&admin, &hash).unwrap().unwrap();
 
         // No delay set → execute should NOT return UpgradeDelayNotMet
         let result = client.try_execute_upgrade(&admin);
@@ -225,10 +215,7 @@ mod upgrade_governance_tests {
     fn admin_can_cancel_pending_upgrade() {
         let (env, _contract_id, client, admin, _operator) = make_env_and_client();
         let hash = zeroed_hash(&env);
-        client
-            .try_propose_upgrade(&admin, &hash)
-            .unwrap()
-            .unwrap();
+        client.try_propose_upgrade(&admin, &hash).unwrap().unwrap();
 
         client
             .try_cancel_upgrade(&admin)
@@ -240,26 +227,17 @@ mod upgrade_governance_tests {
     fn after_cancel_execute_upgrade_fails_with_no_pending() {
         let (env, _contract_id, client, admin, _operator) = make_env_and_client();
         let hash = zeroed_hash(&env);
-        client
-            .try_propose_upgrade(&admin, &hash)
-            .unwrap()
-            .unwrap();
+        client.try_propose_upgrade(&admin, &hash).unwrap().unwrap();
         client.try_cancel_upgrade(&admin).unwrap().unwrap();
 
-        let err = client
-            .try_execute_upgrade(&admin)
-            .unwrap()
-            .unwrap_err();
+        let err = client.try_execute_upgrade(&admin).unwrap().unwrap_err();
         assert_eq!(err, ContractError::NoUpgradePending);
     }
 
     #[test]
     fn cancel_upgrade_with_no_pending_fails() {
         let (_env, _contract_id, client, admin, _operator) = make_env_and_client();
-        let err = client
-            .try_cancel_upgrade(&admin)
-            .unwrap()
-            .unwrap_err();
+        let err = client.try_cancel_upgrade(&admin).unwrap().unwrap_err();
         assert_eq!(err, ContractError::NoUpgradePending);
     }
 
@@ -271,17 +249,11 @@ mod upgrade_governance_tests {
     fn non_admin_cannot_execute_upgrade() {
         let (env, _contract_id, client, admin, _operator) = make_env_and_client();
         let hash = zeroed_hash(&env);
-        client
-            .try_propose_upgrade(&admin, &hash)
-            .unwrap()
-            .unwrap();
+        client.try_propose_upgrade(&admin, &hash).unwrap().unwrap();
 
         let rogue = Address::generate(&env);
         env.ledger().set_timestamp(999_999);
-        let err = client
-            .try_execute_upgrade(&rogue)
-            .unwrap()
-            .unwrap_err();
+        let err = client.try_execute_upgrade(&rogue).unwrap().unwrap_err();
         assert_eq!(err, ContractError::NotAuthorized);
     }
 
@@ -289,10 +261,7 @@ mod upgrade_governance_tests {
     fn after_execute_pending_state_is_cleared() {
         let (env, _contract_id, client, admin, _operator) = make_env_and_client();
         let hash = zeroed_hash(&env);
-        client
-            .try_propose_upgrade(&admin, &hash)
-            .unwrap()
-            .unwrap();
+        client.try_propose_upgrade(&admin, &hash).unwrap().unwrap();
 
         env.ledger().set_timestamp(999_999);
         let result = client.try_execute_upgrade(&admin);
@@ -300,10 +269,7 @@ mod upgrade_governance_tests {
         // should have been cleared. Verify by attempting cancel which requires
         // a pending upgrade to exist.
         if result.is_ok() {
-            let err = client
-                .try_cancel_upgrade(&admin)
-                .unwrap()
-                .unwrap_err();
+            let err = client.try_cancel_upgrade(&admin).unwrap().unwrap_err();
             assert_eq!(err, ContractError::NoUpgradePending);
         }
     }
@@ -315,10 +281,7 @@ mod upgrade_governance_tests {
     #[test]
     fn execute_upgrade_with_no_pending_fails() {
         let (_env, _contract_id, client, admin, _operator) = make_env_and_client();
-        let err = client
-            .try_execute_upgrade(&admin)
-            .unwrap()
-            .unwrap_err();
+        let err = client.try_execute_upgrade(&admin).unwrap().unwrap_err();
         assert_eq!(err, ContractError::NoUpgradePending);
     }
 
@@ -353,17 +316,11 @@ mod upgrade_governance_tests {
         let now: u64 = 10_000;
         env.ledger().set_timestamp(now);
         let hash = zeroed_hash(&env);
-        client
-            .try_propose_upgrade(&admin, &hash)
-            .unwrap()
-            .unwrap();
+        client.try_propose_upgrade(&admin, &hash).unwrap().unwrap();
 
         // Exactly at the boundary should fail (timestamp < execute_at)
         env.ledger().set_timestamp(now + delay_secs - 1);
-        let err = client
-            .try_execute_upgrade(&admin)
-            .unwrap()
-            .unwrap_err();
+        let err = client.try_execute_upgrade(&admin).unwrap().unwrap_err();
         assert_eq!(err, ContractError::UpgradeDelayNotMet);
 
         // One second later passes the check
@@ -378,10 +335,7 @@ mod upgrade_governance_tests {
     fn propose_after_cancel_succeeds() {
         let (env, _contract_id, client, admin, _operator) = make_env_and_client();
         let hash = zeroed_hash(&env);
-        client
-            .try_propose_upgrade(&admin, &hash)
-            .unwrap()
-            .unwrap();
+        client.try_propose_upgrade(&admin, &hash).unwrap().unwrap();
         client.try_cancel_upgrade(&admin).unwrap().unwrap();
 
         // After cancel a fresh proposal is allowed


### PR DESCRIPTION
## Summary

Optimises the GitHub Actions CI pipeline for Shelterflex/monorepo by splitting work into parallel jobs (`test-frontend`, `test-backend`, `test-contracts`, `lint`, `type-check`, `security-scan`), adding explicit `actions/cache@v4` layers, enforcing Clippy warnings as errors, and publishing per-job timing in the workflow summary.

## Purpose / Motivation

CI already ran frontend, backend, and contracts in parallel, but lint/type-check/security were bundled into those jobs and caching was minimal (setup-node cache on backend only, `Swatinem/rust-cache` on contracts). This change aligns job names with branch-protection requirements, adds cache hit/miss logging, splits lint and type-check, runs frontend tests in CI, and adds a `security-scan` job with npm/cargo audit on every PR.

## Changes Made

- Refactored `.github/workflows/ci.yml` from three jobs (`frontend`, `backend`, `contracts`) into seven parallel jobs plus `ci-summary`.
- Frontend: pnpm store cache keyed on `frontend/pnpm-lock.yaml`; test + build only in `test-frontend`.
- Backend: `~/.npm` cache keyed on `backend/package-lock.json`; tests + OpenAPI validation in `test-backend`.
- Contracts: `actions/cache@v4` for registry/git/target deps; `wasm32-unknown-unknown`; `cargo clippy -D warnings`; `cargo fmt --check`.
- New `lint`, `type-check`, and `security-scan` jobs with scoped installs.
- Added workflow `concurrency` and per-job duration lines in `$GITHUB_STEP_SUMMARY`.

## How to Test

1. Open this PR and confirm all seven jobs plus `ci-summary` run in parallel.
2. Re-run the workflow without lockfile changes; verify cache steps log **HIT** and install steps are faster.
3. Introduce a failing contract unit test on a throwaway commit and confirm `test-contracts` fails the PR.
4. Review the Actions run summary for per-job duration lines and the results table.

## Breaking Changes

- None for application code.
- Admins should update branch protection required checks to: `test-frontend`, `test-backend`, `test-contracts`, `security-scan` (and optionally `lint`, `type-check`).

## Related Issues

Closes Shelterflex/monorepo#928

## Checklist

- [x] CI workflow updated
- [x] Caching and contract stage per issue spec
- [ ] Verified on GitHub Actions (after merge)
