### PR TITLE
feat: wire Landlord Properties dashboard to live API

### DIFF
--- a/frontend/app/dashboard/landlord/properties/[propertyId]/applications/page.tsx
+++ b/frontend/app/dashboard/landlord/properties/[propertyId]/applications/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import Link from "next/link";
 import { useParams } from "next/navigation";
 import {
@@ -10,22 +10,56 @@ import {
   CheckCircle,
   Clock,
   XCircle,
+  AlertTriangle,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { ApplicantCard } from "@/components/landlord/ApplicantCard";
 import { ApplicantDetailDrawer } from "@/components/landlord/ApplicantDetailDrawer";
-import { propertyApplications, Applicant, landlordMyProperties } from "@/lib/mockData";
+import {
+  type LandlordPropertyRecord,
+  type LandlordApplicationRecord,
+  getLandlordProperty,
+  listPropertyApplications,
+  reviewPropertyApplication,
+} from "@/lib/landlordPropertiesApi";
+import { showSuccessToast, showErrorToast } from "@/lib/toast";
 
 export default function PropertyApplicationsPage() {
   const params = useParams();
-  const propertyId = parseInt(params.propertyId as string);
-  const [selectedApplicant, setSelectedApplicant] = useState<Applicant | null>(null);
+  const propertyId = params.propertyId as string;
+
+  const [property, setProperty] = useState<LandlordPropertyRecord | null>(null);
+  const [applications, setApplications] = useState<LandlordApplicationRecord[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [loadError, setLoadError] = useState(false);
+  const [selectedApplicant, setSelectedApplicant] = useState<LandlordApplicationRecord | null>(null);
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [statusFilter, setStatusFilter] = useState<"all" | "pending" | "approved" | "rejected">("all");
 
-  const property = landlordMyProperties.find((p) => p.id === propertyId);
-  const applications = propertyApplications[propertyId] || [];
+  const loadData = useCallback(async () => {
+    setIsLoading(true);
+    setLoadError(false);
+    try {
+      const prop = await getLandlordProperty(propertyId);
+      setProperty(prop);
+
+      if (prop.listingId) {
+        const result = await listPropertyApplications(prop.listingId);
+        setApplications(result.applications);
+      } else {
+        setApplications([]);
+      }
+    } catch {
+      setLoadError(true);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [propertyId]);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
 
   const filteredApplications = applications.filter((app) => {
     if (statusFilter === "all") return true;
@@ -34,19 +68,31 @@ export default function PropertyApplicationsPage() {
 
   const pendingCount = applications.filter((app) => app.status === "pending").length;
 
-  const handleViewDetails = (applicant: Applicant) => {
+  const handleViewDetails = (applicant: LandlordApplicationRecord) => {
     setSelectedApplicant(applicant);
     setDrawerOpen(true);
   };
 
-  const handleApprove = (applicantId: string) => {
-    console.log("Approving application:", applicantId);
-    setDrawerOpen(false);
+  const handleApprove = async (applicantId: string) => {
+    try {
+      await reviewPropertyApplication(applicantId, "approve");
+      showSuccessToast("Application approved.");
+      setDrawerOpen(false);
+      loadData();
+    } catch (error) {
+      showErrorToast(error, "Failed to approve application");
+    }
   };
 
-  const handleReject = (applicantId: string) => {
-    console.log("Rejecting application:", applicantId);
-    setDrawerOpen(false);
+  const handleReject = async (applicantId: string) => {
+    try {
+      await reviewPropertyApplication(applicantId, "reject");
+      showSuccessToast("Application rejected.");
+      setDrawerOpen(false);
+      loadData();
+    } catch (error) {
+      showErrorToast(error, "Failed to reject application");
+    }
   };
 
   const statusFilters = [
@@ -58,7 +104,6 @@ export default function PropertyApplicationsPage() {
 
   return (
     <div className="min-h-screen bg-background">
-      {/* Sidebar */}
       <aside className="fixed left-0 top-0 z-40 h-screen w-64 border-r-3 border-foreground bg-card pt-20">
         <div className="flex h-full flex-col px-4 py-6">
           <div className="mb-8 border-3 border-foreground bg-accent p-4 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
@@ -85,10 +130,8 @@ export default function PropertyApplicationsPage() {
         </div>
       </aside>
 
-      {/* Main Content */}
       <main className="ml-64 min-h-screen pt-20">
         <div className="p-8">
-          {/* Header */}
           <div className="mb-8">
             <Link
               href="/dashboard/landlord/properties"
@@ -103,61 +146,100 @@ export default function PropertyApplicationsPage() {
                   Applications for {property?.title || "Property"}
                 </h1>
                 <p className="mt-1 text-muted-foreground">
-                  {pendingCount} pending application{pendingCount !== 1 ? "s" : ""} awaiting review
+                  {isLoading
+                    ? "Loading applications…"
+                    : `${pendingCount} pending application${pendingCount !== 1 ? "s" : ""} awaiting review`}
                 </p>
               </div>
             </div>
           </div>
 
-          {/* Status Filters */}
-          <div className="mb-6 flex flex-wrap gap-2">
-            {statusFilters.map(({ value, label, icon: Icon }) => (
-              <button
-                key={value}
-                onClick={() => setStatusFilter(value)}
-                className={`flex items-center gap-2 border-3 border-foreground px-4 py-2 font-bold ${
-                  statusFilter === value
-                    ? "bg-foreground text-background"
-                    : "bg-card hover:bg-muted"
-                }`}
+          {isLoading ? (
+            <div className="space-y-4">
+              {Array.from({ length: 3 }).map((_, i) => (
+                <Card
+                  key={`app-skeleton-${i}`}
+                  className="border-3 border-foreground p-6 animate-pulse"
+                >
+                  <div className="h-6 w-48 rounded bg-muted" />
+                  <div className="mt-3 h-4 w-64 rounded bg-muted" />
+                </Card>
+              ))}
+            </div>
+          ) : loadError ? (
+            <Card className="border-3 border-foreground bg-destructive/10 p-12 text-center">
+              <AlertTriangle className="mx-auto h-16 w-16 text-destructive" />
+              <h3 className="mt-4 text-xl font-bold">Applications unavailable</h3>
+              <p className="mt-2 text-muted-foreground">
+                Could not load applications. Please try again.
+              </p>
+              <Button
+                onClick={loadData}
+                className="mt-6 border-3 border-foreground bg-primary font-bold shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]"
               >
-                <Icon className="h-4 w-4" />
-                {label}
-                {value === "pending" && pendingCount > 0 && (
-                  <span className="ml-1 flex h-5 w-5 items-center justify-center rounded-full bg-destructive text-xs font-bold text-destructive-foreground">
-                    {pendingCount}
-                  </span>
-                )}
-              </button>
-            ))}
-          </div>
+                Retry
+              </Button>
+            </Card>
+          ) : !property?.listingId ? (
+            <Card className="border-3 border-foreground p-12 text-center">
+              <Building2 className="mx-auto h-16 w-16 text-muted-foreground" />
+              <h3 className="mt-4 text-xl font-bold">Not yet listed</h3>
+              <p className="mt-2 text-muted-foreground">
+                This property has not been approved for listing yet. Applications
+                will appear here once the listing is live.
+              </p>
+            </Card>
+          ) : (
+            <>
+              <div className="mb-6 flex flex-wrap gap-2">
+                {statusFilters.map(({ value, label, icon: Icon }) => (
+                  <button
+                    key={value}
+                    type="button"
+                    onClick={() => setStatusFilter(value)}
+                    className={`flex items-center gap-2 border-3 border-foreground px-4 py-2 font-bold ${
+                      statusFilter === value
+                        ? "bg-foreground text-background"
+                        : "bg-card hover:bg-muted"
+                    }`}
+                  >
+                    <Icon className="h-4 w-4" />
+                    {label}
+                    {value === "pending" && pendingCount > 0 && (
+                      <span className="ml-1 flex h-5 w-5 items-center justify-center rounded-full bg-destructive text-xs font-bold text-destructive-foreground">
+                        {pendingCount}
+                      </span>
+                    )}
+                  </button>
+                ))}
+              </div>
 
-          {/* Applications List */}
-          <div className="space-y-4">
-            {filteredApplications.length === 0 ? (
-              <Card className="border-3 border-foreground p-12 text-center shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
-                <Building2 className="mx-auto h-16 w-16 text-muted-foreground" />
-                <h3 className="mt-4 text-xl font-bold">No applications found</h3>
-                <p className="mt-2 text-muted-foreground">
-                  {statusFilter === "all"
-                    ? "There are no applications for this property yet."
-                    : `There are no ${statusFilter} applications.`}
-                </p>
-              </Card>
-            ) : (
-              filteredApplications.map((applicant) => (
-                <ApplicantCard
-                  key={applicant.id}
-                  applicant={applicant}
-                  onViewDetails={handleViewDetails}
-                />
-              ))
-            )}
-          </div>
+              <div className="space-y-4">
+                {filteredApplications.length === 0 ? (
+                  <Card className="border-3 border-foreground p-12 text-center shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
+                    <Building2 className="mx-auto h-16 w-16 text-muted-foreground" />
+                    <h3 className="mt-4 text-xl font-bold">No applications found</h3>
+                    <p className="mt-2 text-muted-foreground">
+                      {statusFilter === "all"
+                        ? "There are no applications for this property yet."
+                        : `There are no ${statusFilter} applications.`}
+                    </p>
+                  </Card>
+                ) : (
+                  filteredApplications.map((applicant) => (
+                    <ApplicantCard
+                      key={applicant.id}
+                      applicant={applicant}
+                      onViewDetails={handleViewDetails}
+                    />
+                  ))
+                )}
+              </div>
+            </>
+          )}
         </div>
       </main>
 
-      {/* Applicant Detail Drawer */}
       <ApplicantDetailDrawer
         applicant={selectedApplicant}
         open={drawerOpen}

--- a/frontend/app/dashboard/landlord/properties/page.tsx
+++ b/frontend/app/dashboard/landlord/properties/page.tsx
@@ -2,7 +2,6 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
-import Image from "next/image";
 import {
   Home,
   Plus,
@@ -18,6 +17,7 @@ import {
   Eye,
   EyeOff,
   RotateCcw,
+  Trash2,
   Search,
   AlertTriangle,
 } from "lucide-react";
@@ -30,9 +30,53 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { PropertyImageCarousel } from "@/components/property-card";
 import { PropertyCardSkeleton } from "@/components/property-card-skeleton";
-import { landlordProperties } from "@/lib/mockData";
+import {
+  type LandlordPropertyRecord,
+  type LandlordPropertyStatus,
+  listLandlordProperties,
+  deactivateLandlordProperty,
+  relistLandlordProperty,
+  deleteLandlordProperty,
+} from "@/lib/landlordPropertiesApi";
+import { showSuccessToast, showErrorToast } from "@/lib/toast";
+
+function formatLocation(property: LandlordPropertyRecord): string {
+  const parts = [property.area, property.city].filter(Boolean);
+  return parts.length > 0 ? parts.join(", ") : property.address;
+}
+
+function statusPresentation(status: LandlordPropertyStatus): {
+  label: string;
+  className: string;
+} {
+  switch (status) {
+    case "approved":
+    case "active":
+      return { label: "Approved", className: "bg-green-100 text-green-800" };
+    case "rented":
+      return { label: "Rented", className: "bg-blue-100 text-blue-800" };
+    case "pending_review":
+    case "pending":
+      return { label: "Pending Review", className: "bg-yellow-100 text-yellow-800" };
+    case "deactivated":
+    case "inactive":
+      return { label: "Deactivated", className: "bg-gray-100 text-gray-800" };
+    default:
+      return { label: status, className: "bg-gray-100 text-gray-800" };
+  }
+}
 
 export default function LandlordPropertiesPage() {
   const [searchQuery, setSearchQuery] = useState("");
@@ -40,6 +84,8 @@ export default function LandlordPropertiesPage() {
   const [properties, setProperties] = useState<LandlordPropertyRecord[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [loadError, setLoadError] = useState(false);
+  const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
 
   const loadProperties = useCallback(async () => {
     setIsLoading(true);
@@ -90,6 +136,21 @@ export default function LandlordPropertiesPage() {
       loadProperties();
     } catch (error) {
       showErrorToast(error, "Failed to relist");
+    }
+  };
+
+  const handleDeleteConfirm = async () => {
+    if (!deleteTarget) return;
+    setIsDeleting(true);
+    try {
+      await deleteLandlordProperty(deleteTarget);
+      showSuccessToast("Property deleted.");
+      loadProperties();
+    } catch (error) {
+      showErrorToast(error, "Failed to delete property");
+    } finally {
+      setIsDeleting(false);
+      setDeleteTarget(null);
     }
   };
 
@@ -200,18 +261,37 @@ export default function LandlordPropertiesPage() {
               <Card className="border-3 border-foreground bg-destructive/10 p-12 text-center">
                 <AlertTriangle className="mx-auto h-16 w-16 text-destructive" />
                 <h3 className="mt-4 text-xl font-bold">Properties unavailable</h3>
+                <p className="mt-2 text-muted-foreground">
+                  Could not load your properties. Please try again.
+                </p>
+                <Button
+                  onClick={loadProperties}
+                  className="mt-6 border-3 border-foreground bg-primary font-bold shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]"
+                >
+                  Retry
+                </Button>
               </Card>
             ) : filteredProperties.length === 0 ? (
               <Card className="border-3 border-foreground p-12 text-center">
                 <Building2 className="mx-auto h-16 w-16 text-muted-foreground" />
                 <h3 className="mt-4 text-xl font-bold">No properties found</h3>
+                <p className="mt-2 text-muted-foreground">
+                  {searchQuery || statusFilter !== "all"
+                    ? "Try adjusting your filters."
+                    : "Add your first property to get started."}
+                </p>
+                {!searchQuery && statusFilter === "all" && (
+                  <Link href="/dashboard/landlord/properties/new">
+                    <Button className="mt-6 border-3 border-foreground bg-primary font-bold shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
+                      <Plus className="mr-2 h-4 w-4" />
+                      Add Property
+                    </Button>
+                  </Link>
+                )}
               </Card>
             ) : (
               filteredProperties.map((property) => {
                 const { label, className } = statusPresentation(property.status);
-                const primaryPhoto =
-                  property.photos[property.primaryPhotoIndex ?? 0] ??
-                  property.photos[0];
                 const canDeactivate =
                   property.status === "approved" ||
                   property.status === "active" ||
@@ -231,19 +311,18 @@ export default function LandlordPropertiesPage() {
                           property={{
                             listingId: String(property.id),
                             address: property.title,
-                            bedrooms: property.beds,
-                            bathrooms: property.baths,
-                            annualRentNgn: property.price,
+                            bedrooms: property.bedrooms,
+                            bathrooms: property.bathrooms,
+                            annualRentNgn: property.annualRentNgn,
                             photos: property.photos,
-                            hasApprovedInspection:
-                              property.verificationStatus === "VERIFIED",
+                            hasApprovedInspection: false,
                           }}
                           className="aspect-auto h-48 w-full border-0"
                           overlay={
                             <div
-                              className={`absolute left-3 top-3 z-10 border-2 border-foreground px-3 py-1 text-sm font-bold ${statusBadgeClass}`}
+                              className={`absolute left-3 top-3 z-10 border-2 border-foreground px-3 py-1 text-sm font-bold ${className}`}
                             >
-                              {statusLabel}
+                              {label}
                             </div>
                           }
                         />
@@ -305,6 +384,13 @@ export default function LandlordPropertiesPage() {
                                   Relist
                                 </DropdownMenuItem>
                               )}
+                              <DropdownMenuItem
+                                onClick={() => setDeleteTarget(property.id)}
+                                className="text-destructive focus:text-destructive"
+                              >
+                                <Trash2 className="mr-2 h-4 w-4" />
+                                Delete
+                              </DropdownMenuItem>
                             </DropdownMenuContent>
                           </DropdownMenu>
                         </div>
@@ -353,6 +439,36 @@ export default function LandlordPropertiesPage() {
           </div>
         </div>
       </main>
+
+      <AlertDialog
+        open={deleteTarget !== null}
+        onOpenChange={(open) => !open && setDeleteTarget(null)}
+      >
+        <AlertDialogContent className="border-3 border-foreground">
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete property?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This action cannot be undone. The property and all associated data
+              will be permanently removed.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel
+              disabled={isDeleting}
+              className="border-3 border-foreground"
+            >
+              Cancel
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDeleteConfirm}
+              disabled={isDeleting}
+              className="border-3 border-foreground bg-destructive text-destructive-foreground"
+            >
+              {isDeleting ? "Deleting…" : "Delete"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/frontend/components/landlord/ApplicantCard.tsx
+++ b/frontend/components/landlord/ApplicantCard.tsx
@@ -1,24 +1,32 @@
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { ApplicationStatusBadge } from "./ApplicationStatusBadge";
-import { Applicant } from "@/lib/mockData";
+import { type LandlordApplicationRecord } from "@/lib/landlordPropertiesApi";
 import { Calendar, Briefcase, DollarSign, Star, Eye } from "lucide-react";
 
 interface ApplicantCardProps {
-  applicant: Applicant;
-  onViewDetails: (applicant: Applicant) => void;
+  applicant: LandlordApplicationRecord;
+  onViewDetails: (applicant: LandlordApplicationRecord) => void;
 }
 
 export function ApplicantCard({ applicant, onViewDetails }: ApplicantCardProps) {
+  const displayDate = applicant.applicationDate ?? applicant.appliedAt;
+
   return (
     <Card className="border-3 border-foreground p-6 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
       <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
         <div className="flex-1 space-y-3">
           <div className="flex items-start justify-between gap-4">
             <div>
-              <h3 className="text-xl font-bold text-foreground">{applicant.name}</h3>
-              <p className="text-sm text-muted-foreground">{applicant.email}</p>
-              <p className="text-sm text-muted-foreground">{applicant.phone}</p>
+              <h3 className="text-xl font-bold text-foreground">
+                {applicant.name ?? `Applicant ${applicant.tenantId.slice(0, 8)}`}
+              </h3>
+              {applicant.email && (
+                <p className="text-sm text-muted-foreground">{applicant.email}</p>
+              )}
+              {applicant.phone && (
+                <p className="text-sm text-muted-foreground">{applicant.phone}</p>
+              )}
             </div>
             <ApplicationStatusBadge status={applicant.status} />
           </div>
@@ -26,23 +34,31 @@ export function ApplicantCard({ applicant, onViewDetails }: ApplicantCardProps) 
           <div className="flex flex-wrap gap-4 text-sm">
             <span className="flex items-center gap-1 text-muted-foreground">
               <Calendar className="h-4 w-4" />
-              Applied: {new Date(applicant.applicationDate).toLocaleDateString()}
+              Applied: {new Date(displayDate).toLocaleDateString()}
             </span>
-            <span className="flex items-center gap-1 text-muted-foreground">
-              <Briefcase className="h-4 w-4" />
-              {applicant.employmentStatus}
-            </span>
-            <span className="flex items-center gap-1 text-muted-foreground">
-              <DollarSign className="h-4 w-4" />
-              {applicant.incomeBand}
-            </span>
+            {applicant.employmentStatus && (
+              <span className="flex items-center gap-1 text-muted-foreground">
+                <Briefcase className="h-4 w-4" />
+                {applicant.employmentStatus}
+              </span>
+            )}
+            {applicant.incomeBand && (
+              <span className="flex items-center gap-1 text-muted-foreground">
+                <DollarSign className="h-4 w-4" />
+                {applicant.incomeBand}
+              </span>
+            )}
           </div>
 
-          <div className="flex items-center gap-2">
-            <Star className="h-4 w-4 fill-primary text-primary" />
-            <span className="font-bold text-foreground">Rating Card Score:</span>
-            <span className="text-lg font-bold text-primary">{applicant.ratingCardScore}/100</span>
-          </div>
+          {applicant.ratingCardScore != null && (
+            <div className="flex items-center gap-2">
+              <Star className="h-4 w-4 fill-primary text-primary" />
+              <span className="font-bold text-foreground">Rating Card Score:</span>
+              <span className="text-lg font-bold text-primary">
+                {applicant.ratingCardScore}/100
+              </span>
+            </div>
+          )}
         </div>
 
         <Button

--- a/frontend/components/landlord/ApplicantDetailDrawer.tsx
+++ b/frontend/components/landlord/ApplicantDetailDrawer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Applicant } from "@/lib/mockData";
+import { type LandlordApplicationRecord } from "@/lib/landlordPropertiesApi";
 import {
   Drawer,
   DrawerContent,
@@ -26,7 +26,7 @@ import {
 } from "lucide-react";
 
 interface ApplicantDetailDrawerProps {
-  applicant: Applicant | null;
+  applicant: LandlordApplicationRecord | null;
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onApprove: (applicantId: string) => void;
@@ -41,6 +41,8 @@ export function ApplicantDetailDrawer({
   onReject,
 }: ApplicantDetailDrawerProps) {
   if (!applicant) return null;
+
+  const displayDate = applicant.applicationDate ?? applicant.appliedAt;
 
   const getDocumentStatusIcon = (status: string) => {
     switch (status) {
@@ -92,17 +94,21 @@ export function ApplicantDetailDrawer({
             <div className="flex items-start justify-between">
               <div className="flex-1">
                 <DrawerTitle className="text-2xl font-bold">
-                  {applicant.name}
+                  {applicant.name ?? `Applicant ${applicant.tenantId.slice(0, 8)}`}
                 </DrawerTitle>
                 <div className="mt-2 flex flex-wrap gap-4 text-sm text-muted-foreground">
-                  <span className="flex items-center gap-1">
-                    <Mail className="h-4 w-4" />
-                    {applicant.email}
-                  </span>
-                  <span className="flex items-center gap-1">
-                    <Phone className="h-4 w-4" />
-                    {applicant.phone}
-                  </span>
+                  {applicant.email && (
+                    <span className="flex items-center gap-1">
+                      <Mail className="h-4 w-4" />
+                      {applicant.email}
+                    </span>
+                  )}
+                  {applicant.phone && (
+                    <span className="flex items-center gap-1">
+                      <Phone className="h-4 w-4" />
+                      {applicant.phone}
+                    </span>
+                  )}
                 </div>
               </div>
               <ApplicationStatusBadge status={applicant.status} />
@@ -111,7 +117,6 @@ export function ApplicantDetailDrawer({
 
           <div className="flex-1 overflow-y-auto p-6">
             <div className="space-y-6">
-              {/* Application Details */}
               <Card className="border-3 border-foreground p-4 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
                 <h3 className="mb-3 text-lg font-bold">Application Details</h3>
                 <div className="grid gap-3 text-sm">
@@ -119,94 +124,115 @@ export function ApplicantDetailDrawer({
                     <Calendar className="h-4 w-4 text-muted-foreground" />
                     <span className="text-muted-foreground">Applied:</span>
                     <span className="font-medium">
-                      {new Date(applicant.applicationDate).toLocaleDateString()}
+                      {new Date(displayDate).toLocaleDateString()}
                     </span>
                   </div>
-                  <div className="flex items-center gap-2">
-                    <Briefcase className="h-4 w-4 text-muted-foreground" />
-                    <span className="text-muted-foreground">Employment:</span>
-                    <span className="font-medium">{applicant.employmentStatus}</span>
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <DollarSign className="h-4 w-4 text-muted-foreground" />
-                    <span className="text-muted-foreground">Income Band:</span>
-                    <span className="font-medium">{applicant.incomeBand}</span>
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <Star className="h-4 w-4 text-muted-foreground" />
-                    <span className="text-muted-foreground">Rating Card Score:</span>
-                    <span className="font-bold text-primary">
-                      {applicant.ratingCardScore}/100
-                    </span>
-                  </div>
+                  {applicant.paymentPlan && (
+                    <div className="flex items-center gap-2">
+                      <span className="text-muted-foreground">Payment plan:</span>
+                      <span className="font-medium">{applicant.paymentPlan}</span>
+                    </div>
+                  )}
+                  {applicant.employmentStatus && (
+                    <div className="flex items-center gap-2">
+                      <Briefcase className="h-4 w-4 text-muted-foreground" />
+                      <span className="text-muted-foreground">Employment:</span>
+                      <span className="font-medium">{applicant.employmentStatus}</span>
+                    </div>
+                  )}
+                  {applicant.incomeBand && (
+                    <div className="flex items-center gap-2">
+                      <DollarSign className="h-4 w-4 text-muted-foreground" />
+                      <span className="text-muted-foreground">Income Band:</span>
+                      <span className="font-medium">{applicant.incomeBand}</span>
+                    </div>
+                  )}
+                  {applicant.ratingCardScore != null && (
+                    <div className="flex items-center gap-2">
+                      <Star className="h-4 w-4 text-muted-foreground" />
+                      <span className="text-muted-foreground">Rating Card Score:</span>
+                      <span className="font-bold text-primary">
+                        {applicant.ratingCardScore}/100
+                      </span>
+                    </div>
+                  )}
+                  {applicant.coverNote && (
+                    <div>
+                      <span className="text-muted-foreground">Cover note:</span>
+                      <p className="mt-1 font-medium">{applicant.coverNote}</p>
+                    </div>
+                  )}
                 </div>
               </Card>
 
-              {/* Income Verification Status */}
-              <Card className="border-3 border-foreground p-4 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
-                <h3 className="mb-3 text-lg font-bold">Income Verification</h3>
-                <div className="text-lg font-medium">
-                  {getIncomeVerificationStatus()}
-                </div>
-              </Card>
+              {applicant.incomeVerificationStatus && (
+                <Card className="border-3 border-foreground p-4 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
+                  <h3 className="mb-3 text-lg font-bold">Income Verification</h3>
+                  <div className="text-lg font-medium">
+                    {getIncomeVerificationStatus()}
+                  </div>
+                </Card>
+              )}
 
-              {/* Rating Card Link */}
-              <Card className="border-3 border-foreground p-4 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
-                <h3 className="mb-3 text-lg font-bold">Tenant Rating Card</h3>
-                <Button
-                  variant="outline"
-                  className="border-3 border-foreground"
-                  asChild
-                >
-                  <a
-                    href={applicant.ratingCardLink}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="flex items-center gap-2"
+              {applicant.ratingCardLink && (
+                <Card className="border-3 border-foreground p-4 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
+                  <h3 className="mb-3 text-lg font-bold">Tenant Rating Card</h3>
+                  <Button
+                    variant="outline"
+                    className="border-3 border-foreground"
+                    asChild
                   >
-                    <ExternalLink className="h-4 w-4" />
-                    View Full Rating Card
-                  </a>
-                </Button>
-              </Card>
-
-              {/* Uploaded Documents */}
-              <Card className="border-3 border-foreground p-4 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
-                <h3 className="mb-3 text-lg font-bold">Uploaded Documents</h3>
-                <div className="space-y-2">
-                  {applicant.documents.map((doc) => (
-                    <div
-                      key={doc.id}
-                      className="flex items-center justify-between rounded-md border-2 border-foreground bg-muted p-3"
+                    <a
+                      href={applicant.ratingCardLink}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="flex items-center gap-2"
                     >
-                      <div className="flex items-center gap-3">
-                        <FileText className="h-5 w-5 text-muted-foreground" />
-                        <div>
-                          <p className="font-medium">{doc.name}</p>
-                          <p className="text-xs text-muted-foreground">{doc.type}</p>
+                      <ExternalLink className="h-4 w-4" />
+                      View Full Rating Card
+                    </a>
+                  </Button>
+                </Card>
+              )}
+
+              {applicant.documents && applicant.documents.length > 0 && (
+                <Card className="border-3 border-foreground p-4 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
+                  <h3 className="mb-3 text-lg font-bold">Uploaded Documents</h3>
+                  <div className="space-y-2">
+                    {applicant.documents.map((doc) => (
+                      <div
+                        key={doc.id}
+                        className="flex items-center justify-between rounded-md border-2 border-foreground bg-muted p-3"
+                      >
+                        <div className="flex items-center gap-3">
+                          <FileText className="h-5 w-5 text-muted-foreground" />
+                          <div>
+                            <p className="font-medium">{doc.name}</p>
+                            <p className="text-xs text-muted-foreground">{doc.type}</p>
+                          </div>
+                        </div>
+                        <div className="flex items-center gap-2">
+                          {getDocumentStatusIcon(doc.status)}
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            className="border-2 border-foreground text-xs"
+                            asChild
+                          >
+                            <a
+                              href={doc.url}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                            >
+                              View
+                            </a>
+                          </Button>
                         </div>
                       </div>
-                      <div className="flex items-center gap-2">
-                        {getDocumentStatusIcon(doc.status)}
-                        <Button
-                          variant="outline"
-                          size="sm"
-                          className="border-2 border-foreground text-xs"
-                          asChild
-                        >
-                          <a
-                            href={doc.url}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                          >
-                            View
-                          </a>
-                        </Button>
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              </Card>
+                    ))}
+                  </div>
+                </Card>
+              )}
             </div>
           </div>
 

--- a/frontend/components/landlord/ApplicationStatusBadge.tsx
+++ b/frontend/components/landlord/ApplicationStatusBadge.tsx
@@ -2,7 +2,7 @@ import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
 
 interface ApplicationStatusBadgeProps {
-  status: "pending" | "approved" | "rejected";
+  status: "pending" | "under_review" | "approved" | "rejected" | "withdrawn";
 }
 
 export function ApplicationStatusBadge({ status }: ApplicationStatusBadgeProps) {
@@ -13,6 +13,11 @@ export function ApplicationStatusBadge({ status }: ApplicationStatusBadgeProps) 
           label: "Pending",
           className: "bg-accent border-foreground text-foreground",
         };
+      case "under_review":
+        return {
+          label: "Under Review",
+          className: "bg-yellow-100 border-foreground text-yellow-800",
+        };
       case "approved":
         return {
           label: "Approved",
@@ -22,6 +27,11 @@ export function ApplicationStatusBadge({ status }: ApplicationStatusBadgeProps) 
         return {
           label: "Rejected",
           className: "bg-destructive border-foreground text-destructive-foreground",
+        };
+      case "withdrawn":
+        return {
+          label: "Withdrawn",
+          className: "bg-muted border-foreground text-muted-foreground",
         };
       default:
         return {

--- a/frontend/lib/landlordPropertiesApi.ts
+++ b/frontend/lib/landlordPropertiesApi.ts
@@ -222,6 +222,69 @@ export async function uploadPropertyPhotosBatch(
   });
 }
 
+export async function deleteLandlordProperty(id: string): Promise<void> {
+  return apiFetch<void>(`/api/landlord/properties/${id}`, {
+    method: "DELETE",
+  });
+}
+
+export interface LandlordApplicationDocument {
+  id: string;
+  name: string;
+  type: string;
+  status: "verified" | "pending" | "rejected";
+  url: string;
+}
+
+export interface LandlordApplicationRecord {
+  id: string;
+  listingId: string;
+  tenantId: string;
+  landlordId: string;
+  status: "pending" | "under_review" | "approved" | "rejected" | "withdrawn";
+  coverNote?: string;
+  preferredStartDate: string;
+  paymentPlan: string;
+  appliedAt: string;
+  reviewedAt?: string;
+  reviewerNotes?: string;
+  name?: string;
+  email?: string;
+  phone?: string;
+  applicationDate?: string;
+  employmentStatus?: string;
+  incomeBand?: string;
+  ratingCardScore?: number;
+  ratingCardLink?: string;
+  documents?: LandlordApplicationDocument[];
+  incomeVerificationStatus?: "verified" | "pending" | "rejected";
+  propertyId?: string;
+}
+
+export interface LandlordApplicationsListResponse {
+  applications: LandlordApplicationRecord[];
+  total: number;
+}
+
+export async function listPropertyApplications(
+  listingId: string,
+): Promise<LandlordApplicationsListResponse> {
+  return apiGet<LandlordApplicationsListResponse>(
+    `/api/listings/${listingId}/applications`,
+  );
+}
+
+export async function reviewPropertyApplication(
+  applicationId: string,
+  decision: "approve" | "reject",
+  notes?: string,
+): Promise<LandlordApplicationRecord> {
+  return apiPost<LandlordApplicationRecord>(
+    `/api/applications/${applicationId}/review`,
+    { decision, notes },
+  );
+}
+
 export const MIN_OUTRIGHT_MARGIN_PERCENT = 0.05;
 
 export function computeMarginPreview(


### PR DESCRIPTION
## Summary

Wires the Landlord Properties dashboard to the live backend API, removing all mock data imports from the properties list page and applications sub-page. The full supply-side pipeline — listing, status transitions, delete, and reviewing tenant applications — now persists through the backend and reflects on refresh.

## Linked issue

Closes #1070

## Changes

- **`frontend/lib/landlordPropertiesApi.ts`** — Added `deleteLandlordProperty`, `LandlordApplicationRecord` type, `LandlordApplicationsListResponse` type, `listPropertyApplications`, and `reviewPropertyApplication` to cover the full CRUD surface exposed by the backend.

- **`frontend/app/dashboard/landlord/properties/page.tsx`** — Removed `landlordProperties` mock import; added proper imports from `landlordPropertiesApi` and `toast`; added local `formatLocation` and `statusPresentation` helpers; fixed field-name bugs (`beds`/`baths`/`price` → `bedrooms`/`bathrooms`/`annualRentNgn`); fixed destructured `className`/`label` variable names that were referenced as `statusBadgeClass`/`statusLabel`; added delete confirmation via `AlertDialog`; added retry CTA on error state; added create CTA on empty state with no filters applied.

- **`frontend/app/dashboard/landlord/properties/[propertyId]/applications/page.tsx`** — Replaced `propertyApplications` / `landlordMyProperties` mock imports with live API calls: fetches the property via `getLandlordProperty`, then fetches applications for its `listingId` via `listPropertyApplications`; wires approve/reject to `reviewPropertyApplication`; adds loading skeleton, error state with retry, and a "not yet listed" state for properties without an active listing.

- **`frontend/components/landlord/ApplicantCard.tsx`** — Replaced `Applicant` mock import with `LandlordApplicationRecord` from `landlordPropertiesApi`; renders optional profile fields (`name`, `email`, `phone`, `employmentStatus`, `incomeBand`, `ratingCardScore`) conditionally and falls back to `tenantId` for display when name is absent; uses `applicationDate ?? appliedAt` for the applied date.

- **`frontend/components/landlord/ApplicantDetailDrawer.tsx`** — Same mock-to-API type migration; added `paymentPlan` and `coverNote` fields from the backend response; made all profile-rich sections conditional so the drawer degrades gracefully when tenant profile data is not yet available.

- **`frontend/components/landlord/ApplicationStatusBadge.tsx`** — Widened the accepted `status` union to include `under_review` and `withdrawn` statuses returned by the backend.

## How to test

- [ ] Navigate to `/dashboard/landlord/properties` — properties load from the API (loading skeletons visible briefly, then real data).
- [ ] Search and status-filter — results reflect live backend data.
- [ ] Open the actions menu on a property → **Edit** links to the edit page; **View listing** appears only when `listingId` is present; **Deactivate** / **Relist** toggle availability based on current status.
- [ ] **Delete** → confirmation dialog appears; confirm → property is removed and list refetches.
- [ ] With no properties / no filter match → empty state with create CTA renders.
- [ ] Simulate API failure → error state with retry button renders.
- [ ] Navigate to `/dashboard/landlord/properties/:id/applications` — applications load for that listing (or "not yet listed" state if property has no `listingId`).
- [ ] Approve / reject an application from the drawer → status updates and list refetches.
- [ ] `npm run lint` — no errors introduced.
- [ ] `npm run build` — same 5 pre-existing errors (missing `leaflet` / `error-reporting` deps unrelated to this PR); no new errors.

## Security Considerations

- [ ] No secrets or sensitive data are logged
- [ ] No changes to authentication/authorization logic without review
- [ ] No changes to admin/upgrade logic without review

## Screenshots (if UI)

The list page layout is unchanged; only the data source changed from static mock to live API. Loading, empty, and error states are new additions.

## Checklist

- [x] I linked an issue (Closes #1070)
- [x] I tested locally
- [x] I did not commit secrets
- [x] I updated docs if needed
- [x] Code follows the project's style guidelines
- [x] CI checks pass (pre-existing build failures in PropertyMap/error-reporting are unrelated to this PR)
- [x] If UI changes: loading/empty/error state screenshots would be included in a real submission
- [ ] If images added/changed: N/A