### PR TITLE
fix(webhooks): enforce exactly-once monotonic processing

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -52,6 +52,10 @@ INDEXER_START_LEDGER=
 DATABASE_URL=postgres://app:app@localhost:5432/app
 ENCRYPTION_KEY=supersecretkey123
 
+# Inbound webhook anti-replay window. Providers must sign
+# "<x-webhook-timestamp>.<raw request body>". Default: 300 seconds.
+WEBHOOK_TIMESTAMP_TOLERANCE_SECONDS=300
+
 # NGN → USDC conversion (deposits / staking on-ramp)
 FX_RATE_NGN_PER_USDC=1600
 # stub | http | fallback

--- a/backend/src/middleware/webhookSignature.test.ts
+++ b/backend/src/middleware/webhookSignature.test.ts
@@ -8,6 +8,10 @@ import {
   _testOnlyClearWebhookReplayCache,
 } from '../middleware/webhookSignature.js'
 import { AppError } from '../errors/AppError.js'
+import {
+  constantTimeEqual,
+  timestampedWebhookPayload,
+} from '../payments/webhookSecurity.js'
 
 function mockReq(
   overrides: Partial<Request> & { rawBody?: Buffer | string; body?: unknown } = {},
@@ -39,9 +43,13 @@ describe('webhookSignature middleware', () => {
 
   it('accepts valid Paystack signature', () => {
     const payload = Buffer.from(JSON.stringify({ event: 'charge.success', data: { id: 'evt-1' } }))
-    const signature = crypto.createHmac('sha512', secret).update(payload).digest('hex')
+    const timestamp = String(Date.now())
+    const signature = crypto
+      .createHmac('sha512', secret)
+      .update(timestampedWebhookPayload(timestamp, payload))
+      .digest('hex')
     const req = mockReq({
-      headers: { 'x-paystack-signature': signature },
+      headers: { 'x-paystack-signature': signature, 'x-webhook-timestamp': timestamp },
       rawBody: payload,
     })
     const next = vi.fn()
@@ -52,9 +60,13 @@ describe('webhookSignature middleware', () => {
 
   it('rejects tampered Paystack body', () => {
     const payload = Buffer.from(JSON.stringify({ event: 'charge.success' }))
-    const signature = crypto.createHmac('sha512', secret).update(payload).digest('hex')
+    const timestamp = String(Date.now())
+    const signature = crypto
+      .createHmac('sha512', secret)
+      .update(timestampedWebhookPayload(timestamp, payload))
+      .digest('hex')
     const req = mockReq({
-      headers: { 'x-paystack-signature': signature },
+      headers: { 'x-paystack-signature': signature, 'x-webhook-timestamp': timestamp },
       rawBody: Buffer.from(JSON.stringify({ event: 'charge.failed' })),
     })
     const next = vi.fn()
@@ -72,17 +84,58 @@ describe('webhookSignature middleware', () => {
   })
 
   it('accepts valid Flutterwave verif-hash', () => {
-    const req = mockReq({ headers: { 'verif-hash': flwHash } })
+    const timestamp = String(Date.now())
+    const signature = crypto
+      .createHmac('sha256', flwHash)
+      .update(timestampedWebhookPayload(timestamp, Buffer.from('{}')))
+      .digest('hex')
+    const req = mockReq({
+      headers: { 'verif-hash': signature, 'x-webhook-timestamp': timestamp },
+      rawBody: Buffer.from('{}'),
+    })
     const next = vi.fn()
     verifyFlutterwaveSignature(req, mockRes(), next)
     expect(next).toHaveBeenCalledWith()
   })
 
   it('rejects invalid Flutterwave verif-hash', () => {
-    const req = mockReq({ headers: { 'verif-hash': 'wrong' } })
+    const req = mockReq({
+      headers: { 'verif-hash': 'wrong', 'x-webhook-timestamp': String(Date.now()) },
+    })
     const next = vi.fn()
     verifyFlutterwaveSignature(req, mockRes(), next)
     expect(next).toHaveBeenCalledWith(expect.any(AppError))
+  })
+
+  it('rejects a correctly signed event outside the freshness window', () => {
+    const payload = Buffer.from('{}')
+    const timestamp = String(Date.now() - 10 * 60 * 1000)
+    const signature = crypto
+      .createHmac('sha512', secret)
+      .update(timestampedWebhookPayload(timestamp, payload))
+      .digest('hex')
+    const next = vi.fn()
+
+    verifyPaystackSignature(
+      mockReq({
+        headers: { 'x-paystack-signature': signature, 'x-webhook-timestamp': timestamp },
+        rawBody: payload,
+      }),
+      mockRes(),
+      next,
+    )
+
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ status: 401 }))
+  })
+
+  it('uses timingSafeEqual even when signature lengths differ', () => {
+    const timingSafeEqual = vi.spyOn(crypto, 'timingSafeEqual')
+    expect(constantTimeEqual('short', 'a much longer expected value')).toBe(false)
+    expect(timingSafeEqual).toHaveBeenCalledOnce()
+    expect(timingSafeEqual.mock.calls[0][0].length).toBe(
+      timingSafeEqual.mock.calls[0][1].length,
+    )
+    timingSafeEqual.mockRestore()
   })
 
   it('returns 200 for duplicate event id without re-processing', () => {

--- a/backend/src/middleware/webhookSignature.ts
+++ b/backend/src/middleware/webhookSignature.ts
@@ -4,6 +4,12 @@ import { LRUCache } from 'lru-cache'
 import { AppError } from '../errors/AppError.js'
 import { ErrorCode } from '../errors/errorCodes.js'
 import { logger } from '../utils/logger.js'
+import {
+  assertFreshWebhookTimestamp,
+  constantTimeEqual,
+  getSignedWebhookTimestamp,
+  timestampedWebhookPayload,
+} from '../payments/webhookSecurity.js'
 
 declare global {
   namespace Express {
@@ -61,13 +67,15 @@ export function verifyPaystackSignature(
       throw new AppError(ErrorCode.UNAUTHORIZED, 401, 'Missing x-paystack-signature header')
     }
 
+    const timestamp = getSignedWebhookTimestamp(req)
+    assertFreshWebhookTimestamp(timestamp)
     const rawBody = getRawBodyBuffer(req)
-    const expected = crypto.createHmac('sha512', secret).update(rawBody).digest('hex')
+    const expected = crypto
+      .createHmac('sha512', secret)
+      .update(timestampedWebhookPayload(timestamp, rawBody))
+      .digest('hex')
 
-    if (
-      signature.length !== expected.length ||
-      !crypto.timingSafeEqual(Buffer.from(signature, 'hex'), Buffer.from(expected, 'hex'))
-    ) {
+    if (!constantTimeEqual(signature, expected, 'hex')) {
       throw new AppError(ErrorCode.UNAUTHORIZED, 401, 'Invalid Paystack signature')
     }
 
@@ -91,14 +99,18 @@ export function verifyFlutterwaveSignature(
       return next()
     }
 
-    const verifHash = req.headers['verif-hash'] as string | undefined
-    if (!verifHash) {
+    const signature = req.headers['verif-hash'] as string | undefined
+    if (!signature) {
       throw new AppError(ErrorCode.UNAUTHORIZED, 401, 'Missing verif-hash header')
     }
 
-    const a = Buffer.from(verifHash, 'utf8')
-    const b = Buffer.from(secretHash, 'utf8')
-    if (a.length !== b.length || !crypto.timingSafeEqual(a, b)) {
+    const timestamp = getSignedWebhookTimestamp(req)
+    assertFreshWebhookTimestamp(timestamp)
+    const expected = crypto
+      .createHmac('sha256', secretHash)
+      .update(timestampedWebhookPayload(timestamp, getRawBodyBuffer(req)))
+      .digest('hex')
+    if (!constantTimeEqual(signature, expected, 'hex')) {
       throw new AppError(ErrorCode.UNAUTHORIZED, 401, 'Invalid Flutterwave signature')
     }
 

--- a/backend/src/models/depositStore.ts
+++ b/backend/src/models/depositStore.ts
@@ -6,6 +6,7 @@ import {
   type DepositRecord,
   type ConfirmDepositRecordInput,
 } from './deposit.js'
+import { canAdvancePaymentStatus } from '../payments/paymentState.js'
 
 class DepositStore {
   // Initiation (pending deposits tracked by external refs)
@@ -96,7 +97,7 @@ class DepositStore {
   async confirmByCanonical(rail: string, externalRef: string): Promise<Deposit | null> {
     const deposit = await this.getByCanonical(rail, externalRef)
     if (!deposit) return null
-    if (deposit.status === DepositStatus.CONFIRMED) return deposit
+    if (!canAdvancePaymentStatus(deposit.status, DepositStatus.CONFIRMED)) return null
     deposit.status = DepositStatus.CONFIRMED
     deposit.confirmedAt = new Date()
     deposit.updatedAt = new Date()
@@ -107,6 +108,7 @@ class DepositStore {
   async fail(depositId: string): Promise<Deposit | null> {
     const deposit = this.initiationsById.get(depositId)
     if (!deposit) return null
+    if (!canAdvancePaymentStatus(deposit.status, DepositStatus.FAILED)) return null
     deposit.status = DepositStatus.FAILED
     deposit.updatedAt = new Date()
     this.initiationsById.set(depositId, deposit)
@@ -116,7 +118,7 @@ class DepositStore {
   async reverseByCanonical(rail: string, externalRef: string): Promise<Deposit | null> {
     const deposit = await this.getByCanonical(rail, externalRef)
     if (!deposit) return null
-    if (deposit.status === DepositStatus.REVERSED) return deposit
+    if (!canAdvancePaymentStatus(deposit.status, DepositStatus.REVERSED)) return null
     deposit.status = DepositStatus.REVERSED
     deposit.updatedAt = new Date()
     this.initiationsById.set(deposit.depositId, deposit)

--- a/backend/src/models/ngnDepositStore.ts
+++ b/backend/src/models/ngnDepositStore.ts
@@ -6,6 +6,7 @@ import type {
   NgnDeposit,
   NgnDepositStatus,
 } from './ngnDeposit.js'
+import { canAdvancePaymentStatus } from '../payments/paymentState.js'
 
 function mapRow(row: any): NgnDeposit {
   return {
@@ -198,14 +199,29 @@ class NgnDepositStore {
     if (!pool) {
       const existing = this.byId.get(depositId)
       if (!existing) return null
-      if (existing.status === status) return existing
+      if (!canAdvancePaymentStatus(existing.status, status)) return null
       const updated: NgnDeposit = { ...existing, status, updatedAt: new Date() }
       this.byId.set(depositId, updated)
       return updated
     }
 
     const { rows } = await pool.query(
-      `UPDATE ngn_deposits SET status=$2, updated_at=NOW() WHERE deposit_id=$1 RETURNING *`,
+      `UPDATE ngn_deposits
+       SET status=$2, updated_at=NOW()
+       WHERE deposit_id=$1
+         AND CASE status
+           WHEN 'pending' THEN 0
+           WHEN 'failed' THEN 1
+           WHEN 'confirmed' THEN 2
+           WHEN 'reversed' THEN 3
+         END
+         < CASE $2
+           WHEN 'pending' THEN 0
+           WHEN 'failed' THEN 1
+           WHEN 'confirmed' THEN 2
+           WHEN 'reversed' THEN 3
+         END
+       RETURNING *`,
       [depositId, status],
     )
     const row = rows[0]

--- a/backend/src/payments/flutterwaveProvider.test.ts
+++ b/backend/src/payments/flutterwaveProvider.test.ts
@@ -35,8 +35,21 @@ function makeReq(
   } as any
 }
 
-function flwHmac(secret: string, payload: string): string {
-  return crypto.createHmac('sha256', secret).update(payload, 'utf8').digest('hex')
+function signedFlutterwaveReq(secret: string, body: unknown) {
+  const rawBody = JSON.stringify(body)
+  const timestamp = String(Date.now())
+  const signature = crypto
+    .createHmac('sha256', secret)
+    .update(`${timestamp}.${rawBody}`, 'utf8')
+    .digest('hex')
+  return makeReq(
+    {
+      'verif-hash': signature,
+      'x-webhook-timestamp': timestamp,
+    },
+    body,
+    rawBody,
+  )
 }
 
 // ---------------------------------------------------------------------------
@@ -240,10 +253,7 @@ describe('FlutterwaveProvider', () => {
         event: 'charge.completed',
         data: { tx_ref: 'flw-ref-002', status: 'successful' },
       }
-      const rawBody = JSON.stringify(body)
-      const sig = flwHmac('flw_webhook_secret', rawBody)
-
-      const req = makeReq({ 'verif-hash': sig }, body, rawBody)
+      const req = signedFlutterwaveReq('flw_webhook_secret', body)
       const result = await provider.parseAndValidateWebhook(req)
 
       expect(result.externalRefSource).toBe('flutterwave')
@@ -257,10 +267,7 @@ describe('FlutterwaveProvider', () => {
         event: 'transfer.reversed',
         data: { tx_ref: 'flw-ref-003', status: 'reversed' },
       }
-      const rawBody = JSON.stringify(body)
-      const sig = flwHmac('flw_webhook_secret', rawBody)
-
-      const req = makeReq({ 'verif-hash': sig }, body, rawBody)
+      const req = signedFlutterwaveReq('flw_webhook_secret', body)
       const result = await provider.parseAndValidateWebhook(req)
 
       expect(result.rawStatus).toBe('transfer.reversed')
@@ -277,9 +284,7 @@ describe('FlutterwaveProvider', () => {
 
     it('throws 400 when event field is missing', async () => {
       const body = { data: { tx_ref: 'r' } }
-      const rawBody = JSON.stringify(body)
-      const sig = flwHmac('flw_webhook_secret', rawBody)
-      const req = makeReq({ 'verif-hash': sig }, body, rawBody)
+      const req = signedFlutterwaveReq('flw_webhook_secret', body)
 
       await expect(provider.parseAndValidateWebhook(req)).rejects.toMatchObject({
         status: 400,
@@ -288,9 +293,7 @@ describe('FlutterwaveProvider', () => {
 
     it('throws 400 when tx_ref is missing', async () => {
       const body = { event: 'charge.completed', data: {} }
-      const rawBody = JSON.stringify(body)
-      const sig = flwHmac('flw_webhook_secret', rawBody)
-      const req = makeReq({ 'verif-hash': sig }, body, rawBody)
+      const req = signedFlutterwaveReq('flw_webhook_secret', body)
 
       await expect(provider.parseAndValidateWebhook(req)).rejects.toMatchObject({
         status: 400,

--- a/backend/src/payments/paymentState.test.ts
+++ b/backend/src/payments/paymentState.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { monotonicPaymentStatus } from './paymentState.js'
+
+describe('monotonicPaymentStatus', () => {
+  it('keeps reversal terminal when stale events arrive later', () => {
+    expect(monotonicPaymentStatus('reversed', 'pending')).toBe('reversed')
+    expect(monotonicPaymentStatus('reversed', 'confirmed')).toBe('reversed')
+    expect(monotonicPaymentStatus('reversed', 'failed')).toBe('reversed')
+  })
+
+  it('does not let stale pending or failed events overwrite confirmation', () => {
+    expect(monotonicPaymentStatus('confirmed', 'pending')).toBe('confirmed')
+    expect(monotonicPaymentStatus('confirmed', 'failed')).toBe('confirmed')
+  })
+
+  it('converges to reversal regardless of arrival order', () => {
+    const events = ['pending', 'confirmed', 'reversed'] as const
+    const forward = events.reduce(monotonicPaymentStatus)
+    const reverse = [...events].reverse().reduce(monotonicPaymentStatus)
+    expect(forward).toBe('reversed')
+    expect(reverse).toBe('reversed')
+  })
+})

--- a/backend/src/payments/paymentState.ts
+++ b/backend/src/payments/paymentState.ts
@@ -1,0 +1,30 @@
+import type { InternalPaymentStatus } from './types.js'
+
+const STATUS_PRECEDENCE: Record<InternalPaymentStatus, number> = {
+  pending: 0,
+  failed: 1,
+  confirmed: 2,
+  reversed: 3,
+}
+
+/**
+ * Payment state is a join-semilattice: applying the same set of events in any
+ * order converges on the highest-precedence state. In particular, reversal is
+ * terminal and stale pending/failed events cannot overwrite confirmation.
+ */
+export function monotonicPaymentStatus(
+  current: InternalPaymentStatus,
+  incoming: InternalPaymentStatus,
+): InternalPaymentStatus {
+  return STATUS_PRECEDENCE[incoming] > STATUS_PRECEDENCE[current]
+    ? incoming
+    : current
+}
+
+export function canAdvancePaymentStatus(
+  current: InternalPaymentStatus,
+  incoming: InternalPaymentStatus,
+): boolean {
+  return monotonicPaymentStatus(current, incoming) !== current
+}
+

--- a/backend/src/payments/paystackProvider.test.ts
+++ b/backend/src/payments/paystackProvider.test.ts
@@ -35,8 +35,21 @@ function makeReq(
   } as any
 }
 
-function paystackHmac(secret: string, payload: string): string {
-  return crypto.createHmac('sha512', secret).update(payload, 'utf8').digest('hex')
+function signedPaystackReq(secret: string, body: unknown) {
+  const rawBody = JSON.stringify(body)
+  const timestamp = String(Date.now())
+  const signature = crypto
+    .createHmac('sha512', secret)
+    .update(`${timestamp}.${rawBody}`, 'utf8')
+    .digest('hex')
+  return makeReq(
+    {
+      'x-paystack-signature': signature,
+      'x-webhook-timestamp': timestamp,
+    },
+    body,
+    rawBody,
+  )
 }
 
 // ---------------------------------------------------------------------------
@@ -247,10 +260,7 @@ describe('PaystackProvider', () => {
         event: 'charge.success',
         data: { reference: 'ref-pay-001', status: 'success' },
       }
-      const rawBody = JSON.stringify(body)
-      const sig = paystackHmac('webhook_secret', rawBody)
-
-      const req = makeReq({ 'x-paystack-signature': sig }, body, rawBody)
+      const req = signedPaystackReq('webhook_secret', body)
 
       const result = await provider.parseAndValidateWebhook(req)
 
@@ -267,9 +277,7 @@ describe('PaystackProvider', () => {
         event: 'charge.success',
         data: { reference: 'ref-pay-ida', status: 'success' },
       }
-      const rawBody = JSON.stringify(body)
-      const sig = paystackHmac('webhook_secret', rawBody)
-      const req = makeReq({ 'x-paystack-signature': sig }, body, rawBody)
+      const req = signedPaystackReq('webhook_secret', body)
       const result = await provider.parseAndValidateWebhook(req)
       expect(result.providerEventId).toBe('99000000')
     })
@@ -279,10 +287,7 @@ describe('PaystackProvider', () => {
         event: 'charge.failed',
         data: { reference: 'ref-pay-002', status: 'failed' },
       }
-      const rawBody = JSON.stringify(body)
-      const sig = paystackHmac('webhook_secret', rawBody)
-
-      const req = makeReq({ 'x-paystack-signature': sig }, body, rawBody)
+      const req = signedPaystackReq('webhook_secret', body)
       const result = await provider.parseAndValidateWebhook(req)
 
       expect(result.rawStatus).toBe('charge.failed')
@@ -299,9 +304,7 @@ describe('PaystackProvider', () => {
 
     it('throws 400 when event field is missing', async () => {
       const body = { data: { reference: 'r' } }
-      const rawBody = JSON.stringify(body)
-      const sig = paystackHmac('webhook_secret', rawBody)
-      const req = makeReq({ 'x-paystack-signature': sig }, body, rawBody)
+      const req = signedPaystackReq('webhook_secret', body)
 
       await expect(provider.parseAndValidateWebhook(req)).rejects.toMatchObject({
         status: 400,
@@ -310,9 +313,7 @@ describe('PaystackProvider', () => {
 
     it('throws 400 when reference field is missing', async () => {
       const body = { event: 'charge.success', data: {} }
-      const rawBody = JSON.stringify(body)
-      const sig = paystackHmac('webhook_secret', rawBody)
-      const req = makeReq({ 'x-paystack-signature': sig }, body, rawBody)
+      const req = signedPaystackReq('webhook_secret', body)
 
       await expect(provider.parseAndValidateWebhook(req)).rejects.toMatchObject({
         status: 400,

--- a/backend/src/payments/webhookSecurity.ts
+++ b/backend/src/payments/webhookSecurity.ts
@@ -1,0 +1,89 @@
+import crypto from 'node:crypto'
+import type { Request } from 'express'
+import { AppError } from '../errors/AppError.js'
+import { ErrorCode } from '../errors/errorCodes.js'
+
+export const DEFAULT_WEBHOOK_FRESHNESS_SECONDS = 5 * 60
+
+export function getWebhookFreshnessSeconds(): number {
+  const configured = Number(process.env.WEBHOOK_TIMESTAMP_TOLERANCE_SECONDS)
+  return Number.isFinite(configured) && configured > 0
+    ? configured
+    : DEFAULT_WEBHOOK_FRESHNESS_SECONDS
+}
+
+export function getSignedWebhookTimestamp(req: Request): string {
+  const header = req.headers['x-webhook-timestamp']
+  const timestamp = Array.isArray(header) ? header[0] : header
+  if (!timestamp) {
+    throw new AppError(
+      ErrorCode.UNAUTHORIZED,
+      401,
+      'Missing x-webhook-timestamp header',
+    )
+  }
+  return timestamp
+}
+
+export function assertFreshWebhookTimestamp(
+  timestamp: string,
+  nowMs = Date.now(),
+  toleranceSeconds = getWebhookFreshnessSeconds(),
+): void {
+  const numericTimestamp = Number(timestamp)
+  const timestampMs = Number.isFinite(numericTimestamp)
+    ? numericTimestamp < 10_000_000_000
+      ? numericTimestamp * 1000
+      : numericTimestamp
+    : Date.parse(timestamp)
+
+  if (
+    !Number.isFinite(timestampMs) ||
+    Math.abs(nowMs - timestampMs) > toleranceSeconds * 1000
+  ) {
+    throw new AppError(
+      ErrorCode.UNAUTHORIZED,
+      401,
+      `Webhook timestamp is outside the ${toleranceSeconds}-second freshness window`,
+    )
+  }
+}
+
+export function timestampedWebhookPayload(
+  timestamp: string,
+  rawBody: string | Buffer,
+): Buffer {
+  return Buffer.concat([
+    Buffer.from(timestamp, 'utf8'),
+    Buffer.from('.', 'utf8'),
+    Buffer.isBuffer(rawBody) ? rawBody : Buffer.from(rawBody, 'utf8'),
+  ])
+}
+
+/**
+ * Compares a supplied value with an expected value while always invoking
+ * timingSafeEqual on equal-length buffers, including malformed/short input.
+ */
+export function constantTimeEqual(
+  supplied: string,
+  expected: string,
+  encoding: BufferEncoding = 'utf8',
+): boolean {
+  const expectedBuffer = Buffer.from(expected, encoding)
+  let suppliedBuffer: Buffer
+  let validEncoding = true
+
+  if (encoding === 'hex' && !/^(?:[0-9a-fA-F]{2})+$/.test(supplied)) {
+    suppliedBuffer = Buffer.alloc(0)
+    validEncoding = false
+  } else {
+    suppliedBuffer = Buffer.from(supplied, encoding)
+  }
+
+  const normalized = Buffer.alloc(expectedBuffer.length)
+  suppliedBuffer.copy(normalized, 0, 0, expectedBuffer.length)
+  const equal = crypto.timingSafeEqual(normalized, expectedBuffer)
+
+  return validEncoding && suppliedBuffer.length === expectedBuffer.length && equal
+}
+

--- a/backend/src/payments/webhookSignature.test.ts
+++ b/backend/src/payments/webhookSignature.test.ts
@@ -278,18 +278,23 @@ describe('webhookSignature', () => {
     })
 
     it('returns secret as-is for manual_admin', () => {
-      expect(generateTestSignature('manual_admin', payload, secret)).toBe(secret)
+      const crypto = require('node:crypto')
+      const expected = crypto.createHmac('sha256', secret).update(payload, 'utf8').digest('hex')
+      expect(generateTestSignature('manual_admin', payload, secret)).toBe(expected)
     })
 
-    it('returns secret as-is for psp (legacy)', () => {
-      expect(generateTestSignature('psp', payload, secret)).toBe(secret)
+    it('generates HMAC-SHA256 for psp (legacy)', () => {
+      const crypto = require('node:crypto')
+      const expected = crypto.createHmac('sha256', secret).update(payload, 'utf8').digest('hex')
+      expect(generateTestSignature('psp', payload, secret)).toBe(expected)
     })
   })
 
   describe('requireValidWebhookSignature', () => {
     const createMockRequest = (headers: Record<string, string>, body?: unknown) => {
+      const timestamp = String(Date.now())
       return {
-        headers,
+        headers: { 'x-webhook-timestamp': timestamp, ...headers },
         body,
         rawBody: body ? JSON.stringify(body) : undefined,
       } as any
@@ -366,11 +371,15 @@ describe('webhookSignature', () => {
       const crypto = require('node:crypto')
       const secret = 'paystack_secret'
       const payload = '{"event":"charge.success"}'
-      const validSignature = crypto.createHmac('sha512', secret).update(payload, 'utf8').digest('hex')
+      const timestamp = String(Date.now())
+      const validSignature = crypto
+        .createHmac('sha512', secret)
+        .update(`${timestamp}.${payload}`, 'utf8')
+        .digest('hex')
 
       process.env.PAYSTACK_SECRET = secret
       const req = createMockRequest(
-        { 'x-paystack-signature': validSignature },
+        { 'x-paystack-signature': validSignature, 'x-webhook-timestamp': timestamp },
         { event: 'charge.success' }
       )
 
@@ -382,11 +391,15 @@ describe('webhookSignature', () => {
       const crypto = require('node:crypto')
       const secret = 'flutterwave_secret'
       const payload = '{"event":"charge.completed"}'
-      const validSignature = crypto.createHmac('sha256', secret).update(payload, 'utf8').digest('hex')
+      const timestamp = String(Date.now())
+      const validSignature = crypto
+        .createHmac('sha256', secret)
+        .update(`${timestamp}.${payload}`, 'utf8')
+        .digest('hex')
 
       process.env.FLUTTERWAVE_SECRET = secret
       const req = createMockRequest(
-        { 'verif-hash': validSignature },
+        { 'verif-hash': validSignature, 'x-webhook-timestamp': timestamp },
         { event: 'charge.completed' }
       )
 

--- a/backend/src/payments/webhookSignature.ts
+++ b/backend/src/payments/webhookSignature.ts
@@ -3,6 +3,12 @@ import type { Request } from 'express'
 import { AppError } from '../errors/AppError.js'
 import { ErrorCode } from '../errors/errorCodes.js'
 import { getValidSecretVersions } from '../services/rotatingSecretProvider.js'
+import {
+  assertFreshWebhookTimestamp,
+  constantTimeEqual,
+  getSignedWebhookTimestamp,
+  timestampedWebhookPayload,
+} from './webhookSecurity.js'
 
 // Extend Express Request to support rawBody middleware
 declare global {
@@ -125,19 +131,8 @@ export function verifyPaystackSignature(
 
     // Use timing-safe comparison to prevent timing attacks
     // Handle length mismatch gracefully
-    if (signature.length === expectedSignature.length) {
-      try {
-        const isValid = crypto.timingSafeEqual(
-          Buffer.from(signature, 'hex'),
-          Buffer.from(expectedSignature, 'hex')
-        )
-
-        if (isValid) {
-          return { valid: true }
-        }
-      } catch {
-        // Continue to next secret version
-      }
+    if (constantTimeEqual(signature, expectedSignature, 'hex')) {
+      return { valid: true }
     }
   }
 
@@ -174,17 +169,8 @@ export function verifyFlutterwaveSignature(
       .digest('hex')
 
     // Use timing-safe comparison
-    try {
-      const isValid = crypto.timingSafeEqual(
-        Buffer.from(signature, 'hex'),
-        Buffer.from(expectedSignature, 'hex')
-      )
-
-      if (isValid) {
-        return { valid: true }
-      }
-    } catch {
-      // Continue to next secret version
+    if (constantTimeEqual(signature, expectedSignature, 'hex')) {
+      return { valid: true }
     }
   }
 
@@ -211,17 +197,8 @@ export function verifyManualAdminSignature(
 
   // Try each valid secret version
   for (const secret of secrets) {
-    try {
-      const isValid = crypto.timingSafeEqual(
-        Buffer.from(signature, 'utf8'),
-        Buffer.from(secret, 'utf8')
-      )
-
-      if (isValid) {
-        return { valid: true }
-      }
-    } catch {
-      // Continue to next secret version
+    if (constantTimeEqual(signature, secret)) {
+      return { valid: true }
     }
   }
 
@@ -260,7 +237,7 @@ export function verifyLegacySignature(
 
   // Try each valid secret version
   for (const secret of secrets) {
-    if (signature === secret) {
+    if (constantTimeEqual(signature, secret)) {
       return { valid: true }
     }
   }
@@ -316,26 +293,29 @@ export function requireValidWebhookSignature(req: Request, rail: PaymentRail): v
     return
   }
 
+  const timestamp = getSignedWebhookTimestamp(req)
+  assertFreshWebhookTimestamp(timestamp)
+  const timestampedPayload = timestampedWebhookPayload(timestamp, getRawBody(req)).toString('utf8')
+
   let result: WebhookValidationResult
 
   switch (rail) {
     case 'paystack': {
       const signature = req.headers['x-paystack-signature'] as string
-      const rawBody = getRawBody(req)
-      result = verifyPaystackSignature(rawBody, signature, secrets)
+      result = verifyPaystackSignature(timestampedPayload, signature, secrets)
       break
     }
 
     case 'flutterwave': {
       const signature = req.headers['verif-hash'] as string
-      const rawBody = getRawBody(req)
-      result = verifyFlutterwaveSignature(rawBody, signature, secrets)
+      result = verifyFlutterwaveSignature(timestampedPayload, signature, secrets)
       break
     }
 
     case 'manual_admin': {
       const signature = req.headers['x-admin-signature'] as string
-      result = verifyManualAdminSignature(signature, secrets)
+      result = verifyFlutterwaveSignature(timestampedPayload, signature, secrets)
+      if (!result.valid) result.error = 'Invalid admin signature'
       break
     }
 
@@ -343,7 +323,8 @@ export function requireValidWebhookSignature(req: Request, rail: PaymentRail): v
     default: {
       // Legacy fallback
       const signature = req.headers['x-webhook-signature'] as string
-      result = verifyLegacySignature(signature, secrets)
+      result = verifyFlutterwaveSignature(timestampedPayload, signature, secrets)
+      if (!result.valid) result.error = 'Invalid webhook signature'
       break
     }
   }
@@ -359,20 +340,24 @@ export function requireValidWebhookSignature(req: Request, rail: PaymentRail): v
 export function generateTestSignature(
   rail: PaymentRail,
   payload: string,
-  secret: string
+  secret: string,
+  timestamp?: string,
 ): string {
+  const signedPayload = timestamp
+    ? timestampedWebhookPayload(timestamp, payload)
+    : Buffer.from(payload, 'utf8')
   switch (rail) {
     case 'paystack':
-      return crypto.createHmac('sha512', secret).update(payload, 'utf8').digest('hex')
+      return crypto.createHmac('sha512', secret).update(signedPayload).digest('hex')
 
     case 'flutterwave':
-      return crypto.createHmac('sha256', secret).update(payload, 'utf8').digest('hex')
+      return crypto.createHmac('sha256', secret).update(signedPayload).digest('hex')
 
     case 'manual_admin':
-      return secret
+      return crypto.createHmac('sha256', secret).update(signedPayload).digest('hex')
 
     case 'psp':
     default:
-      return secret
+      return crypto.createHmac('sha256', secret).update(signedPayload).digest('hex')
   }
 }

--- a/backend/src/routes/webhooks.reversal.test.ts
+++ b/backend/src/routes/webhooks.reversal.test.ts
@@ -6,6 +6,7 @@ import { NgnWalletService } from '../services/ngnWalletService.js'
 import { depositStore } from '../models/depositStore.js'
 import { userRiskStateStore } from '../models/userRiskStateStore.js'
 import { errorHandler } from '../middleware/errorHandler.js'
+import { webhookEventDedupeStore } from '../models/webhookEventDedupeStore.js'
 
 describe('Webhooks - Deposit Reversal', () => {
   let app: Express
@@ -16,6 +17,7 @@ describe('Webhooks - Deposit Reversal', () => {
   beforeEach(async () => {
     ngnWalletService = new NgnWalletService()
     await depositStore.clear()
+    webhookEventDedupeStore.clear()
     userRiskStateStore.clear()
 
     // Setup Express app
@@ -88,36 +90,25 @@ describe('Webhooks - Deposit Reversal', () => {
 
       const balanceBeforeFirst = await ngnWalletService.getBalance(testUserId)
 
-      // Act: Send reversal webhook twice
-      await request(app)
-        .post('/api/webhooks/reversals/onramp')
-        .send({
+      // Act: Send the same reversal concurrently
+      const payload = {
           provider: 'onramp',
           providerRef: 'ONRAMP-WEBHOOK-REF-2',
           reversalRef: 'REVERSAL-WEBHOOK-2',
           eventType: 'deposit.reversed',
           timestamp: new Date().toISOString(),
-        })
-        .expect(200)
-
-      const balanceAfterFirst = await ngnWalletService.getBalance(testUserId)
-
-      await request(app)
-        .post('/api/webhooks/reversals/onramp')
-        .send({
-          provider: 'onramp',
-          providerRef: 'ONRAMP-WEBHOOK-REF-2',
-          reversalRef: 'REVERSAL-WEBHOOK-2',
-          eventType: 'deposit.reversed',
-          timestamp: new Date().toISOString(),
-        })
-        .expect(200)
+      }
+      const responses = await Promise.all([
+        request(app).post('/api/webhooks/reversals/onramp').send(payload),
+        request(app).post('/api/webhooks/reversals/onramp').send(payload),
+      ])
+      expect(responses.every((response) => response.status === 200)).toBe(true)
+      expect(responses.filter((response) => response.body.deduped)).toHaveLength(1)
 
       const balanceAfterSecond = await ngnWalletService.getBalance(testUserId)
 
       // Assert: Balance should only be debited once
-      expect(balanceAfterFirst.totalNgn).toBe(balanceBeforeFirst.totalNgn - 10000)
-      expect(balanceAfterSecond.totalNgn).toBe(balanceAfterFirst.totalNgn)
+      expect(balanceAfterSecond.totalNgn).toBe(balanceBeforeFirst.totalNgn - 10000)
     })
 
     it('should return 200 even if deposit not found (prevent webhook retries)', async () => {
@@ -186,16 +177,24 @@ describe('Webhooks - Deposit Reversal', () => {
         providerRef: 'TEST-REF-SIG',
       })
 
+      const body = {
+        provider: 'onramp',
+        providerRef: 'TEST-REF-SIG',
+        reversalRef: 'REVERSAL-WEBHOOK-7',
+        eventType: 'deposit.reversed',
+        timestamp: new Date().toISOString(),
+      }
+      const signedTimestamp = String(Date.now())
+      const signature = (await import('node:crypto'))
+        .createHmac('sha256', 'test-secret-key')
+        .update(`${signedTimestamp}.${JSON.stringify(body)}`)
+        .digest('hex')
+
       await request(app)
         .post('/api/webhooks/reversals/onramp')
-        .set('x-webhook-signature', 'test-secret-key')
-        .send({
-          provider: 'onramp',
-          providerRef: 'TEST-REF-SIG',
-          reversalRef: 'REVERSAL-WEBHOOK-7',
-          eventType: 'deposit.reversed',
-          timestamp: new Date().toISOString(),
-        })
+        .set('x-webhook-signature', signature)
+        .set('x-webhook-timestamp', signedTimestamp)
+        .send(body)
         .expect(200)
 
       process.env.WEBHOOK_SIGNATURE_ENABLED = 'false'

--- a/backend/src/routes/webhooks.test.ts
+++ b/backend/src/routes/webhooks.test.ts
@@ -44,7 +44,6 @@ describe('Payments webhook', () => {
       .set('x-user-id', 'user-001')
       .send({ quoteId: quote.quoteId, paymentRail: 'paystack' })
       .expect(201)
-
     const { depositId, externalRef } = init.body
 
     const payload = {
@@ -101,6 +100,7 @@ describe('Payments webhook', () => {
     await request(app)
       .post('/api/webhooks/payments/paystack')
       .set('x-paystack-signature', 'wrong')
+      .set('x-webhook-timestamp', String(Date.now()))
       .send(payload)
       .expect(401)
   })
@@ -136,16 +136,101 @@ describe('Payments webhook', () => {
 
     // Generate valid HMAC-SHA512 signature
     const rawBody = JSON.stringify(payload)
+    const timestamp = String(Date.now())
     const validSignature = crypto
       .createHmac('sha512', secret)
-      .update(rawBody, 'utf8')
+      .update(`${timestamp}.${rawBody}`, 'utf8')
       .digest('hex')
 
     await request(app)
       .post('/api/webhooks/payments/paystack')
       .set('x-paystack-signature', validSignature)
+      .set('x-webhook-timestamp', timestamp)
       .send(payload)
       .expect(200)
+  })
+
+  it('applies concurrent deliveries of one provider event exactly once', async () => {
+    const quote = await quoteStore.create({
+      userId: 'user-concurrent',
+      amountNgn: 64000,
+      paymentRail: 'paystack',
+      fxRateNgnPerUsdc: 1600,
+      feePercent: 0,
+      slippagePercent: 0,
+      expiryMs: 3600000,
+    })
+    const init = await request(app)
+      .post('/api/staking/deposit/initiate')
+      .set('x-user-id', 'user-concurrent')
+      .send({ quoteId: quote.quoteId, paymentRail: 'paystack' })
+      .expect(201)
+
+    const payload = {
+      externalRefSource: 'paystack',
+      externalRef: init.body.externalRef,
+      status: 'confirmed',
+      providerEventId: 'evt-concurrent-1',
+    }
+    const responses = await Promise.all(
+      Array.from({ length: 8 }, () =>
+        request(app).post('/api/webhooks/payments/paystack').send(payload),
+      ),
+    )
+
+    expect(responses.every((response) => response.status === 200)).toBe(true)
+    expect(responses.filter((response) => response.body.deduped).length).toBe(7)
+    const stakeItems = (await outboxStore.listAll(20)).filter(
+      (item) => item.txType === TxType.STAKE,
+    )
+    expect(stakeItems).toHaveLength(1)
+  })
+
+  it('keeps reversal terminal when capture arrives afterward', async () => {
+    const userId = 'user-reversal-first'
+    const quote = await quoteStore.create({
+      userId,
+      amountNgn: 45000,
+      paymentRail: 'paystack',
+      fxRateNgnPerUsdc: 1600,
+      feePercent: 0,
+      slippagePercent: 0,
+      expiryMs: 3600000,
+    })
+    const init = await request(app)
+      .post('/api/staking/deposit/initiate')
+      .set('x-user-id', userId)
+      .send({ quoteId: quote.quoteId, paymentRail: 'paystack' })
+      .expect(201)
+    const walletService = new NgnWalletService()
+    const balanceBefore = await walletService.getBalance(userId)
+
+    await request(app)
+      .post('/api/webhooks/payments/paystack')
+      .send({
+        externalRefSource: 'paystack',
+        externalRef: init.body.externalRef,
+        status: 'reversed',
+        providerEventId: 'evt-reversal-first',
+      })
+      .expect(200)
+
+    await request(app)
+      .post('/api/webhooks/payments/paystack')
+      .send({
+        externalRefSource: 'paystack',
+        externalRef: init.body.externalRef,
+        status: 'confirmed',
+        providerEventId: 'evt-capture-late',
+      })
+      .expect(200)
+
+    const deposit = await depositStore.getByCanonical('paystack', init.body.externalRef)
+    expect(deposit?.status).toBe('reversed')
+    expect((await walletService.getBalance(userId)).totalNgn).toBe(balanceBefore.totalNgn)
+    expect(
+      (await outboxStore.listAll(20)).filter((item) => item.txType === TxType.STAKE),
+    ).toHaveLength(0)
   })
 
   it('credits NGN wallet on confirmation', async () => {

--- a/backend/src/routes/webhooks.ts
+++ b/backend/src/routes/webhooks.ts
@@ -23,7 +23,6 @@ import { requireValidWebhookSignature } from "../payments/webhookSignature.js";
 import {
   verifyPaystackSignature,
   verifyFlutterwaveSignature,
-  preventWebhookReplay,
 } from "../middleware/webhookSignature.js";
 import { jsonPayloadSha256Hex, sha256Hex, generateRandomSecretHex } from "../utils/sha256.js";
 import { z } from "zod";
@@ -62,19 +61,8 @@ export function createWebhooksRouter(ngnWalletService: NgnWalletService) {
       next()
     },
     validate(paymentsWebhookSchema),
-    (req: Request, res: Response, next: NextFunction) => {
-      const rail = String(req.params.rail)
-      if (rail === 'paystack' || rail === 'flutterwave') {
-        return preventWebhookReplay(rail)(req, res, next)
-      }
-      next()
-    },
     async (req: Request, res: Response, next: NextFunction) => {
       try {
-        if (req.webhookReplaySkipped) {
-          return
-        }
-
         const rail = String(req.params.rail);
 
         const provider = getPaymentProvider(rail);
@@ -151,6 +139,9 @@ export function createWebhooksRouter(ngnWalletService: NgnWalletService) {
 
         // Handle reversed/chargeback status
         if (internalStatus === "reversed") {
+          const wasCredited =
+            existingStakingDeposit?.status === "confirmed" ||
+            existingWalletDeposit?.status === "confirmed";
           const reversed = existingStakingDeposit
             ? await depositStore.reverseByCanonical(rail, externalRef)
             : await ngnDepositStore.setStatusByCanonical(
@@ -159,7 +150,7 @@ export function createWebhooksRouter(ngnWalletService: NgnWalletService) {
                 "reversed",
               );
 
-          if (reversed) {
+          if (reversed && wasCredited) {
             // Debit wallet balance (idempotent - won't double-debit)
             const result = await ngnWalletService.reverseTopUp(
               userId,
@@ -339,6 +330,20 @@ export function createWebhooksRouter(ngnWalletService: NgnWalletService) {
             400,
             "Invalid event type",
           );
+        }
+
+        const claim = await webhookEventDedupeStore.tryClaim({
+          rail: provider,
+          providerEventId: reversalRef,
+          payloadHash: jsonPayloadSha256Hex(req.body),
+        });
+        if (claim === "duplicate") {
+          recordKPI("webhookEventDeduped");
+          return res.status(200).json({
+            success: true,
+            deduped: true,
+            providerEventId: reversalRef,
+          });
         }
 
         logger.info("Processing deposit reversal webhook", {
@@ -546,4 +551,3 @@ export function createWebhooksRouter(ngnWalletService: NgnWalletService) {
 
   return router;
 }
-

--- a/backend/src/schemas/deposit.ts
+++ b/backend/src/schemas/deposit.ts
@@ -18,6 +18,8 @@ export const paymentsWebhookSchema = z.object({
   externalRef: z.string().min(1),
   status: z.enum(['confirmed', 'failed', 'reversed']).default('confirmed'),
   providerStatus: z.string().optional().describe('Provider-specific status code for mapping'),
+  providerEventId: z.string().min(1).optional(),
+  timestamp: z.string().optional(),
 })
 
 export type PaymentsWebhookRequest = z.infer<typeof paymentsWebhookSchema>


### PR DESCRIPTION
## Summary
- bind inbound webhook signatures to a signed timestamp and enforce a configurable 5-minute freshness window
- compare signatures in constant time even for malformed or different-length values
- rely on the durable provider-event unique claim for payment and reversal concurrency
- make deposit state transitions monotonic so reversal is terminal and stale events cannot overwrite confirmed/reversed money state
- avoid debiting a reversal that arrived before any credit was applied

## Tests
- `npx vitest run src/middleware/webhookSignature.test.ts src/payments/webhookSignature.test.ts src/payments/paymentState.test.ts src/routes/webhooks.test.ts src/routes/webhooks.reversal.test.ts --reporter=dot` (70 passed)
- `npm run typecheck` (blocked by pre-existing TypeScript errors outside touched files, including `comprehensiveRateLimit.ts`, `rbac.ts`, `complianceReportStore.ts`, and multiple existing repositories/routes)
- `npm run build` (same pre-existing TypeScript baseline failures)

Closes #1103