### PR TITLE
feat: remove mock fallback from whistleblower dashboard, wire to live…

### DIFF
--- a/frontend/app/whistleblower/dashboard/page.tsx
+++ b/frontend/app/whistleblower/dashboard/page.tsx
@@ -22,9 +22,10 @@ import {
   getWhistleblowerDashboardData,
   type WhistleblowerDashboardData,
 } from "@/lib/api/whistleblowerDashboard";
-import { whistleblowerData as mockData } from "@/lib/mockData";
+import useAuthStore from "@/store/useAuthStore";
 
 export default function WhistleblowerDashboard() {
+  const { user } = useAuthStore();
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -40,7 +41,6 @@ export default function WhistleblowerDashboard() {
       } catch (err) {
         console.error("Failed to fetch whistleblower data:", err);
         setError("Failed to connect to live data. Please ensure the backend is running.");
-        // Fallback to mock data in development if needed, but the requirement is "live"
       } finally {
         setLoading(false);
       }
@@ -112,7 +112,7 @@ export default function WhistleblowerDashboard() {
           <div className="mb-8 border-3 border-foreground bg-secondary p-4 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
             <p className="text-sm font-medium text-foreground">Whistleblower</p>
             <p className="text-lg font-bold text-foreground">
-              {mockData.name}
+              {user?.name ?? "Whistleblower"}
             </p>
             <div className="mt-2 flex items-center gap-1">
               <Star className="h-4 w-4 fill-accent text-accent" />


### PR DESCRIPTION
## Summary

Completes the live API integration for the Whistleblower dashboard by removing the last remaining mock data reference. The sidebar user name was still pulled from `whistleblowerData` (mock), while all stats, listings, and earnings were already fetched from the live `/api/whistleblower/dashboard` endpoint. This PR replaces that mock import with the authenticated user's name from `useAuthStore`, matching the pattern used by the earnings page. The dashboard now shows only real data; on API failure the user sees an explicit error state with a retry button — never fabricated values.

## Linked issue

Closes #1071

## Changes

- Removed `import { whistleblowerData as mockData } from "@/lib/mockData"` from `frontend/app/whistleblower/dashboard/page.tsx`
- Added `import useAuthStore from "@/store/useAuthStore"` and consumed `user?.name` for the sidebar display name (falls back to the string `"Whistleblower"` when the auth store has no name yet)
- Removed the stale `// Fallback to mock data in development if needed` comment from the error catch block

## Checklist

- [x] I linked an issue (or explained why one is not needed)
- [x] I tested locally
- [x] I did not commit secrets
- [x] I updated docs if needed
- [x] Code follows the project's style guidelines
- [x] CI checks pass
- [x] If UI changes: I included before/after screenshots
- [x] If images added/changed: I verified they are optimized and accessible