### PR TITLE
feat: wire tenant credit score dashboard to live API

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -856,6 +856,7 @@ export function createApp() {
   app.use("/api/kyc", createKycRouter());
   app.use("/api/admin/abuse", createAbuseRouter());
   app.use("/api/tenant/credit-scoring", createTenantCreditScoringRouter());
+  app.use("/api/tenant/credit-score", createCreditScoreRouter());
   app.use("/api/tenant/onboarding", createTenantOnboardingRouter());
   app.use("/api/tenant/vault", createTenantDocumentVaultRouter());
   app.use("/api/listings", createListingsRouter());

--- a/frontend/app/dashboard/tenant/credit-score/page.tsx
+++ b/frontend/app/dashboard/tenant/credit-score/page.tsx
@@ -13,8 +13,10 @@ import {
   Gauge,
   Clock,
   ArrowRight,
+  AlertCircle,
+  RefreshCw,
 } from "lucide-react";
-import { Suspense } from "react";
+import { Suspense, useEffect, useState } from "react";
 import { DashboardHeader } from "@/components/dashboard-header";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
@@ -22,12 +24,155 @@ import { CreditScoreGauge } from "@/components/tenant/CreditScoreGauge";
 import { ScoreFactorList } from "@/components/tenant/ScoreFactorList";
 import { ScoreHistoryChart } from "@/components/tenant/ScoreHistoryChart";
 import { ScoreImprovementTips } from "@/components/tenant/ScoreImprovementTips";
-import { getMockCreditScoreProfile } from "@/lib/mockCreditScoreData";
+import {
+  getMyCreditScore,
+  getMyCreditScoreHistory,
+  type CreditScoreSnapshot,
+  type ScoreHistoryPoint,
+} from "@/lib/creditScoreApi";
+import { ApiError } from "@/lib/apiClient";
+
+interface CreditScoreProfile {
+  score: number;
+  band: "Poor" | "Fair" | "Good" | "Excellent";
+  factors: { name: string; status: "pass" | "fail" | "warn"; weight: number; detail: string }[];
+  history: ScoreHistoryPoint[];
+  tips: string[];
+}
+
+function formatHistoryDate(isoDate: string): string {
+  const date = new Date(isoDate);
+  return date.toLocaleDateString("en-US", { month: "short", year: "numeric" });
+}
+
+function mapSnapshotToProfile(
+  snapshot: CreditScoreSnapshot,
+  historyData: { score: number; band: string; computedAt: string }[],
+): CreditScoreProfile {
+  return {
+    score: snapshot.score,
+    band: snapshot.band,
+    factors: snapshot.factors,
+    history: historyData.map((h) => ({
+      month: formatHistoryDate(h.computedAt),
+      score: h.score,
+    })),
+    tips: snapshot.tips,
+  };
+}
+
+function CreditScoreSkeleton() {
+  return (
+    <div className="grid gap-6 lg:grid-cols-2">
+      <Card className="border-3 border-foreground p-6 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
+        <div className="mb-6 h-6 w-32 animate-pulse rounded bg-muted" />
+        <div className="flex h-48 items-center justify-center">
+          <div className="h-32 w-32 animate-pulse rounded-full bg-muted" />
+        </div>
+      </Card>
+      <Card className="border-3 border-foreground p-6 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
+        <div className="mb-4 h-6 w-32 animate-pulse rounded bg-muted" />
+        <div className="h-48 animate-pulse rounded bg-muted" />
+      </Card>
+      <Card className="border-3 border-foreground p-6 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
+        <div className="mb-4 h-6 w-40 animate-pulse rounded bg-muted" />
+        <div className="space-y-3">
+          {[1, 2, 3, 4].map((i) => (
+            <div key={i} className="h-10 animate-pulse rounded bg-muted" />
+          ))}
+        </div>
+      </Card>
+      <Card className="border-3 border-foreground p-6 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
+        <div className="mb-4 h-6 w-32 animate-pulse rounded bg-muted" />
+        <div className="space-y-3">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="h-8 animate-pulse rounded bg-muted" />
+          ))}
+        </div>
+      </Card>
+    </div>
+  );
+}
+
+function PendingView() {
+  return (
+    <Card className="border-3 border-foreground p-8 text-center shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] md:p-12">
+      <Clock className="mx-auto h-16 w-16 text-muted-foreground" />
+      <h2 className="mt-4 font-mono text-xl font-bold">
+        Assessment in progress
+      </h2>
+      <p className="mx-auto mt-2 max-w-md text-muted-foreground">
+        Your underwriting review has not completed yet. We will notify
+        you once your credit score is ready.
+      </p>
+      <Link href="/onboarding">
+        <Button className="mt-6 border-3 border-foreground bg-primary font-bold shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
+          Complete onboarding
+          <ArrowRight className="ml-2 h-4 w-4" />
+        </Button>
+      </Link>
+    </Card>
+  );
+}
+
+function ErrorView({ message, onRetry }: { message: string; onRetry: () => void }) {
+  return (
+    <Card className="border-3 border-foreground p-8 text-center shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] md:p-12">
+      <AlertCircle className="mx-auto h-16 w-16 text-destructive" />
+      <h2 className="mt-4 font-mono text-xl font-bold">
+        Unable to load credit score
+      </h2>
+      <p className="mx-auto mt-2 max-w-md text-muted-foreground">
+        {message}
+      </p>
+      <Button
+        onClick={onRetry}
+        className="mt-6 border-3 border-foreground bg-primary font-bold shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]"
+      >
+        <RefreshCw className="mr-2 h-4 w-4" />
+        Try again
+      </Button>
+    </Card>
+  );
+}
 
 function CreditScoreContent() {
   const searchParams = useSearchParams();
   const isPending = searchParams.get("pending") === "1";
-  const profile = isPending ? null : getMockCreditScoreProfile();
+
+  const [profile, setProfile] = useState<CreditScoreProfile | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchScore = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const [snapshot, historyResponse] = await Promise.all([
+        getMyCreditScore(),
+        getMyCreditScoreHistory(),
+      ]);
+      setProfile(mapSnapshotToProfile(snapshot, historyResponse.history));
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 404) {
+        setProfile(null);
+      } else {
+        setError(
+          err instanceof Error ? err.message : "An unexpected error occurred.",
+        );
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (!isPending) {
+      fetchScore();
+    } else {
+      setLoading(false);
+    }
+  }, [isPending]);
 
   return (
     <div className="min-h-screen bg-background">
@@ -37,7 +182,7 @@ function CreditScoreContent() {
         <div className="flex h-full flex-col px-4 py-6">
           <div className="mb-8 border-3 border-foreground bg-secondary p-4 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
             <p className="text-sm font-medium text-foreground">Logged in as</p>
-            <p className="text-lg font-bold text-foreground">Ngozi Adekunle</p>
+            <p className="text-lg font-bold text-foreground">Tenant</p>
             <p className="text-sm text-muted-foreground">Tenant</p>
           </div>
 
@@ -113,24 +258,13 @@ function CreditScoreContent() {
             </p>
           </div>
 
-          {!profile ? (
-            <Card className="border-3 border-foreground p-8 text-center shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] md:p-12">
-              <Clock className="mx-auto h-16 w-16 text-muted-foreground" />
-              <h2 className="mt-4 font-mono text-xl font-bold">
-                Assessment in progress
-              </h2>
-              <p className="mx-auto mt-2 max-w-md text-muted-foreground">
-                Your underwriting review has not completed yet. We will notify
-                you once your credit score is ready.
-              </p>
-              <Link href="/onboarding">
-                <Button className="mt-6 border-3 border-foreground bg-primary font-bold shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
-                  Complete onboarding
-                  <ArrowRight className="ml-2 h-4 w-4" />
-                </Button>
-              </Link>
-            </Card>
-          ) : (
+          {isPending || (!loading && profile === null && !error) ? (
+            <PendingView />
+          ) : loading ? (
+            <CreditScoreSkeleton />
+          ) : error ? (
+            <ErrorView message={error} onRetry={fetchScore} />
+          ) : profile ? (
             <div className="grid gap-6 lg:grid-cols-2">
               <Card className="border-3 border-foreground p-6 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
                 <h2 className="mb-6 font-mono text-lg font-bold">
@@ -160,7 +294,7 @@ function CreditScoreContent() {
                 <ScoreImprovementTips tips={profile.tips} />
               </Card>
             </div>
-          )}
+          ) : null}
         </div>
       </main>
     </div>

--- a/frontend/components/tenant/CreditScoreGauge.tsx
+++ b/frontend/components/tenant/CreditScoreGauge.tsx
@@ -1,4 +1,4 @@
-import type { ScoreBand } from "@/lib/mockCreditScoreData";
+import type { ScoreBand } from "@/lib/creditScoreApi";
 
 type CreditScoreGaugeProps = {
   score: number;

--- a/frontend/components/tenant/ScoreFactorList.tsx
+++ b/frontend/components/tenant/ScoreFactorList.tsx
@@ -1,5 +1,5 @@
 import { CheckCircle2, XCircle } from "lucide-react";
-import type { ScoreFactor } from "@/lib/mockCreditScoreData";
+import type { ScoreFactor } from "@/lib/creditScoreApi";
 
 type ScoreFactorListProps = {
   factors: ScoreFactor[];

--- a/frontend/components/tenant/ScoreHistoryChart.tsx
+++ b/frontend/components/tenant/ScoreHistoryChart.tsx
@@ -9,7 +9,7 @@ import {
   Tooltip,
   ResponsiveContainer,
 } from "recharts";
-import type { ScoreHistoryPoint } from "@/lib/mockCreditScoreData";
+import type { ScoreHistoryPoint } from "@/lib/creditScoreApi";
 
 type ScoreHistoryChartProps = {
   history: ScoreHistoryPoint[];

--- a/frontend/lib/creditScoreApi.ts
+++ b/frontend/lib/creditScoreApi.ts
@@ -1,0 +1,41 @@
+import { apiGet } from "./apiClient";
+
+export type ScoreBand = "Poor" | "Fair" | "Good" | "Excellent";
+
+export type ScoreFactorStatus = "pass" | "fail" | "warn";
+
+export interface ScoreFactor {
+  name: string;
+  status: ScoreFactorStatus;
+  weight: number;
+  detail: string;
+}
+
+export interface CreditScoreSnapshot {
+  score: number;
+  band: ScoreBand;
+  factors: ScoreFactor[];
+  computedAt: string;
+  tips: string[];
+}
+
+export interface ScoreHistoryPoint {
+  month: string;
+  score: number;
+}
+
+export interface CreditScoreHistoryResponse {
+  history: {
+    score: number;
+    band: ScoreBand;
+    computedAt: string;
+  }[];
+}
+
+export async function getMyCreditScore(): Promise<CreditScoreSnapshot> {
+  return apiGet<CreditScoreSnapshot>("/tenant/credit-score/my");
+}
+
+export async function getMyCreditScoreHistory(): Promise<CreditScoreHistoryResponse> {
+  return apiGet<CreditScoreHistoryResponse>("/tenant/credit-score/my/history");
+}


### PR DESCRIPTION
Closes #1068

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional or behavioral changes)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Build / CI configuration change
- [ ] Dependency update
- [ ] Other: <!-- describe -->

---

## Summary

The tenant credit score dashboard was rendering entirely from `getMockCreditScoreProfile()`, showing every tenant the same fabricated score. The backend already had `GET /my` and `GET /my/history` endpoints but the router was never mounted, so they returned 404. This PR mounts the existing router and replaces the frontend mock with a typed API client that fetches live data.

## Motivation / Context

Fixes #1068

The credit score is the tenant-facing surface of the platform's risk engine. Shipping it on mock data means every tenant sees the same fabricated score, which is misleading and blocks the underwriting UX from being trusted. The backend endpoints existed but were unreachable because `createCreditScoreRouter` was imported at `app.ts:161` but never mounted.

## Detailed Changes

### Backend (`backend/src/app.ts`)
- Mounted `createCreditScoreRouter()` at `/api/tenant/credit-score`, adjacent to the existing `/api/tenant/credit-scoring` mount

### Frontend
- **New file** `frontend/lib/creditScoreApi.ts` — typed API client with `getMyCreditScore()` and `getMyCreditScoreHistory()` using the shared `apiClient` (mirrors `ratingCardApi.ts` structure)
- **Updated** `frontend/app/dashboard/tenant/credit-score/page.tsx`:
  - Replaced `getMockCreditScoreProfile()` with live API calls
  - Added loading skeleton (reuse of existing skeleton patterns)
  - Added error state with retry action
  - 404 `NO_SCORE_YET` routes to the existing pending/empty state
  - Kept `?pending=1` query parameter support
- **Updated imports** in `CreditScoreGauge.tsx`, `ScoreFactorList.tsx`, `ScoreHistoryChart.tsx` to use types from `creditScoreApi` instead of `mockCreditScoreData`

## Current Behavior vs. New Behavior

Before: Every tenant sees the same hardcoded credit score (Ngozi Adekunle's profile at 72). The `/api/tenant/credit-score/my` endpoint returns 404.

After: The dashboard fetches and displays the authenticated tenant's real score, factors, history, and improvement tips from the live API. Loading and error states are handled gracefully.

## Testing

- Backend typecheck passes for the changed files (`app.ts`, `creditScore.ts`)
- Verified that `createCreditScoreRouter` was already imported and its types are compatible
- Frontend follows existing patterns from `ratingCardApi.ts` and `apiClient.ts`

## Breaking Changes

No.

## Checklist

### Self-Review
- [x] I have read the entire diff line by line
- [x] No debug code remains
- [x] No hardcoded secrets, tokens, API keys, or internal URLs
- [x] Naming is consistent with the existing codebase
- [x] Error handling is present and produces meaningful messages
- [x] Edge cases are addressed (loading, error, 404 states)

### Testing
- [x] Backend typecheck passes for changed files
- [x] All existing tests pass locally

### CI / Pipeline
- [ ] All CI checks are passing (build, lint, test, type-check)

---

## Reviewer Notes

- The `mockCreditScoreData.ts` file is retained for now — it contains utility functions (`getScoreBand`, `buildImprovementTips`) that may still be useful elsewhere, and the types are now also defined in `creditScoreApi.ts`
- The `createAdminCreditScoreRouter()` was already mounted at `/api/v1/admin` — no changes needed there