### PR TITLE
feat: integrate tenant_reputation Soroban contract for on-chain ancho…

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -896,7 +896,7 @@ export function createApp() {
   app.use('/api/v1', createRentGuaranteeRouter(rentGuaranteeProvider))
 
   // Tenant rating card routes
-  app.use('/api/v1', createTenantRatingCardRouter())
+  app.use('/api/v1', createTenantRatingCardRouter(sorobanAdapter))
 
   // Interactive API documentation
   app.use("/docs", createDocsRouter());

--- a/backend/src/outbox/sender.ts
+++ b/backend/src/outbox/sender.ts
@@ -76,6 +76,13 @@ export class OutboxSender {
             throw new Error('Deal status sync not supported by adapter')
           }
           break
+        case TxType.TENANT_REPUTATION_UPDATE:
+          if (this.adapter.updateTenantReputation) {
+            await this.sendTenantReputationUpdate(item)
+          } else {
+            throw new Error('Tenant reputation update not supported by adapter')
+          }
+          break
         default:
           throw new Error(`Unknown tx type: ${item.txType}`)
       }
@@ -251,6 +258,35 @@ export class OutboxSender {
       contractDealId: String(payload.contractDealId ?? payload.dealId),
       newStatus,
       actor: String(payload.actor ?? 'system'),
+    })
+  }
+
+  private async sendTenantReputationUpdate(item: OutboxItem): Promise<void> {
+    if (!this.adapter.updateTenantReputation) {
+      throw new Error('Adapter does not support updateTenantReputation')
+    }
+    const { payload } = item
+    if (
+      !payload.tenantId ||
+      payload.compositeScore == null ||
+      payload.paymentScore == null ||
+      payload.propertyCareScore == null ||
+      payload.communicationScore == null ||
+      payload.totalRatings == null
+    ) {
+      throw new Error('Invalid tenant reputation payload: missing required fields')
+    }
+    await this.adapter.updateTenantReputation(String(payload.tenantId), {
+      compositeScore: Number(payload.compositeScore),
+      paymentScore: Number(payload.paymentScore),
+      propertyCareScore: Number(payload.propertyCareScore),
+      communicationScore: Number(payload.communicationScore),
+      totalRatings: Number(payload.totalRatings),
+      lastUpdated: 0n,
+    })
+    logger.debug('Tenant reputation anchored on-chain', {
+      tenantId: String(payload.tenantId),
+      compositeScore: Number(payload.compositeScore),
     })
   }
 

--- a/backend/src/outbox/types.ts
+++ b/backend/src/outbox/types.ts
@@ -24,6 +24,7 @@ export enum TxType {
   STAKE_REWARD_CLAIM = 'stake_reward_claim',
   CONVERSION = 'conversion',
   DEAL_STATUS_CHANGED = 'deal_status_changed',
+  TENANT_REPUTATION_UPDATE = 'tenant_reputation_update',
 }
 
 /**

--- a/backend/src/routes/tenantRatingCard.ts
+++ b/backend/src/routes/tenantRatingCard.ts
@@ -1,12 +1,12 @@
 import { Router } from 'express'
 import { authenticateToken, AuthenticatedRequest } from '../middleware/auth.js'
 import { tenantRatingService } from '../services/tenantRatingService.js'
+import { TenantReputationOnChainService } from '../services/tenantReputationOnChainService.js'
 import { AppError } from '../errors/AppError.js'
 import { ErrorCode } from '../errors/errorCodes.js'
 import { auditLog, extractAuditContext } from '../utils/auditLogger.js'
 import { publicTenantRatingRateLimit } from '../middleware/publicRatingRateLimit.js'
-
-const router = Router()
+import { SorobanAdapter } from '../soroban/adapter.js'
 
 function assertLandlordOrAdmin(req: AuthenticatedRequest) {
   if (req.user?.role !== 'landlord' && req.user?.role !== 'admin') {
@@ -14,93 +14,117 @@ function assertLandlordOrAdmin(req: AuthenticatedRequest) {
   }
 }
 
-router.post('/ratings/tenant', authenticateToken, async (req: AuthenticatedRequest, res, next) => {
-  try {
-    assertLandlordOrAdmin(req)
+export function createTenantRatingCardRouter(adapter?: SorobanAdapter) {
+  const router = Router()
 
-    const { tenantId, dealId, paymentTimeliness, propertyCare, communication, overall, comment } = req.body
-
-    if (!tenantId || !dealId) {
-      throw new AppError(ErrorCode.VALIDATION_ERROR, 400, 'tenantId and dealId are required')
-    }
-
-    const rating = await tenantRatingService.submitRating(req.user!.id, tenantId, dealId, {
-      paymentTimeliness,
-      propertyCare,
-      communication,
-      overall,
-      comment,
-    })
-
-    auditLog('TENANT_RATING_SUBMITTED' as any, extractAuditContext(req, 'user'), {
-      tenantId,
-      dealId,
-      ratingId: rating.id,
-      overall,
-    })
-
-    res.status(201).json({ success: true, data: rating })
-  } catch (error) {
-    next(error)
+  if (adapter) {
+    tenantRatingService.setOnChainService(new TenantReputationOnChainService(adapter))
   }
-})
 
-router.get('/ratings/tenant/my-card', authenticateToken, async (req: AuthenticatedRequest, res, next) => {
-  try {
-    const tenantId = req.user?.id
-    if (!tenantId) {
-      throw new AppError(ErrorCode.UNAUTHORIZED, 401, 'User not authenticated')
+  router.post('/ratings/tenant', authenticateToken, async (req: AuthenticatedRequest, res, next) => {
+    try {
+      assertLandlordOrAdmin(req)
+
+      const { tenantId, dealId, paymentTimeliness, propertyCare, communication, overall, comment } = req.body
+
+      if (!tenantId || !dealId) {
+        throw new AppError(ErrorCode.VALIDATION_ERROR, 400, 'tenantId and dealId are required')
+      }
+
+      const rating = await tenantRatingService.submitRating(req.user!.id, tenantId, dealId, {
+        paymentTimeliness,
+        propertyCare,
+        communication,
+        overall,
+        comment,
+      })
+
+      auditLog('TENANT_RATING_SUBMITTED' as any, extractAuditContext(req, 'user'), {
+        tenantId,
+        dealId,
+        ratingId: rating.id,
+        overall,
+      })
+
+      res.status(201).json({ success: true, data: rating })
+    } catch (error) {
+      next(error)
     }
+  })
 
-    const card = await tenantRatingService.getCard(tenantId)
-    res.json({ success: true, data: card })
-  } catch (error) {
-    next(error)
-  }
-})
+  router.get('/ratings/tenant/my-card', authenticateToken, async (req: AuthenticatedRequest, res, next) => {
+    try {
+      const tenantId = req.user?.id
+      if (!tenantId) {
+        throw new AppError(ErrorCode.UNAUTHORIZED, 401, 'User not authenticated')
+      }
 
-router.post('/ratings/tenant/share-token', authenticateToken, async (req: AuthenticatedRequest, res, next) => {
-  try {
-    const tenantId = req.user?.id
-    if (!tenantId) {
-      throw new AppError(ErrorCode.UNAUTHORIZED, 401, 'User not authenticated')
+      const card = await tenantRatingService.getCard(tenantId)
+      res.json({ success: true, data: card })
+    } catch (error) {
+      next(error)
     }
+  })
 
-    const token = await tenantRatingService.generateShareToken(tenantId)
+  router.post('/ratings/tenant/share-token', authenticateToken, async (req: AuthenticatedRequest, res, next) => {
+    try {
+      const tenantId = req.user?.id
+      if (!tenantId) {
+        throw new AppError(ErrorCode.UNAUTHORIZED, 401, 'User not authenticated')
+      }
 
-    auditLog('TENANT_RATING_SHARE_TOKEN_GENERATED' as any, extractAuditContext(req, 'user'), {
-      tenantId,
-      tokenId: token.id,
-      expiresAt: token.expiresAt.toISOString(),
-    })
+      const token = await tenantRatingService.generateShareToken(tenantId)
 
-    res.status(201).json({
-      success: true,
-      data: {
-        token: token.token,
+      auditLog('TENANT_RATING_SHARE_TOKEN_GENERATED' as any, extractAuditContext(req, 'user'), {
+        tenantId,
+        tokenId: token.id,
         expiresAt: token.expiresAt.toISOString(),
-      },
-    })
-  } catch (error) {
-    next(error)
-  }
-})
+      })
 
-router.get('/public/tenant-rating/:token', publicTenantRatingRateLimit(), async (req, res, next) => {
-  try {
-    const { token } = req.params
-    const card = await tenantRatingService.getCardByToken(token)
-
-    if (!card) {
-      throw new AppError(ErrorCode.NOT_FOUND, 404, 'Rating card not found or token has expired')
+      res.status(201).json({
+        success: true,
+        data: {
+          token: token.token,
+          expiresAt: token.expiresAt.toISOString(),
+        },
+      })
+    } catch (error) {
+      next(error)
     }
+  })
 
-    res.json({ success: true, data: card })
-  } catch (error) {
-    next(error)
-  }
-})
+  router.get('/public/tenant-rating/:token', publicTenantRatingRateLimit(), async (req, res, next) => {
+    try {
+      const { token } = req.params
+      const card = await tenantRatingService.getCardByToken(token)
 
-export function createTenantRatingCardRouter() {
+      if (!card) {
+        throw new AppError(ErrorCode.NOT_FOUND, 404, 'Rating card not found or token has expired')
+      }
+
+      res.json({ success: true, data: card })
+    } catch (error) {
+      next(error)
+    }
+  })
+
+  router.get(
+    '/ratings/tenant/on-chain/:tenantId',
+    authenticateToken,
+    async (req: AuthenticatedRequest, res, next) => {
+      try {
+        if (!adapter) {
+          throw new AppError(ErrorCode.SERVICE_UNAVAILABLE, 503, 'On-chain reputation service is not configured')
+        }
+        const { tenantId } = req.params
+        const onChainService = new TenantReputationOnChainService(adapter)
+        const record = await onChainService.getReputation(tenantId)
+        res.json({ success: true, data: record })
+      } catch (error) {
+        next(error)
+      }
+    },
+  )
+
   return router
 }

--- a/backend/src/services/tenantRatingService.ts
+++ b/backend/src/services/tenantRatingService.ts
@@ -1,6 +1,8 @@
 import { tenantRatingRepository, TenantRating, RatingAggregate, RatingCardToken } from '../repositories/TenantRatingRepository.js'
 import { AppError } from '../errors/AppError.js'
 import { ErrorCode } from '../errors/errorCodes.js'
+import { logger } from '../utils/logger.js'
+import { TenantReputationOnChainService } from './tenantReputationOnChainService.js'
 
 export interface SubmitRatingInput {
   paymentTimeliness: number
@@ -11,6 +13,12 @@ export interface SubmitRatingInput {
 }
 
 export class TenantRatingService {
+  private onChainService?: TenantReputationOnChainService
+
+  setOnChainService(svc: TenantReputationOnChainService): void {
+    this.onChainService = svc
+  }
+
   async submitRating(
     landlordId: string,
     tenantId: string,
@@ -24,7 +32,7 @@ export class TenantRatingService {
       throw new AppError(ErrorCode.DUPLICATE_REQUEST, 409, 'You have already rated this tenant for this deal')
     }
 
-    return tenantRatingRepository.create({
+    const rating = await tenantRatingRepository.create({
       tenantId,
       landlordId,
       dealId,
@@ -34,6 +42,29 @@ export class TenantRatingService {
       overall: input.overall,
       comment: input.comment,
     })
+
+    this.anchorReputationAsync(tenantId, rating.id)
+
+    return rating
+  }
+
+  private anchorReputationAsync(tenantId: string, ratingId: string): void {
+    if (!this.onChainService) return
+
+    const svc = this.onChainService
+    tenantRatingRepository
+      .getAggregate(tenantId)
+      .then((aggregate) => {
+        if (!aggregate) return
+        return svc.enqueueReputationUpdate(tenantId, aggregate, ratingId)
+      })
+      .catch((err) => {
+        logger.error('Failed to enqueue on-chain reputation update', {
+          tenantId,
+          ratingId,
+          error: err instanceof Error ? err.message : String(err),
+        })
+      })
   }
 
   async getCard(tenantId: string): Promise<{

--- a/backend/src/services/tenantReputationOnChainService.test.ts
+++ b/backend/src/services/tenantReputationOnChainService.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { TenantReputationOnChainService } from './tenantReputationOnChainService.js'
+import { StubSorobanAdapter } from '../soroban/stub-adapter.js'
+import { outboxStore } from '../outbox/store.js'
+import { OutboxStatus, TxType } from '../outbox/types.js'
+import type { RatingAggregate } from '../repositories/TenantRatingRepository.js'
+
+vi.mock('../outbox/store.js', () => ({
+  outboxStore: {
+    create: vi.fn(),
+    getByExternalRef: vi.fn(),
+  },
+}))
+
+vi.mock('../utils/logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() },
+}))
+
+const makeAdapter = () =>
+  new StubSorobanAdapter({ rpcUrl: 'http://stub', contractId: 'stub-contract' })
+
+const makeAggregate = (overrides: Partial<RatingAggregate> = {}): RatingAggregate => ({
+  tenantId: 'tenant-1',
+  overallAvg: 4.0,
+  paymentTimelinessAvg: 4.5,
+  propertyCareAvg: 3.5,
+  communicationAvg: 5.0,
+  totalRatings: 3,
+  ...overrides,
+})
+
+describe('TenantReputationOnChainService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    StubSorobanAdapter._testOnlyReset()
+  })
+
+  describe('enqueueReputationUpdate', () => {
+    it('creates an outbox item with TENANT_REPUTATION_UPDATE type', async () => {
+      const adapter = makeAdapter()
+      const svc = new TenantReputationOnChainService(adapter)
+      const aggregate = makeAggregate()
+
+      vi.mocked(outboxStore.create).mockResolvedValue({} as any)
+
+      await svc.enqueueReputationUpdate('tenant-1', aggregate, 'rating-abc')
+
+      expect(outboxStore.create).toHaveBeenCalledOnce()
+      const call = vi.mocked(outboxStore.create).mock.calls[0][0]
+      expect(call.txType).toBe(TxType.TENANT_REPUTATION_UPDATE)
+      expect(call.source).toBe('tenant_reputation')
+      expect(call.ref).toBe('tenant-1:rating-abc')
+      expect(call.aggregateType).toBe('TenantReputation')
+      expect(call.aggregateId).toBe('tenant-1')
+    })
+
+    it('maps off-chain 1–5 scores to 0–1000 on-chain scores', async () => {
+      const adapter = makeAdapter()
+      const svc = new TenantReputationOnChainService(adapter)
+
+      vi.mocked(outboxStore.create).mockResolvedValue({} as any)
+
+      await svc.enqueueReputationUpdate(
+        'tenant-1',
+        makeAggregate({
+          overallAvg: 5.0,
+          paymentTimelinessAvg: 4.0,
+          propertyCareAvg: 3.5,
+          communicationAvg: 2.5,
+          totalRatings: 10,
+        }),
+        'rating-xyz',
+      )
+
+      const payload = vi.mocked(outboxStore.create).mock.calls[0][0].payload
+      expect(payload.compositeScore).toBe(1000)   // 5.0 × 200
+      expect(payload.paymentScore).toBe(800)       // 4.0 × 200
+      expect(payload.propertyCareScore).toBe(700)  // 3.5 × 200
+      expect(payload.communicationScore).toBe(500) // 2.5 × 200
+      expect(payload.totalRatings).toBe(10)
+    })
+
+    it('is idempotent: the same ratingId canonical ref is a no-op on replay', async () => {
+      const adapter = makeAdapter()
+      const svc = new TenantReputationOnChainService(adapter)
+
+      vi.mocked(outboxStore.create).mockResolvedValue({
+        id: 'existing-item',
+        status: OutboxStatus.PENDING,
+      } as any)
+
+      await svc.enqueueReputationUpdate('tenant-1', makeAggregate(), 'rating-same')
+      await svc.enqueueReputationUpdate('tenant-1', makeAggregate(), 'rating-same')
+
+      // Both calls hit outboxStore.create; the store's ON CONFLICT deduplicates
+      expect(outboxStore.create).toHaveBeenCalledTimes(2)
+      // Both calls use the same canonical ref
+      const refs = vi.mocked(outboxStore.create).mock.calls.map((c) => c[0].ref)
+      expect(refs[0]).toBe(refs[1])
+    })
+
+    it('creates distinct outbox items for distinct ratingIds', async () => {
+      const adapter = makeAdapter()
+      const svc = new TenantReputationOnChainService(adapter)
+
+      vi.mocked(outboxStore.create).mockResolvedValue({} as any)
+
+      await svc.enqueueReputationUpdate('tenant-1', makeAggregate(), 'rating-1')
+      await svc.enqueueReputationUpdate('tenant-1', makeAggregate(), 'rating-2')
+
+      const refs = vi.mocked(outboxStore.create).mock.calls.map((c) => c[0].ref)
+      expect(refs[0]).toBe('tenant-1:rating-1')
+      expect(refs[1]).toBe('tenant-1:rating-2')
+    })
+  })
+
+  describe('getReputation', () => {
+    it('returns null when no reputation has been anchored', async () => {
+      const adapter = makeAdapter()
+      const svc = new TenantReputationOnChainService(adapter)
+
+      const result = await svc.getReputation('tenant-unknown')
+      expect(result).toBeNull()
+    })
+
+    it('returns the record after updateTenantReputation is called on the adapter', async () => {
+      const adapter = makeAdapter()
+      const svc = new TenantReputationOnChainService(adapter)
+
+      await adapter.updateTenantReputation!('tenant-1', {
+        compositeScore: 800,
+        paymentScore: 900,
+        propertyCareScore: 700,
+        communicationScore: 800,
+        totalRatings: 5,
+        lastUpdated: 0n,
+      })
+
+      const record = await svc.getReputation('tenant-1')
+      expect(record).not.toBeNull()
+      expect(record!.compositeScore).toBe(800)
+      expect(record!.paymentScore).toBe(900)
+      expect(record!.totalRatings).toBe(5)
+    })
+
+    it('returns null and logs a warning when adapter does not support getTenantReputation', async () => {
+      const adapter = makeAdapter()
+      adapter.getTenantReputation = undefined
+      const svc = new TenantReputationOnChainService(adapter)
+
+      const result = await svc.getReputation('tenant-1')
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('score mapping edge cases', () => {
+    it('maps a minimum average of 1.0 to score 200', async () => {
+      const adapter = makeAdapter()
+      const svc = new TenantReputationOnChainService(adapter)
+
+      vi.mocked(outboxStore.create).mockResolvedValue({} as any)
+
+      await svc.enqueueReputationUpdate(
+        'tenant-1',
+        makeAggregate({ overallAvg: 1.0 }),
+        'rating-min',
+      )
+
+      const payload = vi.mocked(outboxStore.create).mock.calls[0][0].payload
+      expect(payload.compositeScore).toBe(200)
+    })
+
+    it('rounds fractional scores correctly', async () => {
+      const adapter = makeAdapter()
+      const svc = new TenantReputationOnChainService(adapter)
+
+      vi.mocked(outboxStore.create).mockResolvedValue({} as any)
+
+      await svc.enqueueReputationUpdate(
+        'tenant-1',
+        makeAggregate({ overallAvg: 3.333 }),
+        'rating-frac',
+      )
+
+      const payload = vi.mocked(outboxStore.create).mock.calls[0][0].payload
+      // 3.333 × 200 = 666.6 → rounds to 667
+      expect(payload.compositeScore).toBe(667)
+    })
+  })
+})

--- a/backend/src/services/tenantReputationOnChainService.ts
+++ b/backend/src/services/tenantReputationOnChainService.ts
@@ -1,0 +1,83 @@
+import { RatingAggregate } from '../repositories/TenantRatingRepository.js'
+import { outboxStore } from '../outbox/store.js'
+import { TxType } from '../outbox/types.js'
+import { SorobanAdapter, TenantReputationRecord } from '../soroban/adapter.js'
+import { logger } from '../utils/logger.js'
+
+/**
+ * Score mapping: off-chain 1–5 avg → on-chain 0–1000 scale.
+ *
+ * Contract fields       ← Off-chain field          Formula
+ * composite_score       ← overallAvg               round(avg × 200)
+ * payment_score         ← paymentTimelinessAvg     round(avg × 200)
+ * property_care_score   ← propertyCareAvg          round(avg × 200)
+ * communication_score   ← communicationAvg         round(avg × 200)
+ *
+ * Rationale: 5.0 × 200 = 1000 (contract max), 1.0 × 200 = 200 (practical min).
+ */
+function toOnChainScore(avg: number): number {
+  return Math.round(avg * 200)
+}
+
+/**
+ * Anchors a tenant's off-chain aggregate reputation on-chain via the
+ * tenant_reputation Soroban contract.
+ *
+ * Write path: enqueueReputationUpdate → outbox → OutboxSender → adapter.updateTenantReputation
+ * Read path:  getReputation → adapter.getTenantReputation
+ */
+export class TenantReputationOnChainService {
+  constructor(private readonly adapter: SorobanAdapter) {}
+
+  /**
+   * Enqueue an on-chain reputation update for tenantId.
+   *
+   * Uses the outbox so a chain failure never fails the rating DB write.
+   * The canonical ref includes the ratingId so each new rating submission
+   * creates a distinct outbox event; the contract SET semantics ensure
+   * replaying the same event is idempotent.
+   */
+  async enqueueReputationUpdate(
+    tenantId: string,
+    aggregate: RatingAggregate,
+    ratingId: string,
+  ): Promise<void> {
+    const payload = {
+      tenantId,
+      compositeScore: toOnChainScore(aggregate.overallAvg),
+      paymentScore: toOnChainScore(aggregate.paymentTimelinessAvg),
+      propertyCareScore: toOnChainScore(aggregate.propertyCareAvg),
+      communicationScore: toOnChainScore(aggregate.communicationAvg),
+      totalRatings: aggregate.totalRatings,
+    }
+
+    await outboxStore.create({
+      txType: TxType.TENANT_REPUTATION_UPDATE,
+      source: 'tenant_reputation',
+      ref: `${tenantId}:${ratingId}`,
+      payload,
+      aggregateType: 'TenantReputation',
+      aggregateId: tenantId,
+      eventType: 'ReputationUpdated',
+    })
+
+    logger.info('Enqueued on-chain reputation update', {
+      tenantId,
+      ratingId,
+      compositeScore: payload.compositeScore,
+      totalRatings: payload.totalRatings,
+    })
+  }
+
+  /**
+   * Fetch the current on-chain reputation for a tenant (verification read path).
+   * Returns null if the adapter does not support the operation or no record exists.
+   */
+  async getReputation(tenantId: string): Promise<TenantReputationRecord | null> {
+    if (!this.adapter.getTenantReputation) {
+      logger.warn('Adapter does not support getTenantReputation; skipping on-chain read', { tenantId })
+      return null
+    }
+    return this.adapter.getTenantReputation(tenantId)
+  }
+}

--- a/backend/src/soroban/adapter.ts
+++ b/backend/src/soroban/adapter.ts
@@ -44,6 +44,19 @@ export interface TxOnChainStatus {
   ledger?: number
 }
 
+/**
+ * On-chain representation of a tenant's aggregated reputation.
+ * Scores are on a 0–1000 scale (off-chain 1–5 avg × 200).
+ */
+export interface TenantReputationRecord {
+  compositeScore: number
+  paymentScore: number
+  propertyCareScore: number
+  communicationScore: number
+  totalRatings: number
+  lastUpdated: bigint
+}
+
 export interface SorobanAdapter {
   getBalance(account: string): Promise<bigint>
   credit(account: string, amount: bigint): Promise<void>
@@ -72,6 +85,10 @@ export interface SorobanAdapter {
    * may omit this method; the sender will fall back to blind resubmission.
    */
   getTransactionStatus?(txHash: string): Promise<TxOnChainStatus>
+
+  // Tenant reputation contract (tenant_reputation)
+  updateTenantReputation?(tenantId: string, record: TenantReputationRecord): Promise<void>
+  getTenantReputation?(tenantId: string): Promise<TenantReputationRecord | null>
 
   // Admin operations (require SOROBAN_ADMIN_SIGNING_ENABLED=true)
   pause?(contractId: string): Promise<string>

--- a/backend/src/soroban/circuit-breaker-adapter.ts
+++ b/backend/src/soroban/circuit-breaker-adapter.ts
@@ -7,7 +7,7 @@ import {
 } from './circuit-breaker-errors.js'
 import { CircuitBreaker } from './circuit-breaker.js'
 import { CircuitBreakerConfig } from './circuit-breaker-config.js'
-import { SorobanAdapter, RecordReceiptParams } from './adapter.js'
+import { SorobanAdapter, RecordReceiptParams, TenantReputationRecord } from './adapter.js'
 import { SorobanConfig } from './client.js'
 import { RawReceiptEvent } from '../indexer/event-parser.js'
 
@@ -257,6 +257,24 @@ export class CircuitBreakerAdapter implements SorobanAdapter {
     }
     return this.executeWithCircuitBreaker('init', () =>
       this.wrappedAdapter.init!(contractId, adminAddress, operatorAddress),
+    )
+  }
+
+  async updateTenantReputation?(tenantId: string, record: TenantReputationRecord): Promise<void> {
+    if (!this.wrappedAdapter.updateTenantReputation) {
+      throw new Error('updateTenantReputation not supported by wrapped adapter')
+    }
+    return this.executeWithCircuitBreaker('updateTenantReputation', () =>
+      this.wrappedAdapter.updateTenantReputation!(tenantId, record),
+    )
+  }
+
+  async getTenantReputation?(tenantId: string): Promise<TenantReputationRecord | null> {
+    if (!this.wrappedAdapter.getTenantReputation) {
+      throw new Error('getTenantReputation not supported by wrapped adapter')
+    }
+    return this.executeWithCircuitBreaker('getTenantReputation', () =>
+      this.wrappedAdapter.getTenantReputation!(tenantId),
     )
   }
 }

--- a/backend/src/soroban/metrics-adapter.ts
+++ b/backend/src/soroban/metrics-adapter.ts
@@ -4,7 +4,7 @@
  * Wraps any SorobanAdapter to automatically track RPC call metrics
  */
 
-import { SorobanAdapter, RecordReceiptParams } from './adapter.js';
+import { SorobanAdapter, RecordReceiptParams, TenantReputationRecord } from './adapter.js';
 import { SorobanConfig } from './client.js';
 import { RawReceiptEvent } from '../indexer/event-parser.js';
 import { recordSorobanRpcCall } from '../utils/metrics.js';
@@ -98,6 +98,24 @@ export class MetricsSorobanAdapter implements SorobanAdapter {
     }
     return this.trackCall('init', () =>
       this.wrapped.init!(contractId, adminAddress, operatorAddress)
+    );
+  }
+
+  async updateTenantReputation?(tenantId: string, record: TenantReputationRecord): Promise<void> {
+    if (!this.wrapped.updateTenantReputation) {
+      throw new Error('updateTenantReputation not implemented');
+    }
+    return this.trackCall('updateTenantReputation', () =>
+      this.wrapped.updateTenantReputation!(tenantId, record)
+    );
+  }
+
+  async getTenantReputation?(tenantId: string): Promise<TenantReputationRecord | null> {
+    if (!this.wrapped.getTenantReputation) {
+      throw new Error('getTenantReputation not implemented');
+    }
+    return this.trackCall('getTenantReputation', () =>
+      this.wrapped.getTenantReputation!(tenantId)
     );
   }
 

--- a/backend/src/soroban/stub-adapter.ts
+++ b/backend/src/soroban/stub-adapter.ts
@@ -1,4 +1,4 @@
-import { SorobanAdapter, RecordReceiptParams, SyncDealStatusParams } from './adapter.js'
+import { SorobanAdapter, RecordReceiptParams, SyncDealStatusParams, TenantReputationRecord } from './adapter.js'
 import { SorobanConfig } from './client.js'
 import { RawReceiptEvent } from '../indexer/event-parser.js'
 import { logger } from '../utils/logger.js'
@@ -7,6 +7,7 @@ import { logger } from '../utils/logger.js'
 export class StubSorobanAdapter implements SorobanAdapter {
      private static stubBalances = new Map<string, bigint>()
      private static stubBonds = new Map<string, bigint>()
+     private static stubReputations = new Map<string, TenantReputationRecord>()
      private config: SorobanConfig
 
      constructor(config: SorobanConfig) {
@@ -24,7 +25,8 @@ export class StubSorobanAdapter implements SorobanAdapter {
      public static _testOnlyReset(): void {
           this.stubBalances.clear()
           this.stubBonds.clear()
-          logger.debug('Soroban stub: static reset complete (balances and bonds cleared)')
+          this.stubReputations.clear()
+          logger.debug('Soroban stub: static reset complete (balances, bonds, and reputations cleared)')
      }
 
      /**
@@ -217,5 +219,20 @@ export class StubSorobanAdapter implements SorobanAdapter {
 
      async syncDealStatus(params: SyncDealStatusParams): Promise<void> {
           logger.info('Soroban stub: syncDealStatus', { ...params })
+     }
+
+     async updateTenantReputation(tenantId: string, record: TenantReputationRecord): Promise<void> {
+          const updated: TenantReputationRecord = {
+               ...record,
+               lastUpdated: BigInt(Math.floor(Date.now() / 1000)),
+          }
+          StubSorobanAdapter.stubReputations.set(tenantId, updated)
+          logger.info('Soroban stub: updateTenantReputation', { tenantId, compositeScore: record.compositeScore })
+     }
+
+     async getTenantReputation(tenantId: string): Promise<TenantReputationRecord | null> {
+          const record = StubSorobanAdapter.stubReputations.get(tenantId) ?? null
+          logger.debug('Soroban stub: getTenantReputation', { tenantId, found: record !== null })
+          return record
      }
 }


### PR DESCRIPTION
## Summary

Bridges the `contracts/tenant_reputation/` Soroban contract and the backend's off-chain Tenant Rating Card. Whenever a landlord submits a rating, the recomputed aggregate is asynchronously enqueued for on-chain anchoring via the existing outbox pattern — so a chain failure never fails the underlying DB write, and the aggregate becomes portable and tamper-evident on Stellar.

## Linked issue

Closes #1075

## Changes

- **`outbox/types.ts`** — adds `TENANT_REPUTATION_UPDATE` to `TxType`
- **`soroban/adapter.ts`** — adds `TenantReputationRecord` type and optional `updateTenantReputation` / `getTenantReputation` methods to `SorobanAdapter`
- **`soroban/stub-adapter.ts`** — in-memory stub implementations of the two new methods; `_testOnlyReset` also clears reputation state
- **`soroban/circuit-breaker-adapter.ts`** — delegates new methods through the circuit breaker
- **`soroban/metrics-adapter.ts`** — delegates new methods through metrics tracking
- **`outbox/sender.ts`** — handles `TENANT_REPUTATION_UPDATE` in the dispatch switch via a new `sendTenantReputationUpdate` method
- **`services/tenantReputationOnChainService.ts`** *(new)* — core service:
  - **Score mapping** (documented inline): off-chain 1–5 avg × 200 → on-chain 0–1000 (`composite_score`, `payment_score`, `property_care_score`, `communication_score`)
  - `enqueueReputationUpdate(tenantId, aggregate, ratingId)` — creates an outbox item keyed on `tenant_reputation:{tenantId}:{ratingId}`; the contract's SET semantics make replay idempotent
  - `getReputation(tenantId)` — read path via `adapter.getTenantReputation`
- **`services/tenantRatingService.ts`** — after each `submitRating`, fires-and-forgets `anchorReputationAsync` which fetches the fresh aggregate and calls `enqueueReputationUpdate`; errors are caught and logged, never surfaced to the caller
- **`routes/tenantRatingCard.ts`** — refactored to a proper factory (`createTenantRatingCardRouter(adapter?)`) that wires the on-chain service when an adapter is provided; adds `GET /api/v1/ratings/tenant/on-chain/:tenantId` for verification reads
- **`app.ts`** — passes `sorobanAdapter` to `createTenantRatingCardRouter`
- **`services/tenantReputationOnChainService.test.ts`** *(new)* — 9 unit tests covering enqueue arg correctness, score mapping (including edge cases and rounding), idempotency semantics, read path against `StubSorobanAdapter`, and graceful no-op when adapter lacks the method

## Checklist

- [x] I tested locally
- [x] I did not commit secrets
- [x] I updated docs if needed
- [x] `npm run typecheck` passes (no new errors introduced)
- [x] `npm run lint` passes (no new errors)
- [x] Unit tests pass: 9/9 (`tenantReputationOnChainService.test.ts`)
- [ ] If UI changes: I included before/after screenshots — N/A (backend only)
- [ ] If images added/changed: I verified they are optimized and accessible — N/A