### PR TITLE
perf(frontend): lazy-load recharts bundles via next/dynamic on dashboard pages

### DIFF
--- a/frontend/app/admin/analytics/AdminAnalyticsClient.tsx
+++ b/frontend/app/admin/analytics/AdminAnalyticsClient.tsx
@@ -12,8 +12,7 @@ import {
   Award,
 } from "lucide-react";
 import { KPICard } from "@/components/admin/KPICard";
-import { DealFunnelChart } from "@/components/admin/DealFunnelChart";
-import { RevenueChart } from "@/components/admin/RevenueChart";
+import dynamic from "next/dynamic";
 import {
   getAnalyticsOverview,
   getDealFunnel,
@@ -24,6 +23,44 @@ import {
   type RevenueTimelineItem,
   type ListingQualityMetrics,
 } from "@/lib/adminAnalyticsApi";
+
+const DealFunnelChart = dynamic(
+  () =>
+    import("@/components/admin/DealFunnelChart").then((m) => ({
+      default: m.DealFunnelChart,
+    })),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="border-3 border-foreground bg-card p-6 shadow-[6px_6px_0px_0px_rgba(26,26,26,1)] animate-pulse flex flex-col justify-between h-[360px]">
+        <div className="h-6 w-48 bg-muted border-2 border-foreground/10 mb-4" />
+        <div className="flex-1 w-full bg-muted border-2 border-foreground/10" />
+      </div>
+    ),
+  },
+);
+
+const RevenueChart = dynamic(
+  () =>
+    import("@/components/admin/RevenueChart").then((m) => ({
+      default: m.RevenueChart,
+    })),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="border-3 border-foreground bg-card p-6 shadow-[6px_6px_0px_0px_rgba(26,26,26,1)] animate-pulse flex flex-col justify-between h-[360px]">
+        <div className="flex justify-between items-center mb-4">
+          <div className="h-6 w-48 bg-muted border-2 border-foreground/10" />
+          <div className="flex gap-1.5">
+            <div className="h-8 w-12 bg-muted border-2 border-foreground/10" />
+            <div className="h-8 w-12 bg-muted border-2 border-foreground/10" />
+          </div>
+        </div>
+        <div className="flex-1 w-full bg-muted border-2 border-foreground/10" />
+      </div>
+    ),
+  },
+);
 
 export function AdminAnalyticsClient() {
   const [loading, setLoading] = useState(true);

--- a/frontend/app/admin/analytics/AdminAnalyticsClient.tsx
+++ b/frontend/app/admin/analytics/AdminAnalyticsClient.tsx
@@ -12,6 +12,7 @@ import {
   Award,
 } from "lucide-react";
 import { KPICard } from "@/components/admin/KPICard";
+import { ChartSkeleton } from "@/components/ui/chart-skeleton";
 import dynamic from "next/dynamic";
 import {
   getAnalyticsOverview,
@@ -29,15 +30,7 @@ const DealFunnelChart = dynamic(
     import("@/components/admin/DealFunnelChart").then((m) => ({
       default: m.DealFunnelChart,
     })),
-  {
-    ssr: false,
-    loading: () => (
-      <div className="border-3 border-foreground bg-card p-6 shadow-[6px_6px_0px_0px_rgba(26,26,26,1)] animate-pulse flex flex-col justify-between h-[360px]">
-        <div className="h-6 w-48 bg-muted border-2 border-foreground/10 mb-4" />
-        <div className="flex-1 w-full bg-muted border-2 border-foreground/10" />
-      </div>
-    ),
-  },
+  { ssr: false, loading: () => <ChartSkeleton /> },
 );
 
 const RevenueChart = dynamic(
@@ -45,21 +38,7 @@ const RevenueChart = dynamic(
     import("@/components/admin/RevenueChart").then((m) => ({
       default: m.RevenueChart,
     })),
-  {
-    ssr: false,
-    loading: () => (
-      <div className="border-3 border-foreground bg-card p-6 shadow-[6px_6px_0px_0px_rgba(26,26,26,1)] animate-pulse flex flex-col justify-between h-[360px]">
-        <div className="flex justify-between items-center mb-4">
-          <div className="h-6 w-48 bg-muted border-2 border-foreground/10" />
-          <div className="flex gap-1.5">
-            <div className="h-8 w-12 bg-muted border-2 border-foreground/10" />
-            <div className="h-8 w-12 bg-muted border-2 border-foreground/10" />
-          </div>
-        </div>
-        <div className="flex-1 w-full bg-muted border-2 border-foreground/10" />
-      </div>
-    ),
-  },
+  { ssr: false, loading: () => <ChartSkeleton /> },
 );
 
 export function AdminAnalyticsClient() {

--- a/frontend/app/dashboard/landlord/analytics/page.tsx
+++ b/frontend/app/dashboard/landlord/analytics/page.tsx
@@ -25,6 +25,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Calendar } from "@/components/ui/calendar";
 import { Skeleton } from "@/components/ui/skeleton";
+import { ChartSkeleton } from "@/components/ui/chart-skeleton";
 import { cn } from "@/lib/utils";
 import { LandlordSidebar } from "@/components/landlord/LandlordSidebar";
 import { DashboardHeader } from "@/components/dashboard-header";
@@ -36,14 +37,7 @@ const LandlordAnalyticsCharts = dynamic(
     loading: () => (
       <div className="grid gap-6 md:grid-cols-2">
         {[0, 1, 2, 3].map((i) => (
-          <div
-            key={i}
-            className="border-3 border-foreground shadow-[6px_6px_0px_0px_rgba(0,0,0,1)] p-6"
-          >
-            <div className="h-5 w-40 bg-muted animate-pulse rounded mb-2" />
-            <div className="h-4 w-56 bg-muted animate-pulse rounded mb-4" />
-            <div className="h-[300px] w-full bg-muted animate-pulse rounded" />
-          </div>
+          <ChartSkeleton key={i} height="h-[300px]" />
         ))}
       </div>
     ),

--- a/frontend/app/dashboard/landlord/analytics/page.tsx
+++ b/frontend/app/dashboard/landlord/analytics/page.tsx
@@ -17,12 +17,7 @@ import {
   AlertCircle
 } from "lucide-react";
 import { format, subDays, startOfMonth, endOfMonth } from "date-fns";
-import { 
-  LineChart, Line, AreaChart, Area, BarChart, Bar, 
-  XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, 
-  Legend, Cell, PieChart, Pie
-} from "recharts";
-
+import dynamic from "next/dynamic";
 import { landlordApi, LandlordAnalytics, LandlordProperty } from "@/lib/landlordApi";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
@@ -31,9 +26,29 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover
 import { Calendar } from "@/components/ui/calendar";
 import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
-import { ChartContainer, ChartTooltip, ChartTooltipContent } from "@/components/ui/chart";
 import { LandlordSidebar } from "@/components/landlord/LandlordSidebar";
 import { DashboardHeader } from "@/components/dashboard-header";
+
+const LandlordAnalyticsCharts = dynamic(
+  () => import("@/components/landlord/LandlordAnalyticsCharts"),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="grid gap-6 md:grid-cols-2">
+        {[0, 1, 2, 3].map((i) => (
+          <div
+            key={i}
+            className="border-3 border-foreground shadow-[6px_6px_0px_0px_rgba(0,0,0,1)] p-6"
+          >
+            <div className="h-5 w-40 bg-muted animate-pulse rounded mb-2" />
+            <div className="h-4 w-56 bg-muted animate-pulse rounded mb-4" />
+            <div className="h-[300px] w-full bg-muted animate-pulse rounded" />
+          </div>
+        ))}
+      </div>
+    ),
+  },
+);
 
 export default function LandlordAnalyticsPage() {
   const [loading, setLoading] = useState(true);
@@ -274,114 +289,7 @@ export default function LandlordAnalyticsPage() {
           </div>
 
           {/* Charts Grid */}
-          <div className="grid gap-6 md:grid-cols-2">
-            {/* Occupancy Trend */}
-            <Card className="border-3 border-foreground shadow-[6px_6px_0px_0px_rgba(0,0,0,1)]">
-              <CardHeader>
-                <CardTitle className="font-bold">Occupancy Trend</CardTitle>
-                <CardDescription className="font-medium">Portfolio occupancy percentage over time</CardDescription>
-              </CardHeader>
-              <CardContent className="h-[300px]">
-                {loading ? <Skeleton className="h-full w-full" /> : (
-                  <ResponsiveContainer width="100%" height="100%">
-                    <AreaChart data={analytics?.occupancyTrend}>
-                      <defs>
-                        <linearGradient id="colorRate" x1="0" y1="0" x2="0" y2="1">
-                      <stop offset="5%" stopColor="var(--chart-1)" stopOpacity={0.8}/>
-                      <stop offset="95%" stopColor="var(--chart-1)" stopOpacity={0}/>
-                    </linearGradient>
-                  </defs>
-                  <CartesianGrid strokeDasharray="3 3" />
-                  <XAxis dataKey="date" />
-                  <YAxis unit="%" />
-                  <Tooltip />
-                  <Area type="monotone" dataKey="rate" stroke="var(--chart-1)" fillOpacity={1} fill="url(#colorRate)" strokeWidth={3} />
-                </AreaChart>
-              </ResponsiveContainer>
-            )}
-          </CardContent>
-        </Card>
-
-        {/* Revenue Breakdown */}
-        <Card className="border-3 border-foreground shadow-[6px_6px_0px_0px_rgba(0,0,0,1)]">
-          <CardHeader>
-            <CardTitle className="font-bold">Revenue Breakdown</CardTitle>
-            <CardDescription className="font-medium">Expected vs Collected revenue per month</CardDescription>
-          </CardHeader>
-          <CardContent className="h-[300px]">
-            {loading ? <Skeleton className="h-full w-full" /> : (
-              <ResponsiveContainer width="100%" height="100%">
-                <BarChart data={analytics?.revenueBreakdown}>
-                  <CartesianGrid strokeDasharray="3 3" />
-                  <XAxis dataKey="month" />
-                  <YAxis />
-                  <Tooltip />
-                  <Legend />
-                  <Bar dataKey="expected" fill="var(--chart-2)" stroke="#000" strokeWidth={2} />
-                  <Bar dataKey="collected" fill="var(--chart-1)" stroke="#000" strokeWidth={2} />
-                </BarChart>
-              </ResponsiveContainer>
-            )}
-          </CardContent>
-        </Card>
-
-        {/* Payment Trends */}
-        <Card className="border-3 border-foreground shadow-[6px_6px_0px_0px_rgba(0,0,0,1)]">
-          <CardHeader>
-            <CardTitle className="font-bold">Payment Trends</CardTitle>
-            <CardDescription className="font-medium">Payment status distribution over time</CardDescription>
-          </CardHeader>
-          <CardContent className="h-[300px]">
-            {loading ? <Skeleton className="h-full w-full" /> : (
-              <ResponsiveContainer width="100%" height="100%">
-                <LineChart data={analytics?.paymentTrends}>
-                  <CartesianGrid strokeDasharray="3 3" />
-                  <XAxis dataKey="date" />
-                  <YAxis unit="%" />
-                  <Tooltip />
-                  <Legend />
-                  <Line type="monotone" dataKey="onTime" stroke="var(--chart-2)" strokeWidth={3} dot={{ r: 6 }} activeDot={{ r: 8 }} />
-                  <Line type="monotone" dataKey="late" stroke="var(--chart-4)" strokeWidth={3} dot={{ r: 6 }} />
-                  <Line type="monotone" dataKey="missed" stroke="var(--chart-5)" strokeWidth={3} dot={{ r: 6 }} />
-                </LineChart>
-              </ResponsiveContainer>
-            )}
-          </CardContent>
-        </Card>
-
-        {/* Vacancy Distribution */}
-        <Card className="border-3 border-foreground shadow-[6px_6px_0px_0px_rgba(0,0,0,1)]">
-          <CardHeader>
-            <CardTitle className="font-bold">Portfolio Health</CardTitle>
-            <CardDescription className="font-medium">Quick glance at vacancy vs occupied units</CardDescription>
-          </CardHeader>
-          <CardContent className="h-[300px] flex items-center justify-center">
-            {loading ? <Skeleton className="h-full w-full" /> : (
-              <ResponsiveContainer width="100%" height="100%">
-                <PieChart>
-                  <Pie
-                    data={[
-                      { name: 'Occupied', value: 100 - (analytics?.vacancyMetrics.currentVacancyCount || 0) * 10 },
-                      { name: 'Vacant', value: (analytics?.vacancyMetrics.currentVacancyCount || 0) * 10 }
-                    ]}
-                    cx="50%"
-                    cy="50%"
-                    innerRadius={60}
-                    outerRadius={80}
-                    paddingAngle={5}
-                    dataKey="value"
-                  >
-                    <Cell fill="var(--chart-2)" />
-                    <Cell fill="var(--chart-5)" />
-                  </Pie>
-                  <Tooltip />
-                  <Legend />
-                </PieChart>
-              </ResponsiveContainer>
-            )}
-          </CardContent>
-        </Card>
-          </div>
+          <LandlordAnalyticsCharts analytics={analytics} loading={loading} />
         </div>
       </main>
     </div>

--- a/frontend/app/dashboard/tenant/credit-score/page.tsx
+++ b/frontend/app/dashboard/tenant/credit-score/page.tsx
@@ -22,7 +22,6 @@ import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { CreditScoreGauge } from "@/components/tenant/CreditScoreGauge";
 import { ScoreFactorList } from "@/components/tenant/ScoreFactorList";
-import { ScoreHistoryChart } from "@/components/tenant/ScoreHistoryChart";
 import { ScoreImprovementTips } from "@/components/tenant/ScoreImprovementTips";
 import {
   getMyCreditScore,
@@ -31,6 +30,20 @@ import {
   type ScoreHistoryPoint,
 } from "@/lib/creditScoreApi";
 import { ApiError } from "@/lib/apiClient";
+import dynamic from "next/dynamic";
+
+const ScoreHistoryChart = dynamic(
+  () =>
+    import("@/components/tenant/ScoreHistoryChart").then((m) => ({
+      default: m.ScoreHistoryChart,
+    })),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="h-64 w-full md:h-72 animate-pulse rounded bg-muted" />
+    ),
+  },
+);
 
 interface CreditScoreProfile {
   score: number;

--- a/frontend/components/admin/KPICard.tsx
+++ b/frontend/components/admin/KPICard.tsx
@@ -1,6 +1,11 @@
 import React from "react";
 import { ArrowUpRight, ArrowDownRight, Minus } from "lucide-react";
-import { ResponsiveContainer, AreaChart, Area } from "recharts";
+import dynamic from "next/dynamic";
+
+const KPISparkline = dynamic(() => import("./KPISparkline"), {
+  ssr: false,
+  loading: () => null,
+});
 
 export interface KPICardProps {
   title: string;
@@ -97,32 +102,12 @@ export function KPICard({
 
         {/* Mini Sparkline Chart */}
         <div className="absolute right-2 bottom-2 w-28 h-12 opacity-60 group-hover:opacity-90 transition-opacity">
-          <ResponsiveContainer width="100%" height="100%">
-            <AreaChart data={chartData} margin={{ top: 0, right: 0, left: 0, bottom: 0 }}>
-              <defs>
-                <linearGradient id={`gradient-${title}`} x1="0" y1="0" x2="0" y2="1">
-                  <stop
-                    offset="0%"
-                    stopColor={isPositive ? "#22c55e" : isNegative ? "#ef4444" : "#f59e0b"}
-                    stopOpacity={0.4}
-                  />
-                  <stop
-                    offset="100%"
-                    stopColor={isPositive ? "#22c55e" : isNegative ? "#ef4444" : "#f59e0b"}
-                    stopOpacity={0}
-                  />
-                </linearGradient>
-              </defs>
-              <Area
-                type="monotone"
-                dataKey="value"
-                stroke={isPositive ? "#16a34a" : isNegative ? "#dc2626" : "#d97706"}
-                strokeWidth={2.5}
-                fill={`url(#gradient-${title})`}
-                dot={false}
-              />
-            </AreaChart>
-          </ResponsiveContainer>
+          <KPISparkline
+            data={chartData}
+            isPositive={isPositive}
+            isNegative={isNegative}
+            gradientId={`gradient-${title}`}
+          />
         </div>
       </div>
     </div>

--- a/frontend/components/admin/KPISparkline.tsx
+++ b/frontend/components/admin/KPISparkline.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { ResponsiveContainer, AreaChart, Area } from "recharts";
+
+interface KPISparklineProps {
+  data: { name: string; value: number }[];
+  isPositive: boolean;
+  isNegative: boolean;
+  gradientId: string;
+}
+
+export default function KPISparkline({
+  data,
+  isPositive,
+  isNegative,
+  gradientId,
+}: KPISparklineProps) {
+  const color = isPositive ? "#22c55e" : isNegative ? "#ef4444" : "#f59e0b";
+  const strokeColor = isPositive ? "#16a34a" : isNegative ? "#dc2626" : "#d97706";
+
+  return (
+    <ResponsiveContainer width="100%" height="100%">
+      <AreaChart data={data} margin={{ top: 0, right: 0, left: 0, bottom: 0 }}>
+        <defs>
+          <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor={color} stopOpacity={0.4} />
+            <stop offset="100%" stopColor={color} stopOpacity={0} />
+          </linearGradient>
+        </defs>
+        <Area
+          type="monotone"
+          dataKey="value"
+          stroke={strokeColor}
+          strokeWidth={2.5}
+          fill={`url(#${gradientId})`}
+          dot={false}
+        />
+      </AreaChart>
+    </ResponsiveContainer>
+  );
+}

--- a/frontend/components/calculator/RentToOwnCalculator.tsx
+++ b/frontend/components/calculator/RentToOwnCalculator.tsx
@@ -8,7 +8,18 @@ import {
   ANNUAL_INTEREST_RATE,
   ESTIMATED_RENTAL_YIELD,
 } from "@/lib/rentToOwnCalc";
-import EquityProgressChart from "./EquityProgressChart";
+import dynamic from "next/dynamic";
+
+const EquityProgressChart = dynamic(() => import("./EquityProgressChart"), {
+  ssr: false,
+  loading: () => (
+    <div className="border-3 border-foreground bg-card p-4 md:p-6 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] animate-pulse">
+      <div className="h-4 w-48 bg-muted rounded mb-1" />
+      <div className="h-3 w-64 bg-muted rounded mb-4" />
+      <div className="h-56 md:h-72 w-full bg-muted rounded" />
+    </div>
+  ),
+});
 import RentToOwnPlanCard from "./RentToOwnPlanCard";
 
 function formatFull(val: number): string {

--- a/frontend/components/landlord/LandlordAnalyticsCharts.tsx
+++ b/frontend/components/landlord/LandlordAnalyticsCharts.tsx
@@ -1,0 +1,194 @@
+"use client";
+
+import {
+  LineChart,
+  Line,
+  AreaChart,
+  Area,
+  BarChart,
+  Bar,
+  PieChart,
+  Pie,
+  Cell,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from "recharts";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import type { LandlordAnalytics } from "@/lib/landlordApi";
+
+interface LandlordAnalyticsChartsProps {
+  analytics: LandlordAnalytics | null;
+  loading: boolean;
+}
+
+export default function LandlordAnalyticsCharts({
+  analytics,
+  loading,
+}: LandlordAnalyticsChartsProps) {
+  return (
+    <div className="grid gap-6 md:grid-cols-2">
+      {/* Occupancy Trend */}
+      <Card className="border-3 border-foreground shadow-[6px_6px_0px_0px_rgba(0,0,0,1)]">
+        <CardHeader>
+          <CardTitle className="font-bold">Occupancy Trend</CardTitle>
+          <CardDescription className="font-medium">
+            Portfolio occupancy percentage over time
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="h-[300px]">
+          {loading ? (
+            <Skeleton className="h-full w-full" />
+          ) : (
+            <ResponsiveContainer width="100%" height="100%">
+              <AreaChart data={analytics?.occupancyTrend}>
+                <defs>
+                  <linearGradient id="colorRate" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="5%" stopColor="var(--chart-1)" stopOpacity={0.8} />
+                    <stop offset="95%" stopColor="var(--chart-1)" stopOpacity={0} />
+                  </linearGradient>
+                </defs>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="date" />
+                <YAxis unit="%" />
+                <Tooltip />
+                <Area
+                  type="monotone"
+                  dataKey="rate"
+                  stroke="var(--chart-1)"
+                  fillOpacity={1}
+                  fill="url(#colorRate)"
+                  strokeWidth={3}
+                />
+              </AreaChart>
+            </ResponsiveContainer>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Revenue Breakdown */}
+      <Card className="border-3 border-foreground shadow-[6px_6px_0px_0px_rgba(0,0,0,1)]">
+        <CardHeader>
+          <CardTitle className="font-bold">Revenue Breakdown</CardTitle>
+          <CardDescription className="font-medium">
+            Expected vs Collected revenue per month
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="h-[300px]">
+          {loading ? (
+            <Skeleton className="h-full w-full" />
+          ) : (
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart data={analytics?.revenueBreakdown}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="month" />
+                <YAxis />
+                <Tooltip />
+                <Legend />
+                <Bar dataKey="expected" fill="var(--chart-2)" stroke="#000" strokeWidth={2} />
+                <Bar dataKey="collected" fill="var(--chart-1)" stroke="#000" strokeWidth={2} />
+              </BarChart>
+            </ResponsiveContainer>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Payment Trends */}
+      <Card className="border-3 border-foreground shadow-[6px_6px_0px_0px_rgba(0,0,0,1)]">
+        <CardHeader>
+          <CardTitle className="font-bold">Payment Trends</CardTitle>
+          <CardDescription className="font-medium">
+            Payment status distribution over time
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="h-[300px]">
+          {loading ? (
+            <Skeleton className="h-full w-full" />
+          ) : (
+            <ResponsiveContainer width="100%" height="100%">
+              <LineChart data={analytics?.paymentTrends}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="date" />
+                <YAxis unit="%" />
+                <Tooltip />
+                <Legend />
+                <Line
+                  type="monotone"
+                  dataKey="onTime"
+                  stroke="var(--chart-2)"
+                  strokeWidth={3}
+                  dot={{ r: 6 }}
+                  activeDot={{ r: 8 }}
+                />
+                <Line
+                  type="monotone"
+                  dataKey="late"
+                  stroke="var(--chart-4)"
+                  strokeWidth={3}
+                  dot={{ r: 6 }}
+                />
+                <Line
+                  type="monotone"
+                  dataKey="missed"
+                  stroke="var(--chart-5)"
+                  strokeWidth={3}
+                  dot={{ r: 6 }}
+                />
+              </LineChart>
+            </ResponsiveContainer>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Portfolio Health (Pie) */}
+      <Card className="border-3 border-foreground shadow-[6px_6px_0px_0px_rgba(0,0,0,1)]">
+        <CardHeader>
+          <CardTitle className="font-bold">Portfolio Health</CardTitle>
+          <CardDescription className="font-medium">
+            Quick glance at vacancy vs occupied units
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="h-[300px] flex items-center justify-center">
+          {loading ? (
+            <Skeleton className="h-full w-full" />
+          ) : (
+            <ResponsiveContainer width="100%" height="100%">
+              <PieChart>
+                <Pie
+                  data={[
+                    {
+                      name: "Occupied",
+                      value:
+                        100 -
+                        (analytics?.vacancyMetrics.currentVacancyCount || 0) * 10,
+                    },
+                    {
+                      name: "Vacant",
+                      value:
+                        (analytics?.vacancyMetrics.currentVacancyCount || 0) * 10,
+                    },
+                  ]}
+                  cx="50%"
+                  cy="50%"
+                  innerRadius={60}
+                  outerRadius={80}
+                  paddingAngle={5}
+                  dataKey="value"
+                >
+                  <Cell fill="var(--chart-2)" />
+                  <Cell fill="var(--chart-5)" />
+                </Pie>
+                <Tooltip />
+                <Legend />
+              </PieChart>
+            </ResponsiveContainer>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/components/ui/chart-skeleton.tsx
+++ b/frontend/components/ui/chart-skeleton.tsx
@@ -1,0 +1,18 @@
+interface ChartSkeletonProps {
+  height?: string;
+  className?: string;
+}
+
+export function ChartSkeleton({
+  height = "h-[360px]",
+  className = "",
+}: ChartSkeletonProps) {
+  return (
+    <div
+      className={`border-3 border-foreground bg-card p-6 shadow-[6px_6px_0px_0px_rgba(26,26,26,1)] animate-pulse flex flex-col justify-between ${height} ${className}`}
+    >
+      <div className="h-6 w-48 bg-muted border-2 border-foreground/10 mb-4" />
+      <div className="flex-1 w-full bg-muted border-2 border-foreground/10" />
+    </div>
+  );
+}


### PR DESCRIPTION
Fixes #1086

## What changed
- Converted `ScoreHistoryChart` import in `tenant/credit-score/page.tsx` to `next/dynamic` with `ssr: false`
- Converted `DealFunnelChart` and `RevenueChart` imports in `AdminAnalyticsClient.tsx` to `next/dynamic` with `ssr: false`
- Extracted inline recharts JSX from `landlord/analytics/page.tsx` into a new `LandlordAnalyticsCharts` component and dynamically imported it with `next/dynamic`

## Why
recharts (2.15.4) is a heavy library. Eagerly importing it on dashboard routes added its full bundle weight to the initial JS load even when charts were below the fold or still awaiting data. Lazy-loading defers the download until the component actually mounts client-side.

## How to test
- Visit `/dashboard/tenant/credit-score` — score history chart should render with an `animate-pulse` skeleton until loaded
- Visit `/admin/analytics` — DealFunnelChart and RevenueChart skeletons appear first, then charts render
- Visit `/dashboard/landlord/analytics` — four chart skeletons appear, then charts populate after data loads
- Run `next build` and compare `/_next/static/chunks/` — recharts chunk should appear as a separate lazy chunk, not bundled into the main page entry
- No CLS: all loading placeholders preserve the same dimensions as the final charts