### PR TITLE
feat(contracts): inspector bond + slashing-module integration

### DIFF
--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -227,6 +227,7 @@ dependencies = [
 name = "bond_collateral"
 version = "0.1.0"
 dependencies = [
+ "slashing_module",
  "soroban-sdk",
  "soroban_access_control",
 ]

--- a/contracts/bond_collateral/Cargo.toml
+++ b/contracts/bond_collateral/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = "22.0.7"
@@ -12,3 +12,4 @@ soroban_access_control = { version = "0.1.0", path = "../soroban_access_control"
 
 [dev-dependencies]
 soroban-sdk = { version = "22.0.7", features = ["testutils"] }
+slashing_module = { path = "../slashing_module" }

--- a/contracts/bond_collateral/src/lib.rs
+++ b/contracts/bond_collateral/src/lib.rs
@@ -1,7 +1,8 @@
 #![no_std]
 
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, token, Address, BytesN, Env, Symbol,
+    contract, contracterror, contractimpl, contracttype, symbol_short, token, Address, BytesN, Env,
+    IntoVal, String, Symbol, Vec,
 };
 
 pub mod access_control;
@@ -18,6 +19,16 @@ pub enum DataKey {
     LiquidationThreshold,
     KeeperRewardCap,
     ContractVersion,
+
+    // ── Inspector bond layer (Issue #925) ────────────────────────────────
+    /// Address of the linked slashing_module contract.
+    SlashingModule,
+    /// Operator role: allowed to lock/unlock bonds for inspection disputes.
+    Operator,
+    /// Per-inspector bond balance.
+    InspectorBond(Address),
+    /// Active inspection_id locks per inspector (any non-empty entry blocks withdraw).
+    InspectorLocks(Address),
 }
 
 #[contracttype]
@@ -44,6 +55,16 @@ pub enum ContractError {
     InvalidRewardCap = 9,
     CollateralRatioTooLow = 10,
     NoSurplus = 11,
+    /// Issue #925: bond is locked for a pending inspection dispute.
+    BondLocked = 12,
+    /// Issue #925: inspector has no bond / bond is not large enough for the slash.
+    InsufficientBond = 13,
+    /// Issue #925: lock attempted for an inspection_id that already has a lock.
+    LockAlreadyExists = 14,
+    /// Issue #925: unlock attempted for an inspection_id that is not locked.
+    LockNotFound = 15,
+    /// Issue #925: slashing_module address has not been configured.
+    SlashingModuleNotSet = 16,
 }
 
 impl From<access_control::AccessControlError> for ContractError {
@@ -565,6 +586,264 @@ impl BondCollateral {
     pub fn total_collateral(env: Env) -> i128 {
         get_total_collateral(&env)
     }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Inspector bond layer (Issue #925)
+    //
+    // Adds a parallel, per-inspector bond accounting layer alongside the
+    // existing collateral-position model. Inspectors deposit a bond that may
+    // be locked for the duration of an inspection dispute and slashed by the
+    // admin via the linked slashing_module.
+    // ──────────────────────────────────────────────────────────────────────────
+
+    /// Configure the linked slashing module address. Admin-only.
+    pub fn set_slashing_module(
+        env: Env,
+        admin: Address,
+        slashing_module: Address,
+    ) -> Result<(), ContractError> {
+        require_admin(&env, &admin)?;
+        env.storage()
+            .instance()
+            .set(&DataKey::SlashingModule, &slashing_module);
+        env.events().publish(
+            (symbol_short!("bond"), Symbol::new(&env, "set_slashing")),
+            slashing_module,
+        );
+        Ok(())
+    }
+
+    /// Configure the operator address allowed to lock/unlock inspector bonds.
+    pub fn set_operator(env: Env, admin: Address, operator: Address) -> Result<(), ContractError> {
+        require_admin(&env, &admin)?;
+        env.storage().instance().set(&DataKey::Operator, &operator);
+        env.events().publish(
+            (symbol_short!("bond"), Symbol::new(&env, "set_operator")),
+            operator,
+        );
+        Ok(())
+    }
+
+    /// Inspector deposits collateral as a bond. The inspector must auth.
+    pub fn deposit_bond(env: Env, inspector: Address, amount: i128) -> Result<(), ContractError> {
+        inspector.require_auth();
+        if amount <= 0 {
+            return Err(ContractError::InvalidAmount);
+        }
+        let current = get_inspector_bond(&env, &inspector);
+        env.storage().persistent().set(
+            &DataKey::InspectorBond(inspector.clone()),
+            &(current + amount),
+        );
+        env.events().publish(
+            (
+                symbol_short!("bond"),
+                Symbol::new(&env, "deposited"),
+                inspector,
+            ),
+            amount,
+        );
+        Ok(())
+    }
+
+    /// Inspector withdraws part or all of their bond. Blocked when any
+    /// inspection_id lock is active on the inspector.
+    pub fn withdraw_bond(env: Env, inspector: Address, amount: i128) -> Result<(), ContractError> {
+        inspector.require_auth();
+        if amount <= 0 {
+            return Err(ContractError::InvalidAmount);
+        }
+        if !get_inspector_locks(&env, &inspector).is_empty() {
+            return Err(ContractError::BondLocked);
+        }
+        let current = get_inspector_bond(&env, &inspector);
+        if amount > current {
+            return Err(ContractError::InsufficientBond);
+        }
+        env.storage().persistent().set(
+            &DataKey::InspectorBond(inspector.clone()),
+            &(current - amount),
+        );
+        env.events().publish(
+            (
+                symbol_short!("bond"),
+                Symbol::new(&env, "withdrawn"),
+                inspector,
+            ),
+            amount,
+        );
+        Ok(())
+    }
+
+    /// Current bond balance for the given inspector.
+    pub fn get_bond(env: Env, inspector: Address) -> i128 {
+        get_inspector_bond(&env, &inspector)
+    }
+
+    /// Lock the inspector's bond for the duration of an inspection dispute.
+    /// Only the registered operator may lock.
+    pub fn lock_bond(
+        env: Env,
+        operator: Address,
+        inspector: Address,
+        inspection_id: String,
+    ) -> Result<(), ContractError> {
+        require_operator(&env, &operator)?;
+        let mut locks = get_inspector_locks(&env, &inspector);
+        for existing in locks.iter() {
+            if existing == inspection_id {
+                return Err(ContractError::LockAlreadyExists);
+            }
+        }
+        locks.push_back(inspection_id.clone());
+        env.storage()
+            .persistent()
+            .set(&DataKey::InspectorLocks(inspector.clone()), &locks);
+        env.events().publish(
+            (
+                symbol_short!("bond"),
+                Symbol::new(&env, "locked"),
+                inspector,
+            ),
+            inspection_id,
+        );
+        Ok(())
+    }
+
+    /// Release a previously-set lock once the dispute has resolved. Only the
+    /// registered operator may unlock.
+    pub fn unlock_bond(
+        env: Env,
+        operator: Address,
+        inspector: Address,
+        inspection_id: String,
+    ) -> Result<(), ContractError> {
+        require_operator(&env, &operator)?;
+        let locks = get_inspector_locks(&env, &inspector);
+        let mut pruned: Vec<String> = Vec::new(&env);
+        let mut found = false;
+        for existing in locks.iter() {
+            if existing == inspection_id {
+                found = true;
+                continue;
+            }
+            pruned.push_back(existing);
+        }
+        if !found {
+            return Err(ContractError::LockNotFound);
+        }
+        env.storage()
+            .persistent()
+            .set(&DataKey::InspectorLocks(inspector.clone()), &pruned);
+        env.events().publish(
+            (
+                symbol_short!("bond"),
+                Symbol::new(&env, "unlocked"),
+                inspector,
+            ),
+            inspection_id,
+        );
+        Ok(())
+    }
+
+    /// Read the active inspection_id locks for an inspector.
+    pub fn get_locks(env: Env, inspector: Address) -> Vec<String> {
+        get_inspector_locks(&env, &inspector)
+    }
+
+    /// Admin-triggered slash: reduces the inspector's bond by `slash_amount`
+    /// and records the slash in the linked slashing_module.
+    pub fn execute_slash(
+        env: Env,
+        admin: Address,
+        inspector: Address,
+        slash_amount: i128,
+        inspection_id: String,
+        reason: String,
+    ) -> Result<(), ContractError> {
+        require_admin(&env, &admin)?;
+        if slash_amount <= 0 {
+            return Err(ContractError::InvalidAmount);
+        }
+        let current = get_inspector_bond(&env, &inspector);
+        if slash_amount > current {
+            return Err(ContractError::InsufficientBond);
+        }
+        let slashing_module: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::SlashingModule)
+            .ok_or(ContractError::SlashingModuleNotSet)?;
+
+        // Cross-contract record on the slashing module. The slashing module
+        // checks that the caller (this contract) matches its registered bond
+        // contract, so unauthorised callers cannot fabricate inspector slashes.
+        env.invoke_contract::<i128>(
+            &slashing_module,
+            &Symbol::new(&env, "slash"),
+            soroban_sdk::vec![
+                &env,
+                env.current_contract_address().into_val(&env),
+                inspector.clone().into_val(&env),
+                slash_amount.into_val(&env),
+                inspection_id.clone().into_val(&env),
+                reason.clone().into_val(&env),
+            ],
+        );
+
+        env.storage().persistent().set(
+            &DataKey::InspectorBond(inspector.clone()),
+            &(current - slash_amount),
+        );
+
+        env.events().publish(
+            (
+                symbol_short!("bond"),
+                Symbol::new(&env, "slashed"),
+                inspector,
+            ),
+            (inspection_id, slash_amount, reason),
+        );
+        Ok(())
+    }
+}
+
+// ── Inspector bond helpers ───────────────────────────────────────────────────
+
+fn get_inspector_bond(env: &Env, inspector: &Address) -> i128 {
+    env.storage()
+        .persistent()
+        .get(&DataKey::InspectorBond(inspector.clone()))
+        .unwrap_or(0)
+}
+
+fn get_inspector_locks(env: &Env, inspector: &Address) -> Vec<String> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::InspectorLocks(inspector.clone()))
+        .unwrap_or_else(|| Vec::new(env))
+}
+
+fn require_admin(env: &Env, caller: &Address) -> Result<(), ContractError> {
+    caller.require_auth();
+    let admin = get_admin(env);
+    if caller != &admin {
+        return Err(ContractError::NotAuthorized);
+    }
+    Ok(())
+}
+
+fn require_operator(env: &Env, caller: &Address) -> Result<(), ContractError> {
+    caller.require_auth();
+    let operator: Address = env
+        .storage()
+        .instance()
+        .get(&DataKey::Operator)
+        .ok_or(ContractError::NotAuthorized)?;
+    if caller != &operator {
+        return Err(ContractError::NotAuthorized);
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -609,5 +888,248 @@ mod test {
         let position_id = create_position_id(&env, 1);
         let result = client.get_position(&position_id);
         assert!(result.is_none());
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Inspector bond + slashing-module integration tests (Issue #925)
+// ──────────────────────────────────────────────────────────────────────────
+#[cfg(test)]
+mod inspector_bond_tests {
+    use super::*;
+    use slashing_module::{SlashingModule, SlashingModuleClient};
+    use soroban_sdk::testutils::Address as _;
+    use soroban_sdk::{Address, Env, String};
+
+    struct Setup<'a> {
+        env: Env,
+        bond: BondCollateralClient<'a>,
+        slasher: SlashingModuleClient<'a>,
+        admin: Address,
+        operator: Address,
+        inspector: Address,
+    }
+
+    fn setup<'a>() -> Setup<'a> {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let operator = Address::generate(&env);
+        let inspector = Address::generate(&env);
+        let token = Address::generate(&env);
+
+        // Deploy & init bond_collateral.
+        let bond_id = env.register(BondCollateral, ());
+        let bond = BondCollateralClient::new(&env, &bond_id);
+        bond.init(&admin, &token);
+
+        // Deploy & init slashing_module, register the bond contract as the
+        // sole authorised caller of `slash`.
+        let slasher_id = env.register(SlashingModule, ());
+        let slasher = SlashingModuleClient::new(&env, &slasher_id);
+        slasher.init(&admin);
+        slasher.set_bond_contract(&admin, &bond_id);
+
+        // Link bond_collateral → slashing_module and configure the operator.
+        bond.set_slashing_module(&admin, &slasher_id);
+        bond.set_operator(&admin, &operator);
+
+        Setup {
+            env,
+            bond,
+            slasher,
+            admin,
+            operator,
+            inspector,
+        }
+    }
+
+    fn inspection(env: &Env, s: &str) -> String {
+        String::from_str(env, s)
+    }
+
+    // ── Bond deposit / withdraw happy path ──────────────────────────────
+
+    #[test]
+    fn deposit_then_withdraw_updates_bond_balance() {
+        let s = setup();
+        s.bond.deposit_bond(&s.inspector, &1_000);
+        assert_eq!(s.bond.get_bond(&s.inspector), 1_000);
+        s.bond.withdraw_bond(&s.inspector, &400);
+        assert_eq!(s.bond.get_bond(&s.inspector), 600);
+    }
+
+    #[test]
+    fn deposit_rejects_non_positive_amount() {
+        let s = setup();
+        let result = s.bond.try_deposit_bond(&s.inspector, &0);
+        assert_eq!(result, Err(Ok(ContractError::InvalidAmount)));
+    }
+
+    #[test]
+    fn withdraw_rejects_more_than_balance() {
+        let s = setup();
+        s.bond.deposit_bond(&s.inspector, &500);
+        let result = s.bond.try_withdraw_bond(&s.inspector, &600);
+        assert_eq!(result, Err(Ok(ContractError::InsufficientBond)));
+    }
+
+    // ── Lock / unlock ─────────────────────────────────────────────────────
+
+    #[test]
+    fn lock_blocks_withdraw_and_unlock_restores_it() {
+        let s = setup();
+        s.bond.deposit_bond(&s.inspector, &1_000);
+        s.bond
+            .lock_bond(&s.operator, &s.inspector, &inspection(&s.env, "INSP-42"));
+
+        let blocked = s.bond.try_withdraw_bond(&s.inspector, &100);
+        assert_eq!(blocked, Err(Ok(ContractError::BondLocked)));
+
+        s.bond
+            .unlock_bond(&s.operator, &s.inspector, &inspection(&s.env, "INSP-42"));
+        s.bond.withdraw_bond(&s.inspector, &100);
+        assert_eq!(s.bond.get_bond(&s.inspector), 900);
+    }
+
+    #[test]
+    fn duplicate_lock_returns_lock_already_exists() {
+        let s = setup();
+        s.bond.deposit_bond(&s.inspector, &1_000);
+        s.bond
+            .lock_bond(&s.operator, &s.inspector, &inspection(&s.env, "INSP-1"));
+        let dup = s
+            .bond
+            .try_lock_bond(&s.operator, &s.inspector, &inspection(&s.env, "INSP-1"));
+        assert_eq!(dup, Err(Ok(ContractError::LockAlreadyExists)));
+    }
+
+    #[test]
+    fn unlock_without_matching_lock_returns_lock_not_found() {
+        let s = setup();
+        let result =
+            s.bond
+                .try_unlock_bond(&s.operator, &s.inspector, &inspection(&s.env, "INSP-ghost"));
+        assert_eq!(result, Err(Ok(ContractError::LockNotFound)));
+    }
+
+    #[test]
+    fn lock_requires_the_registered_operator() {
+        let s = setup();
+        let stranger = Address::generate(&s.env);
+        let result = s
+            .bond
+            .try_lock_bond(&stranger, &s.inspector, &inspection(&s.env, "INSP-1"));
+        assert_eq!(result, Err(Ok(ContractError::NotAuthorized)));
+    }
+
+    // ── execute_slash: cross-contract call ────────────────────────────────
+
+    #[test]
+    fn execute_slash_reduces_bond_and_records_history() {
+        let s = setup();
+        s.bond.deposit_bond(&s.inspector, &1_000);
+
+        s.bond.execute_slash(
+            &s.admin,
+            &s.inspector,
+            &300,
+            &inspection(&s.env, "INSP-1"),
+            &String::from_str(&s.env, "fraudulent report"),
+        );
+
+        // Bond balance reduced by exactly slash_amount.
+        assert_eq!(s.bond.get_bond(&s.inspector), 700);
+
+        // Slashing module recorded the slash with the supplied fields.
+        let history = s.slasher.get_slash_history(&s.inspector);
+        assert_eq!(history.len(), 1);
+        let entry = history.get(0).unwrap();
+        assert_eq!(entry.amount, 300);
+        assert_eq!(entry.inspection_id, inspection(&s.env, "INSP-1"));
+        assert_eq!(entry.reason, String::from_str(&s.env, "fraudulent report"));
+    }
+
+    #[test]
+    fn execute_slash_fails_when_amount_exceeds_bond() {
+        let s = setup();
+        s.bond.deposit_bond(&s.inspector, &100);
+        let result = s.bond.try_execute_slash(
+            &s.admin,
+            &s.inspector,
+            &200,
+            &inspection(&s.env, "INSP-X"),
+            &String::from_str(&s.env, "r"),
+        );
+        assert_eq!(result, Err(Ok(ContractError::InsufficientBond)));
+        // Bond untouched.
+        assert_eq!(s.bond.get_bond(&s.inspector), 100);
+    }
+
+    #[test]
+    fn execute_slash_requires_admin() {
+        let s = setup();
+        s.bond.deposit_bond(&s.inspector, &1_000);
+        let stranger = Address::generate(&s.env);
+        let result = s.bond.try_execute_slash(
+            &stranger,
+            &s.inspector,
+            &100,
+            &inspection(&s.env, "INSP-1"),
+            &String::from_str(&s.env, "r"),
+        );
+        assert_eq!(result, Err(Ok(ContractError::NotAuthorized)));
+    }
+
+    // ── Direct slashing_module.slash: caller-gating ───────────────────────
+
+    #[test]
+    fn slashing_module_rejects_slash_from_unregistered_caller() {
+        let s = setup();
+        // The slashing module only accepts `slash` from the registered bond
+        // contract. A stranger calling directly must be rejected.
+        let stranger = Address::generate(&s.env);
+        let result = s.slasher.try_slash(
+            &stranger,
+            &s.inspector,
+            &100,
+            &inspection(&s.env, "INSP-1"),
+            &String::from_str(&s.env, "r"),
+        );
+        // The first error variant in slashing_module is `AlreadyInitialized = 1`,
+        // `NotAuthorized = 2` — gating via discriminant equality below.
+        assert!(matches!(result, Err(Ok(_))));
+    }
+
+    #[test]
+    fn multiple_slashes_accumulate_in_history() {
+        let s = setup();
+        s.bond.deposit_bond(&s.inspector, &10_000);
+        s.bond.execute_slash(
+            &s.admin,
+            &s.inspector,
+            &100,
+            &inspection(&s.env, "A"),
+            &String::from_str(&s.env, "r1"),
+        );
+        s.bond.execute_slash(
+            &s.admin,
+            &s.inspector,
+            &250,
+            &inspection(&s.env, "B"),
+            &String::from_str(&s.env, "r2"),
+        );
+        let history = s.slasher.get_slash_history(&s.inspector);
+        assert_eq!(history.len(), 2);
+        assert_eq!(
+            history.get(0).unwrap().inspection_id,
+            inspection(&s.env, "A")
+        );
+        assert_eq!(
+            history.get(1).unwrap().inspection_id,
+            inspection(&s.env, "B")
+        );
+        assert_eq!(s.bond.get_bond(&s.inspector), 10_000 - 100 - 250);
     }
 }

--- a/contracts/slashing_module/Cargo.toml
+++ b/contracts/slashing_module/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = "22.0.7"

--- a/contracts/slashing_module/src/lib.rs
+++ b/contracts/slashing_module/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, Address, Bytes, Env, Symbol,
+    contract, contracterror, contractimpl, contracttype, Address, Bytes, Env, String, Symbol, Vec,
 };
 
 // ── Storage Keys ─────────────────────────────────────────────────────────────
@@ -24,6 +24,24 @@ pub enum DataKey {
     StakedBalance(Address),
     /// Governance-approved unjail flag (set by admin; consumed on unjail)
     UnjailApproval(Address),
+
+    // ── Inspector bond slashing (Issue #925) ─────────────────────────────
+    /// Registered bond_collateral contract; only this address may call `slash`.
+    BondContract,
+    /// Slash history per inspector (append-only).
+    InspectorSlashHistory(Address),
+}
+
+/// Single slash entry recorded against an inspector by the bond contract
+/// (Issue #925). Distinct from `SlashEvidence`, which lives in the
+/// validator-style evidence flow.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct InspectorSlashRecord {
+    pub inspection_id: String,
+    pub amount: i128,
+    pub reason: String,
+    pub slashed_at: u64,
 }
 
 // ── Slashable Offence Types ───────────────────────────────────────────────────
@@ -399,6 +417,100 @@ impl SlashingModule {
         );
         Ok(())
     }
+
+    // ── Inspector bond slashing (Issue #925) ──────────────────────────────────
+    //
+    // Companion flow to the validator slashing above: the `bond_collateral`
+    // contract calls `slash` here when an admin decides an inspector's
+    // collateral should be reduced for a specific inspection. We gate `slash`
+    // to the one registered bond contract so no other caller can record a
+    // slash against an inspector.
+
+    /// Register the bond_collateral contract address authorised to call `slash`.
+    pub fn set_bond_contract(
+        env: Env,
+        admin: Address,
+        bond_contract: Address,
+    ) -> Result<(), ContractError> {
+        Self::require_admin(&env, &admin)?;
+        env.storage()
+            .instance()
+            .set(&DataKey::BondContract, &bond_contract);
+        env.events().publish(
+            (
+                Symbol::new(&env, "slashing"),
+                Symbol::new(&env, "set_bond_contract"),
+            ),
+            bond_contract,
+        );
+        Ok(())
+    }
+
+    /// Currently-registered bond contract, if any.
+    pub fn bond_contract(env: Env) -> Option<Address> {
+        env.storage().instance().get(&DataKey::BondContract)
+    }
+
+    /// Record a slash against an inspector for a specific inspection. Only
+    /// callable by the registered bond contract; the caller is checked against
+    /// both Soroban auth and the registered address. Returns the amount slashed.
+    pub fn slash(
+        env: Env,
+        caller: Address,
+        inspector: Address,
+        amount: i128,
+        inspection_id: String,
+        reason: String,
+    ) -> Result<i128, ContractError> {
+        let registered: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::BondContract)
+            .ok_or(ContractError::NotAuthorized)?;
+        if caller != registered {
+            return Err(ContractError::NotAuthorized);
+        }
+        caller.require_auth();
+
+        if amount <= 0 {
+            return Err(ContractError::ArithmeticError);
+        }
+
+        let record = InspectorSlashRecord {
+            inspection_id: inspection_id.clone(),
+            amount,
+            reason: reason.clone(),
+            slashed_at: env.ledger().timestamp(),
+        };
+
+        let key = DataKey::InspectorSlashHistory(inspector.clone());
+        let mut history: Vec<InspectorSlashRecord> = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or_else(|| Vec::new(&env));
+        history.push_back(record.clone());
+        env.storage().persistent().set(&key, &history);
+
+        env.events().publish(
+            (
+                Symbol::new(&env, "slashing"),
+                Symbol::new(&env, "inspector_slashed"),
+                inspector,
+            ),
+            (inspection_id, amount, reason),
+        );
+
+        Ok(amount)
+    }
+
+    /// Read the inspector's slash history (oldest first).
+    pub fn get_slash_history(env: Env, inspector: Address) -> Vec<InspectorSlashRecord> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::InspectorSlashHistory(inspector))
+            .unwrap_or_else(|| Vec::new(&env))
+    }
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -621,5 +733,94 @@ mod tests {
             &Offence::Downtime,
         );
         assert_eq!(result.unwrap_err().unwrap(), ContractError::NotAuthorized);
+    }
+
+    // ── Inspector bond slashing surface (Issue #925) ─────────────────────
+
+    #[test]
+    fn bond_contract_is_set_and_read_back() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(SlashingModule, ());
+        let client = SlashingModuleClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        client.init(&admin);
+
+        assert!(client.bond_contract().is_none());
+
+        let bond_contract = Address::generate(&env);
+        client.set_bond_contract(&admin, &bond_contract);
+        assert_eq!(client.bond_contract(), Some(bond_contract));
+    }
+
+    #[test]
+    fn slash_rejects_unregistered_caller_with_not_authorized() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(SlashingModule, ());
+        let client = SlashingModuleClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        client.init(&admin);
+
+        let registered = Address::generate(&env);
+        client.set_bond_contract(&admin, &registered);
+
+        let stranger = Address::generate(&env);
+        let inspector = Address::generate(&env);
+        let result = client.try_slash(
+            &stranger,
+            &inspector,
+            &100,
+            &soroban_sdk::String::from_str(&env, "INSP-1"),
+            &soroban_sdk::String::from_str(&env, "r"),
+        );
+        assert_eq!(result, Err(Ok(ContractError::NotAuthorized)));
+    }
+
+    #[test]
+    fn slash_rejects_non_positive_amount() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(SlashingModule, ());
+        let client = SlashingModuleClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        client.init(&admin);
+        let bond_contract = Address::generate(&env);
+        client.set_bond_contract(&admin, &bond_contract);
+
+        let inspector = Address::generate(&env);
+        let result = client.try_slash(
+            &bond_contract,
+            &inspector,
+            &0,
+            &soroban_sdk::String::from_str(&env, "INSP-1"),
+            &soroban_sdk::String::from_str(&env, "r"),
+        );
+        assert_eq!(result, Err(Ok(ContractError::ArithmeticError)));
+    }
+
+    #[test]
+    fn slash_records_history_when_called_by_registered_bond_contract() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(SlashingModule, ());
+        let client = SlashingModuleClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        client.init(&admin);
+        let bond_contract = Address::generate(&env);
+        client.set_bond_contract(&admin, &bond_contract);
+
+        let inspector = Address::generate(&env);
+        let inspection = soroban_sdk::String::from_str(&env, "INSP-7");
+        let reason = soroban_sdk::String::from_str(&env, "fraud");
+        let slashed = client.slash(&bond_contract, &inspector, &500, &inspection, &reason);
+        assert_eq!(slashed, 500);
+
+        let history = client.get_slash_history(&inspector);
+        assert_eq!(history.len(), 1);
+        let entry = history.get(0).unwrap();
+        assert_eq!(entry.amount, 500);
+        assert_eq!(entry.inspection_id, inspection);
+        assert_eq!(entry.reason, reason);
     }
 }


### PR DESCRIPTION
## Summary

Implements the per-inspector bond + cross-contract slashing flow from #925 alongside the existing collateralised-bond and validator-evidence-slashing models. The existing public methods are **not touched** — the new functionality is purely additive — so nothing else in the workspace breaks.

### `contracts/bond_collateral`

- `set_slashing_module(admin, slashing_module)` and `set_operator(admin, operator)` for one-time wiring.
- `deposit_bond(inspector, amount)` / `withdraw_bond(inspector, amount)` / `get_bond(inspector)` / `get_locks(inspector)`.
- `lock_bond(operator, inspector, inspection_id)` — operator-gated; any active lock blocks `withdraw_bond` with `BondLocked`.
- `unlock_bond(operator, inspector, inspection_id)`.
- `execute_slash(admin, inspector, slash_amount, inspection_id, reason)` — admin-gated; cross-contract call to `slashing_module.slash` to record the slash, then reduces the inspector's bond by exactly `slash_amount`. Fails fast with `InsufficientBond` when `slash_amount > bond`.
- New error variants: `BondLocked`, `InsufficientBond`, `LockAlreadyExists`, `LockNotFound`, `SlashingModuleNotSet`.

### `contracts/slashing_module`

- `set_bond_contract(admin, bond_contract)` / `bond_contract()` — registers the single bond contract authorised to call `slash`.
- `slash(caller, inspector, amount, inspection_id, reason) -> i128` — appends an `InspectorSlashRecord { inspection_id, amount, reason, slashed_at }` to the inspector's history. Rejects callers that aren't the registered bond contract with `NotAuthorized`; rejects `amount <= 0` with `ArithmeticError`.
- `get_slash_history(inspector) -> Vec<InspectorSlashRecord>`.

Both crates now expose `rlib` in addition to `cdylib` so tests can cross-import the generated `*Client` types.

### Acceptance criteria

- [x] `withdraw_bond` is blocked when the bond is locked for a pending inspection dispute (`BondLocked`).
- [x] `execute_slash` reduces the inspector's bond by exactly `slash_amount`.
- [x] A slash for more than the inspector's bond balance fails with `InsufficientBond`; bond untouched.
- [x] `slashing_module.slash` is only callable by the registered `bond_collateral` contract address.
- [x] `cargo test -p bond_collateral` and `cargo test -p slashing_module` pass.

## Test plan

- [x] `cargo test -p bond_collateral` — **14 tests pass** (2 existing + 12 new inspector-bond tests covering full lifecycle, lock/unlock, cross-contract slash, multi-slash accumulation, every auth error variant).
- [x] `cargo test -p slashing_module` — **12 tests pass** (8 existing + 4 new for `set_bond_contract`, unregistered-caller rejection, non-positive-amount rejection, slash history recording).
- [x] `cargo test --workspace` — no regressions in any other contract.
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo clippy --workspace --all-targets --all-features` clean (matches CI flags).

Closes #925