### PR TITLE
feat(backend): make fiat<->on-chain conversion atomic (FX lock + saga compensation)

### DIFF
--- a/backend/migrations/042_conversion_saga.sql
+++ b/backend/migrations/042_conversion_saga.sql
@@ -1,0 +1,44 @@
+-- Atomic fiat <-> on-chain conversion saga.
+--
+-- Persists each NGN -> USDC conversion as an explicit state machine so the
+-- off-chain fiat leg, the LOCKED FX rate, and the on-chain (Soroban) leg never
+-- end up torn. The locked rate + expiry are stored WITH the saga record so
+-- crash recovery re-executes at the original price instead of re-quoting.
+
+CREATE TABLE IF NOT EXISTS conversion_sagas (
+    saga_id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    deposit_id       TEXT NOT NULL,
+    user_id          TEXT NOT NULL,
+    kind             TEXT NOT NULL DEFAULT 'deposit',          -- 'deposit' | 'staking'
+    amount_ngn       BIGINT NOT NULL,
+    amount_usdc      TEXT NOT NULL DEFAULT '0',
+    locked_rate      DOUBLE PRECISION NOT NULL,                -- NGN per 1 USDC, captured at quote time
+    rate_expires_at  TIMESTAMPTZ NOT NULL,                     -- locked quote expiry
+    provider         TEXT NOT NULL,
+    provider_ref     TEXT NOT NULL DEFAULT '',
+    state            TEXT NOT NULL DEFAULT 'quote_locked',
+    compensation_ref TEXT,                                     -- refund/reversal reference
+    failure_reason   TEXT,
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT conversion_sagas_state_chk CHECK (
+        state IN (
+            'quote_locked',
+            'fiat_committed',
+            'onchain_submitted',
+            'onchain_confirmed',
+            'completed',
+            'compensating',
+            'compensated',
+            'failed'
+        )
+    )
+);
+
+-- One saga per deposit gives once-per-deposit semantics and lets recovery
+-- find the in-flight saga (with its original locked rate) by deposit id.
+CREATE UNIQUE INDEX IF NOT EXISTS conversion_sagas_deposit_id_uidx
+    ON conversion_sagas (deposit_id);
+
+CREATE INDEX IF NOT EXISTS conversion_sagas_user_id_idx ON conversion_sagas (user_id);
+CREATE INDEX IF NOT EXISTS conversion_sagas_state_idx ON conversion_sagas (state);

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -32,6 +32,11 @@ import { createDepositsRouter } from "./routes/deposits.js"
 import { EarningsServiceImpl } from "./services/earnings.js"
 import { StubConversionProvider } from "./services/conversionProvider.js"
 import { ConversionService } from "./services/conversionService.js"
+import {
+  ConversionSagaService,
+  createOutboxOnchainLeg,
+  createNgnWalletFiatLeg,
+} from "./services/conversionSagaService.js"
 import { createWalletRouter } from "./routes/wallet.js"
 import { createNgnWalletRouter } from "./routes/ngnWallet.js"
 import { createAdminRiskRouter } from "./routes/adminRisk.js"
@@ -320,6 +325,17 @@ export function createApp() {
   const conversionService = new ConversionService(conversionProvider, "onramp");
   app.set("conversionService", conversionService);
   app.set("conversionRateService", conversionRateService);
+
+  // Atomic fiat <-> on-chain conversion saga (FX-rate lock + saga compensation).
+  // Reuses the existing exactly-once outbox sender for the on-chain leg and the
+  // existing NgnWalletService reversal mechanism for compensating refunds.
+  const conversionSagaService = new ConversionSagaService(
+    conversionProvider,
+    "onramp",
+    createNgnWalletFiatLeg(ngnWalletService),
+    createOutboxOnchainLeg(new OutboxSender(sorobanAdapter)),
+  );
+  app.set("conversionSagaService", conversionSagaService);
 
   const earningsService = new EarningsServiceImpl(rewardsDataLayer, conversionRateService);
   const stakingService = new StakingService(sorobanAdapter);

--- a/backend/src/models/conversionSaga.ts
+++ b/backend/src/models/conversionSaga.ts
@@ -1,0 +1,91 @@
+/**
+ * Atomic fiat <-> on-chain conversion saga.
+ *
+ * Models a single NGN -> USDC conversion as an explicit, durably-persisted
+ * state machine (saga) so the off-chain fiat leg, the locked FX rate and the
+ * on-chain (Soroban) leg never end up torn.
+ *
+ * Step ordering:
+ *   quote_locked -> fiat_committed -> onchain_submitted -> onchain_confirmed -> completed
+ *
+ * Failure / compensation branch:
+ *   ...           -> compensating -> compensated   (fiat refunded after a fiat
+ *                                                    commit that cannot reach a
+ *                                                    completed on-chain leg)
+ *   quote_locked  -> failed                         (fiat never committed; safe
+ *                                                    to abort, nothing to undo)
+ */
+
+export type ConversionSagaState =
+  | 'quote_locked'
+  | 'fiat_committed'
+  | 'onchain_submitted'
+  | 'onchain_confirmed'
+  | 'completed'
+  | 'compensating'
+  | 'compensated'
+  | 'failed'
+
+/** States from which no further forward/compensation transition is allowed. */
+export const TERMINAL_SAGA_STATES: ReadonlySet<ConversionSagaState> = new Set<ConversionSagaState>([
+  'completed',
+  'compensated',
+  'failed',
+])
+
+/**
+ * Allowed transitions. Every transition the orchestrator performs is validated
+ * against this map so a buggy retry cannot drive the saga into an illegal state.
+ */
+export const SAGA_TRANSITIONS: Readonly<Record<ConversionSagaState, ReadonlyArray<ConversionSagaState>>> = {
+  quote_locked: ['fiat_committed', 'failed'],
+  fiat_committed: ['onchain_submitted', 'compensating'],
+  onchain_submitted: ['onchain_confirmed', 'compensating'],
+  onchain_confirmed: ['completed', 'compensating'],
+  completed: [],
+  compensating: ['compensated'],
+  compensated: [],
+  failed: [],
+}
+
+export function canTransition(from: ConversionSagaState, to: ConversionSagaState): boolean {
+  if (from === to) return true // idempotent no-op re-entry is always allowed
+  return SAGA_TRANSITIONS[from].includes(to)
+}
+
+export type ConversionSagaKind = 'deposit' | 'staking'
+
+export type ConversionProviderName = 'onramp' | 'offramp' | 'manual_admin'
+
+export interface ConversionSagaRecord {
+  sagaId: string
+  /** Synthetic deposit id used as the idempotency anchor (`stake:src:ref` for staking). */
+  depositId: string
+  userId: string
+  kind: ConversionSagaKind
+  amountNgn: number
+  amountUsdc: string
+  /** NGN per 1 USDC captured at quote time. The saga always executes at this rate. */
+  lockedRate: number
+  /** ISO timestamp after which the locked quote may no longer be executed. */
+  rateExpiresAt: Date
+  provider: ConversionProviderName
+  /** Provider reference of the executed conversion (also the on-chain leg ref). */
+  providerRef: string
+  state: ConversionSagaState
+  /** Reversal reference emitted by the compensation leg (refund). */
+  compensationRef: string | null
+  failureReason: string | null
+  createdAt: Date
+  updatedAt: Date
+}
+
+export interface CreateConversionSagaInput {
+  depositId: string
+  userId: string
+  kind: ConversionSagaKind
+  amountNgn: number
+  lockedRate: number
+  rateExpiresAt: Date
+  provider: ConversionProviderName
+}

--- a/backend/src/models/conversionSagaStore.ts
+++ b/backend/src/models/conversionSagaStore.ts
@@ -1,0 +1,229 @@
+import { randomUUID } from 'node:crypto'
+import {
+  type ConversionSagaRecord,
+  type ConversionSagaState,
+  type CreateConversionSagaInput,
+} from './conversionSaga.js'
+import { getPool } from '../db.js'
+
+function mapRow(row: Record<string, unknown>): ConversionSagaRecord {
+  return {
+    sagaId: String(row.saga_id),
+    depositId: String(row.deposit_id),
+    userId: String(row.user_id),
+    kind: row.kind as ConversionSagaRecord['kind'],
+    amountNgn: Number(row.amount_ngn),
+    amountUsdc: String(row.amount_usdc),
+    lockedRate: Number(row.locked_rate),
+    rateExpiresAt: new Date(row.rate_expires_at as string),
+    provider: row.provider as ConversionSagaRecord['provider'],
+    providerRef: String(row.provider_ref ?? ''),
+    state: row.state as ConversionSagaState,
+    compensationRef: (row.compensation_ref as string) ?? null,
+    failureReason: (row.failure_reason as string) ?? null,
+    createdAt: new Date(row.created_at as string),
+    updatedAt: new Date(row.updated_at as string),
+  }
+}
+
+/**
+ * Durable store for {@link ConversionSagaRecord}.
+ *
+ * Mirrors the persistence strategy of {@link ../models/conversionStore.ts}:
+ * a Postgres-backed table when a pool is available, an in-memory map otherwise
+ * (tests / local). One saga per `deposit_id` (unique), which gives us
+ * once-per-deposit semantics for free.
+ */
+class ConversionSagaStore {
+  private byId = new Map<string, ConversionSagaRecord>()
+  private byDepositId = new Map<string, string>()
+
+  private async pool() {
+    return getPool()
+  }
+
+  async getById(sagaId: string): Promise<ConversionSagaRecord | null> {
+    const pool = await this.pool()
+    if (!pool) return this.byId.get(sagaId) ?? null
+    const { rows } = await pool.query(`SELECT * FROM conversion_sagas WHERE saga_id = $1`, [sagaId])
+    return rows[0] ? mapRow(rows[0]) : null
+  }
+
+  async getByDepositId(depositId: string): Promise<ConversionSagaRecord | null> {
+    const pool = await this.pool()
+    if (!pool) {
+      const id = this.byDepositId.get(depositId)
+      return id ? this.byId.get(id) ?? null : null
+    }
+    const { rows } = await pool.query(
+      `SELECT * FROM conversion_sagas WHERE deposit_id = $1 ORDER BY created_at DESC LIMIT 1`,
+      [depositId],
+    )
+    return rows[0] ? mapRow(rows[0]) : null
+  }
+
+  /**
+   * Idempotently create a saga in `quote_locked` for a deposit. If one already
+   * exists for the deposit, the existing record is returned unchanged (the
+   * locked rate is therefore preserved across retries — recovery reuses the
+   * original price rather than re-quoting).
+   */
+  async createQuoteLocked(input: CreateConversionSagaInput): Promise<ConversionSagaRecord> {
+    const pool = await this.pool()
+    if (!pool) {
+      // Synchronous check-and-set: no await between the lookup and the insert,
+      // so concurrent creators for the same deposit converge on one saga
+      // (matches the Postgres unique-deposit-id guarantee).
+      const existingId = this.byDepositId.get(input.depositId)
+      if (existingId) {
+        const existing = this.byId.get(existingId)
+        if (existing) return existing
+      }
+
+      const now = new Date()
+      const record: ConversionSagaRecord = {
+        sagaId: randomUUID(),
+        depositId: input.depositId,
+        userId: input.userId,
+        kind: input.kind,
+        amountNgn: input.amountNgn,
+        amountUsdc: '0',
+        lockedRate: input.lockedRate,
+        rateExpiresAt: input.rateExpiresAt,
+        provider: input.provider,
+        providerRef: '',
+        state: 'quote_locked',
+        compensationRef: null,
+        failureReason: null,
+        createdAt: now,
+        updatedAt: now,
+      }
+      this.byId.set(record.sagaId, record)
+      this.byDepositId.set(record.depositId, record.sagaId)
+      return record
+    }
+
+    const { rows } = await pool.query(
+      `INSERT INTO conversion_sagas
+         (deposit_id, user_id, kind, amount_ngn, locked_rate, rate_expires_at, provider)
+       VALUES ($1, $2, $3, $4, $5, $6::timestamptz, $7)
+       ON CONFLICT (deposit_id) DO UPDATE SET updated_at = NOW()
+       RETURNING *`,
+      [
+        input.depositId,
+        input.userId,
+        input.kind,
+        Math.trunc(input.amountNgn),
+        input.lockedRate,
+        input.rateExpiresAt.toISOString(),
+        input.provider,
+      ],
+    )
+    return mapRow(rows[0])
+  }
+
+  /**
+   * Advance the saga state, optionally persisting derived fields.
+   *
+   * `expectedState` makes the update conditional (compare-and-set): if the
+   * persisted state no longer matches, the write is skipped and the current
+   * record is returned. This prevents a slow concurrent attempt from clobbering
+   * a state already advanced by the winner (lost-update protection).
+   */
+  async transition(
+    sagaId: string,
+    state: ConversionSagaState,
+    patch: {
+      amountUsdc?: string
+      providerRef?: string
+      compensationRef?: string
+      failureReason?: string | null
+      expectedState?: ConversionSagaState
+    } = {},
+  ): Promise<ConversionSagaRecord | null> {
+    const pool = await this.pool()
+    if (!pool) {
+      const existing = this.byId.get(sagaId)
+      if (!existing) return null
+      if (patch.expectedState !== undefined && existing.state !== patch.expectedState) {
+        return existing // CAS miss — leave the winner's state intact
+      }
+      const updated: ConversionSagaRecord = {
+        ...existing,
+        state,
+        amountUsdc: patch.amountUsdc ?? existing.amountUsdc,
+        providerRef: patch.providerRef ?? existing.providerRef,
+        compensationRef: patch.compensationRef ?? existing.compensationRef,
+        failureReason:
+          patch.failureReason === undefined ? existing.failureReason : patch.failureReason,
+        updatedAt: new Date(),
+      }
+      this.byId.set(sagaId, updated)
+      return updated
+    }
+
+    const params: unknown[] = [
+      sagaId,
+      state,
+      patch.amountUsdc ?? null,
+      patch.providerRef ?? null,
+      patch.compensationRef ?? null,
+      patch.failureReason === undefined ? null : patch.failureReason,
+    ]
+    let guard = ''
+    if (patch.expectedState !== undefined) {
+      params.push(patch.expectedState)
+      guard = ` AND state = $${params.length}`
+    }
+
+    const { rows } = await pool.query(
+      `UPDATE conversion_sagas
+       SET state           = $2,
+           amount_usdc     = COALESCE($3, amount_usdc),
+           provider_ref    = COALESCE($4, provider_ref),
+           compensation_ref = COALESCE($5, compensation_ref),
+           failure_reason  = $6,
+           updated_at      = NOW()
+       WHERE saga_id = $1${guard}
+       RETURNING *`,
+      params,
+    )
+    if (rows[0]) return mapRow(rows[0])
+    // CAS miss (or row gone): return the latest record so callers see truth.
+    return this.getById(sagaId)
+  }
+
+  /** Sagas stuck mid-flight (for a recovery worker / admin tooling). */
+  async listInFlight(limit = 100): Promise<ConversionSagaRecord[]> {
+    const inFlight: ConversionSagaState[] = [
+      'fiat_committed',
+      'onchain_submitted',
+      'onchain_confirmed',
+      'compensating',
+    ]
+    const pool = await this.pool()
+    if (!pool) {
+      return Array.from(this.byId.values())
+        .filter((r) => inFlight.includes(r.state))
+        .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime())
+        .slice(0, limit)
+    }
+    const { rows } = await pool.query(
+      `SELECT * FROM conversion_sagas WHERE state = ANY($1) ORDER BY created_at ASC LIMIT $2`,
+      [inFlight, limit],
+    )
+    return rows.map(mapRow)
+  }
+
+  async clear(): Promise<void> {
+    const pool = await this.pool()
+    if (pool) {
+      await pool.query('DELETE FROM conversion_sagas')
+      return
+    }
+    this.byId.clear()
+    this.byDepositId.clear()
+  }
+}
+
+export const conversionSagaStore = new ConversionSagaStore()

--- a/backend/src/services/conversionSagaService.test.ts
+++ b/backend/src/services/conversionSagaService.test.ts
@@ -1,0 +1,277 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+
+import {
+  ConversionSagaService,
+  type ConversionFiatLeg,
+  type ConversionOnchainLeg,
+} from './conversionSagaService.js'
+import { StubConversionProvider } from './conversionProvider.js'
+import { conversionSagaStore } from '../models/conversionSagaStore.js'
+import { _resetDurableIdempotencyMemory } from './durableIdempotencyService.js'
+
+/**
+ * Failure-injection tests for the atomic conversion saga.
+ *
+ * Acceptance criteria exercised here:
+ *  - fiat-ok / chain-fail        -> refund (compensation) fires; no torn state.
+ *  - chain-ok / receipt-fail     -> forward recovery, no double mint.
+ *  - rate-expired                -> execution rejected.
+ *  - retry storms                -> no duplication (idempotency holds).
+ *  - fiat-commit-fail            -> chain leg never starts.
+ */
+
+const RATE = 1600 // NGN per USDC (StubConversionProvider)
+
+/**
+ * In-memory fiat ledger that records every commit/refund so tests can assert
+ * "debited exactly once" / "refunded exactly once". Idempotent on (ref) like
+ * the real NgnWalletService reversal path.
+ */
+class FakeFiatLeg implements ConversionFiatLeg {
+  commits: string[] = []
+  refunds: string[] = []
+  failCommit = false
+  private committed = new Set<string>()
+  private refunded = new Set<string>()
+
+  async commit(input: { userId: string; refSource: string; ref: string; amountNgn: number }) {
+    if (this.failCommit) {
+      throw new Error('Simulated fiat commit failure')
+    }
+    if (this.committed.has(input.ref)) return // idempotent
+    this.committed.add(input.ref)
+    this.commits.push(input.ref)
+  }
+
+  async refund(input: { userId: string; ref: string; amountNgn: number; reversalRef: string }) {
+    if (this.refunded.has(input.reversalRef)) return // idempotent
+    this.refunded.add(input.reversalRef)
+    this.refunds.push(input.reversalRef)
+  }
+
+  /** Net fiat position from the ledger's perspective. */
+  net(amountNgn: number): number {
+    return this.commits.length * -amountNgn + this.refunds.length * amountNgn
+  }
+}
+
+/** On-chain leg whose behaviour is injectable per-test. */
+class FakeOnchainLeg implements ConversionOnchainLeg {
+  submitCalls = 0
+  mode: 'confirm' | 'queue' | 'throw' = 'confirm'
+
+  async submit(): Promise<{ confirmed: boolean; outboxId: string }> {
+    this.submitCalls += 1
+    if (this.mode === 'throw') {
+      throw new Error('Simulated unrecoverable on-chain failure')
+    }
+    return { confirmed: this.mode === 'confirm', outboxId: `outbox-${this.submitCalls}` }
+  }
+}
+
+function makeService(
+  fiat: FakeFiatLeg,
+  chain: FakeOnchainLeg,
+  overrides: Partial<{ rateLockTtlMs: number; maxSlippage: number }> = {},
+) {
+  return new ConversionSagaService(new StubConversionProvider(RATE), 'onramp', fiat, chain, {
+    rateLockTtlMs: 60_000,
+    maxSlippage: 0.05,
+    ...overrides,
+  })
+}
+
+describe('ConversionSagaService — atomic conversion saga', () => {
+  beforeEach(async () => {
+    await conversionSagaStore.clear()
+    _resetDurableIdempotencyMemory()
+  })
+
+  it('happy path: fiat committed + chain confirmed -> completed', async () => {
+    const fiat = new FakeFiatLeg()
+    const chain = new FakeOnchainLeg()
+    chain.mode = 'confirm'
+    const svc = makeService(fiat, chain)
+
+    const saga = await svc.convert({
+      depositId: 'dep-happy',
+      userId: 'u1',
+      kind: 'deposit',
+      amountNgn: 160_000,
+    })
+
+    expect(saga.state).toBe('completed')
+    expect(saga.amountUsdc).toBe('100.000000') // 160000 / 1600
+    expect(fiat.commits).toHaveLength(1)
+    expect(fiat.refunds).toHaveLength(0)
+    expect(chain.submitCalls).toBe(1)
+  })
+
+  it('fiat-ok / chain-fail -> compensation fires, fiat refunded, no torn state', async () => {
+    const fiat = new FakeFiatLeg()
+    const chain = new FakeOnchainLeg()
+    chain.mode = 'throw'
+    const svc = makeService(fiat, chain)
+
+    const saga = await svc.convert({
+      depositId: 'dep-chainfail',
+      userId: 'u1',
+      kind: 'deposit',
+      amountNgn: 160_000,
+    })
+
+    expect(saga.state).toBe('compensated')
+    expect(fiat.commits).toHaveLength(1)
+    expect(fiat.refunds).toHaveLength(1)
+    expect(saga.compensationRef).toBe(`conv-refund:${saga.sagaId}`)
+    // No torn state: net fiat position is zero (debited then refunded).
+    expect(fiat.net(160_000)).toBe(0)
+  })
+
+  it('fiat-commit-fail -> chain leg never starts, saga failed', async () => {
+    const fiat = new FakeFiatLeg()
+    fiat.failCommit = true
+    const chain = new FakeOnchainLeg()
+    const svc = makeService(fiat, chain)
+
+    await expect(
+      svc.convert({ depositId: 'dep-fiatfail', userId: 'u1', kind: 'deposit', amountNgn: 160_000 }),
+    ).rejects.toThrow(/fiat commit/i)
+
+    const saga = await conversionSagaStore.getByDepositId('dep-fiatfail')
+    expect(saga?.state).toBe('failed')
+    expect(fiat.commits).toHaveLength(0)
+    expect(chain.submitCalls).toBe(0) // never started
+  })
+
+  it('chain-ok / receipt-fail (queued) -> forward recovery, no double mint', async () => {
+    const fiat = new FakeFiatLeg()
+    const chain = new FakeOnchainLeg()
+    chain.mode = 'queue' // submitted but not confirmed (receipt write pending)
+    const svc = makeService(fiat, chain)
+
+    const first = await svc.convert({
+      depositId: 'dep-recovery',
+      userId: 'u1',
+      kind: 'deposit',
+      amountNgn: 160_000,
+    })
+
+    expect(first.state).toBe('onchain_submitted')
+    expect(fiat.commits).toHaveLength(1)
+    expect(chain.submitCalls).toBe(1)
+
+    // Forward recovery: re-run. The submit-onchain step replays (idempotent),
+    // so no second submission / no double mint.
+    const recovered = await svc.execute(first)
+    expect(recovered.state).toBe('onchain_submitted')
+    expect(chain.submitCalls).toBe(1) // NOT re-submitted
+    expect(fiat.commits).toHaveLength(1) // NOT re-debited
+  })
+
+  it('rate-expired -> execution rejected', async () => {
+    const fiat = new FakeFiatLeg()
+    const chain = new FakeOnchainLeg()
+    // Lock a quote that has already expired by the time we execute.
+    const svc = makeService(fiat, chain, { rateLockTtlMs: -1 })
+
+    const saga = await svc.lockQuote({
+      depositId: 'dep-expired',
+      userId: 'u1',
+      kind: 'deposit',
+      amountNgn: 160_000,
+    })
+
+    await expect(svc.execute(saga)).rejects.toThrow(/expired/i)
+    expect(fiat.commits).toHaveLength(0)
+    expect(chain.submitCalls).toBe(0)
+  })
+
+  it('retry storm: many concurrent convert() calls -> single debit, single mint', async () => {
+    const fiat = new FakeFiatLeg()
+    const chain = new FakeOnchainLeg()
+    chain.mode = 'confirm'
+    const svc = makeService(fiat, chain)
+
+    const input = { depositId: 'dep-storm', userId: 'u1', kind: 'deposit' as const, amountNgn: 160_000 }
+
+    const results = await Promise.allSettled(Array.from({ length: 12 }, () => svc.convert(input)))
+
+    // Some concurrent attempts may bounce off the in-flight idempotency lease;
+    // at least one must complete, and side effects must not duplicate.
+    const fulfilled = results.filter((r) => r.status === 'fulfilled')
+    expect(fulfilled.length).toBeGreaterThan(0)
+
+    const saga = await conversionSagaStore.getByDepositId('dep-storm')
+    expect(saga?.state).toBe('completed')
+    expect(fiat.commits).toHaveLength(1) // exactly one debit
+    expect(chain.submitCalls).toBe(1) // exactly one mint
+    expect(fiat.refunds).toHaveLength(0)
+  })
+
+  it('sequential retries after completion are replay-safe no-ops', async () => {
+    const fiat = new FakeFiatLeg()
+    const chain = new FakeOnchainLeg()
+    chain.mode = 'confirm'
+    const svc = makeService(fiat, chain)
+    const input = { depositId: 'dep-replay', userId: 'u1', kind: 'deposit' as const, amountNgn: 160_000 }
+
+    const a = await svc.convert(input)
+    const b = await svc.convert(input)
+    const c = await svc.convert(input)
+
+    expect(a.sagaId).toBe(b.sagaId)
+    expect(b.sagaId).toBe(c.sagaId)
+    expect(a.state).toBe('completed')
+    expect(c.state).toBe('completed')
+    expect(fiat.commits).toHaveLength(1)
+    expect(chain.submitCalls).toBe(1)
+  })
+
+  it('locked rate is preserved on re-lock (recovery uses original price)', async () => {
+    const fiat = new FakeFiatLeg()
+    const chain = new FakeOnchainLeg()
+    const svc = makeService(fiat, chain)
+
+    const first = await svc.lockQuote({
+      depositId: 'dep-lock',
+      userId: 'u1',
+      kind: 'deposit',
+      amountNgn: 160_000,
+    })
+    expect(first.lockedRate).toBe(RATE)
+
+    // Re-locking the same deposit must return the SAME locked rate/saga, even
+    // though a fresh quote could differ.
+    const second = await svc.lockQuote({
+      depositId: 'dep-lock',
+      userId: 'u1',
+      kind: 'deposit',
+      amountNgn: 160_000,
+    })
+    expect(second.sagaId).toBe(first.sagaId)
+    expect(second.lockedRate).toBe(first.lockedRate)
+    expect(second.rateExpiresAt.getTime()).toBe(first.rateExpiresAt.getTime())
+  })
+
+  it('compensation is idempotent: re-running does not double-refund', async () => {
+    const fiat = new FakeFiatLeg()
+    const chain = new FakeOnchainLeg()
+    chain.mode = 'throw'
+    const svc = makeService(fiat, chain)
+
+    const saga = await svc.convert({
+      depositId: 'dep-comp-idem',
+      userId: 'u1',
+      kind: 'deposit',
+      amountNgn: 160_000,
+    })
+    expect(saga.state).toBe('compensated')
+    expect(fiat.refunds).toHaveLength(1)
+
+    // Re-run compensation explicitly — must be a no-op.
+    const again = await svc.compensate(saga, 'retry')
+    expect(again.state).toBe('compensated')
+    expect(fiat.refunds).toHaveLength(1) // not doubled
+  })
+})

--- a/backend/src/services/conversionSagaService.ts
+++ b/backend/src/services/conversionSagaService.ts
@@ -1,0 +1,472 @@
+import { logger } from '../utils/logger.js'
+import { AppError } from '../errors/AppError.js'
+import { ErrorCode } from '../errors/errorCodes.js'
+import {
+  type ConversionSagaRecord,
+  type ConversionSagaState,
+  type ConversionSagaKind,
+  type ConversionProviderName,
+  canTransition,
+} from '../models/conversionSaga.js'
+import { conversionSagaStore } from '../models/conversionSagaStore.js'
+import { durableIdempotencyService } from './durableIdempotencyService.js'
+import { type ConversionProvider } from './conversionProvider.js'
+import { outboxStore, TxType, type OutboxItem } from '../outbox/index.js'
+import { getUsdcTokenAddress } from '../utils/token.js'
+
+/**
+ * Off-chain fiat leg used by the saga. Production wires this to the existing
+ * NgnWalletService so the COMMIT debits the NGN wallet (CONVERSION_DEBIT ledger
+ * entry) and the REFUND reuses the existing reversal mechanism (TOPUP_REVERSED
+ * ledger entry — the same path exercised by ngnWalletService.reversal.test.ts).
+ */
+export interface ConversionFiatLeg {
+  /** Debit fiat for the conversion. MUST be idempotent on (refSource, ref). */
+  commit(input: { userId: string; refSource: string; ref: string; amountNgn: number }): Promise<void>
+  /** Refund/reverse a previously committed fiat debit. MUST be idempotent. */
+  refund(input: {
+    userId: string
+    refSource: string
+    ref: string
+    amountNgn: number
+    reversalRef: string
+  }): Promise<void>
+}
+
+/**
+ * On-chain leg used by the saga. Production enqueues a CONVERSION outbox item
+ * (idempotent by source+ref) and the existing exactly-once OutboxSender drives
+ * it to the chain. `submit` returns whether the chain write has confirmed; an
+ * unconfirmed-but-queued submission is *recoverable* (forward recovery) and is
+ * NOT treated as a torn state.
+ */
+export interface ConversionOnchainLeg {
+  /**
+   * Submit the on-chain conversion receipt.
+   * @returns `{ confirmed }` — true if the chain write confirmed synchronously,
+   *          false if it is durably queued for retry (forward recovery).
+   * @throws if submission is unrecoverable (triggers compensation).
+   */
+  submit(input: {
+    saga: ConversionSagaRecord
+  }): Promise<{ confirmed: boolean; outboxId: string }>
+}
+
+const SAGA_SCOPE = 'conversion-saga'
+
+/** Steps that are guarded by the durable idempotency service. */
+type SagaStep = 'commit-fiat' | 'submit-onchain' | 'compensate'
+
+/**
+ * True for errors raised by the idempotency lease itself (a concurrent worker
+ * holds the step, or a payload conflict) rather than by the step's side effect.
+ * These must NOT poison the saga or trigger compensation — they are transient.
+ */
+function isIdempotencyControlError(e: unknown): boolean {
+  return (
+    e instanceof AppError &&
+    (e.code === ErrorCode.REQUEST_IN_FLIGHT || e.code === ErrorCode.CONFLICT)
+  )
+}
+
+export interface ConversionSagaConfig {
+  /** How long a locked FX quote stays valid before execution is rejected. */
+  rateLockTtlMs: number
+  /**
+   * Max fractional deviation tolerated if a re-quote is required during
+   * recovery (e.g. 0.01 = 1%). Beyond this the saga refuses to execute at a
+   * different price and the locked quote must be re-issued.
+   */
+  maxSlippage: number
+}
+
+export const DEFAULT_SAGA_CONFIG: ConversionSagaConfig = {
+  rateLockTtlMs: parseInt(process.env.CONVERSION_RATE_LOCK_TTL_MS ?? String(2 * 60 * 1000), 10),
+  maxSlippage: Number(process.env.CONVERSION_MAX_SLIPPAGE ?? '0.01'),
+}
+
+/**
+ * Default on-chain leg: enqueue a CONVERSION outbox item and attempt an
+ * immediate send via the injected sender. Idempotent by (provider, providerRef).
+ */
+export function createOutboxOnchainLeg(sender: {
+  send: (item: OutboxItem) => Promise<boolean>
+}): ConversionOnchainLeg {
+  return {
+    async submit({ saga }) {
+      const item = await outboxStore.create({
+        txType: TxType.CONVERSION,
+        source: saga.provider,
+        ref: saga.providerRef,
+        payload: {
+          txType: TxType.CONVERSION,
+          amountUsdc: saga.amountUsdc,
+          tokenAddress: getUsdcTokenAddress(),
+          dealId: 'conversion',
+          amountNgn: saga.amountNgn,
+          fxRateNgnPerUsdc: saga.lockedRate,
+          fxProvider: saga.provider,
+          conversionId: saga.sagaId,
+          depositId: saga.depositId,
+          conversionProviderRef: saga.providerRef,
+          userId: saga.userId,
+        },
+      })
+      const confirmed = await sender.send(item)
+      return { confirmed, outboxId: item.id }
+    },
+  }
+}
+
+export class ConversionSagaService {
+  private readonly config: ConversionSagaConfig
+
+  constructor(
+    private readonly provider: ConversionProvider,
+    private readonly fxProviderName: ConversionProviderName,
+    private readonly fiatLeg: ConversionFiatLeg,
+    private readonly onchainLeg: ConversionOnchainLeg,
+    config: Partial<ConversionSagaConfig> = {},
+  ) {
+    this.config = { ...DEFAULT_SAGA_CONFIG, ...config }
+  }
+
+  /**
+   * Guarded transition: validates the edge, then performs a compare-and-set on
+   * the expected source state so a slow concurrent attempt cannot regress a
+   * saga the winner already advanced (lost-update protection).
+   */
+  private async advance(
+    saga: ConversionSagaRecord,
+    to: ConversionSagaState,
+    patch: Parameters<typeof conversionSagaStore.transition>[2] = {},
+  ): Promise<ConversionSagaRecord> {
+    if (!canTransition(saga.state, to)) {
+      throw new AppError(
+        ErrorCode.INVALID_STATE_TRANSITION,
+        409,
+        `Illegal conversion saga transition ${saga.state} -> ${to}`,
+        { sagaId: saga.sagaId },
+      )
+    }
+    const updated = await conversionSagaStore.transition(saga.sagaId, to, {
+      ...patch,
+      expectedState: patch.expectedState ?? saga.state,
+    })
+    if (!updated) {
+      throw new AppError(ErrorCode.INTERNAL_ERROR, 500, 'Conversion saga vanished mid-transition', {
+        sagaId: saga.sagaId,
+      })
+    }
+    return updated
+  }
+
+  /**
+   * Run an idempotent step. The durable idempotency service guarantees the body
+   * runs at most once for a given (saga, step); concurrent duplicate retries get
+   * `in_flight`, completed retries replay without re-running side effects.
+   *
+   * Returns the body's value on first run, or `undefined` on replay (the step's
+   * side effects already happened, so callers must tolerate a replayed step).
+   */
+  private async runStep<T>(
+    saga: ConversionSagaRecord,
+    step: SagaStep,
+    body: () => Promise<T>,
+  ): Promise<T | undefined> {
+    const idempotencyKey = `${saga.depositId}:${step}`
+    const requestBodyHash = durableIdempotencyService.payloadHash({
+      sagaId: saga.sagaId,
+      step,
+      amountNgn: saga.amountNgn,
+      lockedRate: saga.lockedRate,
+    })
+    const start = await durableIdempotencyService.start({
+      scope: SAGA_SCOPE,
+      idempotencyKey,
+      requestBodyHash,
+    })
+
+    if (start.type === 'replay') {
+      // Step already completed in a prior attempt — no double side effect.
+      return undefined
+    }
+    if (start.type === 'in_flight') {
+      throw new AppError(ErrorCode.REQUEST_IN_FLIGHT, 409, `Conversion step ${step} already in flight`, {
+        sagaId: saga.sagaId,
+      })
+    }
+    if (start.type === 'conflict') {
+      throw new AppError(ErrorCode.CONFLICT, 409, `Conversion step ${step} payload conflict`, {
+        sagaId: saga.sagaId,
+      })
+    }
+
+    try {
+      const value = await body()
+      await durableIdempotencyService.complete({
+        scope: SAGA_SCOPE,
+        idempotencyKey,
+        httpStatus: 200,
+        body: { step, sagaId: saga.sagaId },
+      })
+      return value
+    } catch (e) {
+      // Release the lease so a retry can re-run this step.
+      await durableIdempotencyService.fail({
+        scope: SAGA_SCOPE,
+        idempotencyKey,
+        message: e instanceof Error ? e.message : String(e),
+      })
+      throw e
+    }
+  }
+
+  /** Reject execution of a saga whose locked quote has expired. */
+  private assertNotExpired(saga: ConversionSagaRecord): void {
+    if (Date.now() > saga.rateExpiresAt.getTime()) {
+      throw new AppError(
+        ErrorCode.CONFLICT,
+        409,
+        `Locked FX quote expired at ${saga.rateExpiresAt.toISOString()}; re-quote required`,
+        { sagaId: saga.sagaId, code: 'RATE_EXPIRED' },
+      )
+    }
+  }
+
+  /**
+   * Quote-lock step: capture the current rate with an expiry and persist it WITH
+   * the saga record. Idempotent per deposit — an existing saga keeps its
+   * original locked rate (recovery uses the original price, never a fresh quote).
+   */
+  async lockQuote(input: {
+    depositId: string
+    userId: string
+    kind: ConversionSagaKind
+    amountNgn: number
+  }): Promise<ConversionSagaRecord> {
+    const existing = await conversionSagaStore.getByDepositId(input.depositId)
+    if (existing) return existing
+
+    if (input.amountNgn <= 0) {
+      throw new AppError(ErrorCode.VALIDATION_ERROR, 400, 'amountNgn must be positive')
+    }
+
+    const quote = await this.provider.getRate()
+    if (!Number.isFinite(quote.rate) || quote.rate <= 0) {
+      throw new AppError(ErrorCode.EXTERNAL_SERVICE_ERROR, 502, 'Conversion provider returned an invalid rate')
+    }
+
+    return conversionSagaStore.createQuoteLocked({
+      depositId: input.depositId,
+      userId: input.userId,
+      kind: input.kind,
+      amountNgn: input.amountNgn,
+      lockedRate: quote.rate,
+      rateExpiresAt: new Date(Date.now() + this.config.rateLockTtlMs),
+      provider: this.fxProviderName,
+    })
+  }
+
+  /**
+   * Drive a quote-locked saga to completion (or compensation).
+   *
+   * Ordering guarantees the acceptance criteria:
+   *   1. If fiat commit fails -> the chain leg never starts (saga -> failed).
+   *   2. After fiat commit, if the chain leg is unrecoverable -> deterministic
+   *      refund via the existing reversal mechanism (saga -> compensated).
+   *   3. A queued-but-unconfirmed chain leg is forward recovery, NOT torn.
+   */
+  async execute(saga: ConversionSagaRecord): Promise<ConversionSagaRecord> {
+    let current = saga
+
+    // Already terminal — replay-safe no-op.
+    if (current.state === 'completed' || current.state === 'compensated' || current.state === 'failed') {
+      return current
+    }
+
+    this.assertNotExpired(current)
+
+    // --- Step 0: execute the FX conversion at the LOCKED rate -----------------
+    // Compute the USDC amount from the locked rate (never a fresh quote). We
+    // still call the provider to obtain a providerRef, but reject if the
+    // returned rate has drifted beyond the slippage policy.
+    if (current.state === 'quote_locked' && current.providerRef === '') {
+      const result = await this.provider.convertNgnToUsdc({
+        amountNgn: current.amountNgn,
+        userId: current.userId,
+        depositId: current.depositId,
+      })
+      this.assertSlippageWithinPolicy(current.lockedRate, result.fxRateNgnPerUsdc, current.sagaId)
+      // Compare-and-set: only stamp the providerRef/usdc while still
+      // quote_locked. A concurrent attempt that has already advanced the saga
+      // wins (CAS miss returns the advanced record, never regressing it).
+      current =
+        (await conversionSagaStore.transition(current.sagaId, 'quote_locked', {
+          amountUsdc: this.usdcAtLockedRate(current.amountNgn, current.lockedRate),
+          providerRef: result.providerRef,
+          expectedState: 'quote_locked',
+        })) ?? current
+    }
+
+    // --- Step 1: commit the fiat leg -----------------------------------------
+    if (current.state === 'quote_locked') {
+      try {
+        await this.runStep(current, 'commit-fiat', () =>
+          this.fiatLeg.commit({
+            userId: current.userId,
+            refSource: current.provider,
+            ref: current.providerRef,
+            amountNgn: current.amountNgn,
+          }),
+        )
+      } catch (e) {
+        // A transient idempotency-control bounce (another worker holds the
+        // lease, or a conflicting in-flight key) is NOT a fiat failure: leave
+        // the saga in quote_locked so a later attempt can finish it. Only a
+        // genuine fiat-commit failure aborts the saga (nothing to undo).
+        if (isIdempotencyControlError(e)) throw e
+        const msg = e instanceof Error ? e.message : String(e)
+        logger.error('Conversion saga: fiat commit failed; aborting before chain leg', {
+          sagaId: current.sagaId,
+          error: msg,
+        })
+        await this.advance(current, 'failed', { failureReason: `fiat_commit_failed: ${msg}` })
+        throw e
+      }
+      current = await this.advance(current, 'fiat_committed')
+    }
+
+    // --- Step 2: submit the on-chain leg -------------------------------------
+    if (current.state === 'fiat_committed') {
+      let submission: { confirmed: boolean; outboxId: string } | undefined
+      try {
+        submission = await this.runStep(current, 'submit-onchain', () =>
+          this.onchainLeg.submit({ saga: current }),
+        )
+      } catch (e) {
+        // A transient idempotency-control bounce means another worker is
+        // already submitting — re-throw without compensating (fiat stays
+        // committed; forward recovery will complete it).
+        if (isIdempotencyControlError(e)) throw e
+        // Chain leg unrecoverable AFTER fiat commit -> compensate (refund).
+        const msg = e instanceof Error ? e.message : String(e)
+        logger.error('Conversion saga: on-chain leg unrecoverable; compensating', {
+          sagaId: current.sagaId,
+          error: msg,
+        })
+        return this.compensate(current, msg)
+      }
+
+      current = await this.advance(current, 'onchain_submitted')
+
+      // A confirmed synchronous submission completes the saga; an unconfirmed
+      // (queued) submission is left for forward recovery by the outbox worker.
+      if (submission?.confirmed) {
+        current = await this.advance(current, 'onchain_confirmed')
+        current = await this.advance(current, 'completed')
+      }
+    }
+
+    return current
+  }
+
+  /**
+   * Compensating action: refund the fiat debit using the EXISTING reversal
+   * mechanism, then mark the saga compensated. Idempotent — a retried
+   * compensation does not double-refund.
+   */
+  async compensate(saga: ConversionSagaRecord, reason: string): Promise<ConversionSagaRecord> {
+    if (saga.state === 'compensated') return saga
+    if (saga.state === 'completed') {
+      throw new AppError(ErrorCode.INVALID_STATE_TRANSITION, 409, 'Cannot compensate a completed saga', {
+        sagaId: saga.sagaId,
+      })
+    }
+
+    let current = saga.state === 'compensating' ? saga : await this.advance(saga, 'compensating', {
+      failureReason: reason,
+    })
+
+    const reversalRef = `conv-refund:${current.sagaId}`
+    await this.runStep(current, 'compensate', () =>
+      this.fiatLeg.refund({
+        userId: current.userId,
+        refSource: current.provider,
+        ref: current.providerRef,
+        amountNgn: current.amountNgn,
+        reversalRef,
+      }),
+    )
+
+    current = await this.advance(current, 'compensated', { compensationRef: reversalRef })
+    logger.info('Conversion saga compensated (fiat refunded)', {
+      sagaId: current.sagaId,
+      reason,
+      reversalRef,
+    })
+    return current
+  }
+
+  /**
+   * Convenience entry point: lock the quote then execute end-to-end.
+   * Idempotent by deposit id — repeated calls converge on the same saga.
+   */
+  async convert(input: {
+    depositId: string
+    userId: string
+    kind: ConversionSagaKind
+    amountNgn: number
+  }): Promise<ConversionSagaRecord> {
+    const saga = await this.lockQuote(input)
+    return this.execute(saga)
+  }
+
+  private usdcAtLockedRate(amountNgn: number, lockedRate: number): string {
+    return (amountNgn / lockedRate).toFixed(6)
+  }
+
+  private assertSlippageWithinPolicy(lockedRate: number, executedRate: number, sagaId: string): void {
+    if (!Number.isFinite(executedRate) || executedRate <= 0) return
+    const slippage = Math.abs(executedRate - lockedRate) / lockedRate
+    if (slippage > this.config.maxSlippage) {
+      throw new AppError(
+        ErrorCode.CONFLICT,
+        409,
+        `FX slippage ${(slippage * 100).toFixed(2)}% exceeds max ${(this.config.maxSlippage * 100).toFixed(2)}%; re-quote required`,
+        { sagaId, lockedRate, executedRate, code: 'SLIPPAGE_EXCEEDED' },
+      )
+    }
+  }
+}
+
+/**
+ * Production fiat leg backed by NgnWalletService.
+ *
+ * COMMIT  -> debitNgnForConversion (CONVERSION_DEBIT ledger entry)
+ * REFUND  -> reverseTopUp          (TOPUP_REVERSED ledger entry — the existing
+ *                                   reversal mechanism)
+ */
+export function createNgnWalletFiatLeg(ngnWalletService: {
+  debitNgnForConversion: (
+    userId: string,
+    externalRefSource: string,
+    externalRef: string,
+    amountNgn: number,
+  ) => Promise<unknown>
+  reverseTopUp: (
+    userId: string,
+    depositId: string,
+    amountNgn: number,
+    reference: string,
+  ) => Promise<unknown>
+}): ConversionFiatLeg {
+  return {
+    async commit({ userId, refSource, ref, amountNgn }) {
+      await ngnWalletService.debitNgnForConversion(userId, refSource, ref, amountNgn)
+    },
+    async refund({ userId, ref, amountNgn, reversalRef }) {
+      await ngnWalletService.reverseTopUp(userId, ref, amountNgn, reversalRef)
+    },
+  }
+}


### PR DESCRIPTION
## Summary

`convertDeposit`/`convertForStaking` coordinated an off-chain fiat leg, an FX rate, and an on-chain (Soroban) leg with **no shared transaction**, leaving torn states possible: fiat debited but chain failed; chain ok but receipt write failed; or the FX rate moving between quote and execution.

This models NGN→USDC conversion as an **explicit, durably-persisted saga / state machine** with FX-rate locking and deterministic compensation, reusing the codebase's existing outbox, durable-idempotency, and reversal mechanisms rather than inventing new ones.

## Changes

- **State machine** (`models/conversionSaga.ts`): `quote_locked → fiat_committed → onchain_submitted → onchain_confirmed → completed`, plus `compensating → compensated` and `failed`, with validated transitions (`canTransition`).
- **Durable store** (`models/conversionSagaStore.ts` + `migrations/042_conversion_saga.sql`): Postgres + in-memory, one saga per `deposit_id`. The **locked rate and its expiry are persisted with the saga record**, so recovery re-executes at the original price — never a fresh quote. Transitions support compare-and-set on the expected source state to avoid lost-update regressions.
- **Orchestrator** (`services/conversionSagaService.ts`):
  - **FX-rate lock**: rate captured at quote time with an expiry; execution past expiry is rejected; a max-slippage policy rejects execution if the executed rate drifts beyond tolerance (`CONVERSION_RATE_LOCK_TTL_MS`, `CONVERSION_MAX_SLIPPAGE`).
  - **Idempotency**: each step (`commit-fiat`, `submit-onchain`, `compensate`) is keyed through the existing `durableIdempotencyService` (scope `conversion-saga`, key `<depositId>:<step>`) so retries cannot double-debit / double-mint / double-refund.
  - **On-chain leg via outbox**: enqueues a `CONVERSION` item through the existing exactly-once `OutboxSender`; a queued-but-unconfirmed submission is treated as **forward recovery**, not a torn state.
  - **Compensation**: if the chain leg is unrecoverable after fiat commit, the fiat is refunded deterministically by **reusing the existing reversal mechanism** (`NgnWalletService.reverseTopUp` → `TOPUP_REVERSED` ledger entry). If fiat commit fails, the chain leg never starts.
- **Wiring** (`app.ts`): registers `ConversionSagaService` with the NgnWallet fiat leg and the outbox on-chain leg.

## How it works

- **Compensation** reuses `NgnWalletService.reverseTopUp` (the same `TOPUP_REVERSED` reversal path covered by `ngnWalletService.reversal.test.ts`) — no new reversal mechanism.
- **Idempotency** reuses `durableIdempotencyService` (start/complete/fail leases) for per-step keys; idempotency-control bounces (`in_flight`/`conflict`) are treated as transient and never poison the saga or trigger a spurious refund.
- **FX lock** stores `locked_rate` + `rate_expires_at` on the saga; execute() rejects expired quotes and enforces the slippage policy before committing fiat.

## Test plan (vitest, failure injection — `src/services/conversionSagaService.test.ts`)

- fiat-ok / chain-fail → compensation fires, fiat refunded, **no torn state**.
- chain-ok / receipt-fail (queued) → forward recovery, **no double mint**.
- rate-expired → execution rejected.
- retry storm (12 concurrent) → exactly one debit, exactly one mint.
- fiat-commit-fail → chain leg never starts (saga `failed`).
- compensation idempotent (no double-refund); locked rate preserved on re-lock.

All 9 new tests pass; existing `conversionService`, `conversionReceipt.integration`, and `ngnWalletService.reversal` suites remain green (32 tests total). `typecheck`/`build` introduce zero new errors (76 pre-existing repo errors are unrelated — e.g. a missing `uuid` dependency in `admin.ts`/`repaymentScheduleService.ts`).

## Out of scope

- Conversion provider integrations (`conversionProvider*`).
- UI for conversion status.
- A standalone recovery worker that drains in-flight sagas (the store exposes `listInFlight()` for one); not required by the acceptance criteria.

Closes #1100