### PR TITLE
Contract Hardening: Reward Conservation, Multisig TTL, Oracle Aggregation, Tiered Slashing

### DIFF
--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -951,6 +951,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "multisig_admin"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "mvp-staking-pool"
 version = "0.1.0"
 dependencies = [

--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -27,6 +27,7 @@ members = [
   "inspector_bond",
   "rent_to_own",
   "governance",
+  "multisig_admin",
 ]
 
 [profile.release]

--- a/contracts/epoch_rewards/src/lib.rs
+++ b/contracts/epoch_rewards/src/lib.rs
@@ -19,6 +19,8 @@ pub enum DataKey {
     EpochRewardIndex(u64),
     /// Global reward index (scaled by SCALE)
     RewardIndex,
+    /// Reward index at the start of each epoch (for dust computation)
+    EpochStartIndex(u64),
     /// Total staked across all users
     TotalStaked,
     /// Per-user stake info
@@ -50,6 +52,8 @@ pub enum ContractError {
     EpochNotExpired = 7,
     /// Contract is paused
     Paused = 8,
+    /// Claim attempted before any epoch has been sealed
+    ClaimBeforeSeal = 9,
 }
 
 // ── Data Structures ───────────────────────────────────────────────────────────
@@ -70,6 +74,10 @@ pub struct EpochInfo {
     pub carried_forward: i128,
     /// Reward index snapshot at seal time
     pub reward_index_at_seal: i128,
+    /// Rounding dust accumulated in this epoch (funded - actually distributed)
+    pub dust: i128,
+    /// Total claimable computed at seal time (Σ claimable ≤ total_rewards invariant)
+    pub total_claimable_at_seal: i128,
 }
 
 #[contracttype]
@@ -103,7 +111,7 @@ impl EpochRewards {
             .persistent()
             .set(&DataKey::TotalStaked, &0i128);
 
-        // Initialise epoch 1
+        // Initialise epoch 1 and record its start reward index (0)
         let epoch1 = EpochInfo {
             epoch_number: 1,
             start_ts: env.ledger().timestamp(),
@@ -114,8 +122,13 @@ impl EpochRewards {
             total_rewards: 0,
             carried_forward: 0,
             reward_index_at_seal: 0,
+            dust: 0,
+            total_claimable_at_seal: 0,
         };
         env.storage().persistent().set(&DataKey::Epoch(1), &epoch1);
+        env.storage()
+            .persistent()
+            .set(&DataKey::EpochStartIndex(1), &0i128);
 
         env.events().publish(
             (
@@ -296,6 +309,10 @@ impl EpochRewards {
     // ── Reward funding ────────────────────────────────────────────────────────
 
     /// Fund rewards for the current epoch (operator or admin only).
+    ///
+    /// Uses integer division to update the global reward index. The remainder
+    /// (rounding dust) is tracked in the epoch's `dust` field and reported at
+    /// seal time so no funds are silently lost.
     pub fn fund_epoch_rewards(
         env: Env,
         caller: Address,
@@ -308,6 +325,20 @@ impl EpochRewards {
         }
 
         let total = Self::get_total_staked(&env);
+
+        // Compute rounding dust for this funding event.
+        // delta_index = floor(amount * SCALE / total), so
+        // effectively_distributed = floor(delta_index * total / SCALE)
+        // dust = amount - effectively_distributed
+        let dust_this_funding: i128 = if total > 0 {
+            let delta_index = amount * SCALE / total;
+            let effectively_distributed = delta_index * total / SCALE;
+            amount - effectively_distributed
+        } else {
+            // No stakers: entire amount is dust (not distributed to anyone)
+            amount
+        };
+
         if total > 0 {
             let reward_index = Self::get_reward_index(&env);
             let new_index = reward_index + (amount * SCALE / total);
@@ -316,7 +347,7 @@ impl EpochRewards {
                 .set(&DataKey::RewardIndex, &new_index);
         }
 
-        // Track total rewards for the current epoch
+        // Track total rewards and accumulated dust for the current epoch
         let current_epoch: u64 = env
             .storage()
             .instance()
@@ -328,6 +359,7 @@ impl EpochRewards {
             .get::<_, EpochInfo>(&DataKey::Epoch(current_epoch))
         {
             epoch.total_rewards += amount;
+            epoch.dust += dust_this_funding;
             env.storage()
                 .persistent()
                 .set(&DataKey::Epoch(current_epoch), &epoch);
@@ -347,8 +379,10 @@ impl EpochRewards {
 
     /// Seal the current epoch (or catch up missed epochs).
     ///
-    /// `target_epoch` must be the current unsealed epoch. Call repeatedly to
-    /// catch up if the keeper missed a sealing window.
+    /// After sealing the invariant Σ claimable(epoch) ≤ funded(epoch) is
+    /// enforced by computing total_claimable from the reward-index delta and
+    /// recording dust = funded - total_claimable. Dust is carried to the next
+    /// epoch automatically via the `carry_forward` field.
     pub fn seal_epoch(
         env: Env,
         caller: Address,
@@ -385,12 +419,32 @@ impl EpochRewards {
         // Snapshot reward index at seal time
         let reward_index_at_seal = Self::get_reward_index(&env);
 
-        // Determine unclaimed rewards to carry forward.
-        // "Unclaimed" in the rewards index model means the global index accumulated
-        // rewards that are owed to stakers but not yet claimed.  We carry the epoch's
-        // total_rewards that were funded but not yet claimed by summing epoch state.
-        // Simplified: carry_forward = previously carried + this epoch total_rewards
-        // (actual per-user accounting is lazy via reward index).
+        // Read the reward index at the start of this epoch to compute
+        // exactly how much was distributed to stakers during this epoch.
+        let start_index: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::EpochStartIndex(target_epoch))
+            .unwrap_or(0);
+
+        let total_staked = Self::get_total_staked(&env);
+
+        // total_claimable = floor(total_staked * delta_index / SCALE)
+        // This is the tight upper bound on Σ claimable(epoch).
+        let total_claimable_at_seal: i128 = if total_staked > 0 {
+            total_staked * (reward_index_at_seal - start_index) / SCALE
+        } else {
+            0
+        };
+
+        // Dust = funded - claimable (always ≥ 0 by integer division).
+        // We use epoch.dust already accumulated during fund_epoch_rewards
+        // but recalculate from first principles to keep it consistent.
+        let dust = epoch.total_rewards - total_claimable_at_seal;
+        let dust = if dust < 0 { 0 } else { dust };
+
+        // Determine unclaimed rewards to carry forward to the next epoch.
+        // Includes the rounding dust so it is never silently lost.
         let carry_forward = epoch.carried_forward + epoch.total_rewards;
 
         // Seal this epoch
@@ -398,6 +452,8 @@ impl EpochRewards {
         epoch.seal_ts = now;
         epoch.sealed = true;
         epoch.reward_index_at_seal = reward_index_at_seal;
+        epoch.dust = dust;
+        epoch.total_claimable_at_seal = total_claimable_at_seal;
         env.storage()
             .persistent()
             .set(&DataKey::Epoch(target_epoch), &epoch);
@@ -407,6 +463,11 @@ impl EpochRewards {
         env.storage()
             .instance()
             .set(&DataKey::CurrentEpoch, &next_epoch);
+
+        // Record next epoch's starting reward index for accurate dust tracking
+        env.storage()
+            .persistent()
+            .set(&DataKey::EpochStartIndex(next_epoch), &reward_index_at_seal);
 
         let next_epoch_info = EpochInfo {
             epoch_number: next_epoch,
@@ -418,28 +479,36 @@ impl EpochRewards {
             total_rewards: 0,
             carried_forward: carry_forward,
             reward_index_at_seal: 0,
+            dust: 0,
+            total_claimable_at_seal: 0,
         };
         env.storage()
             .persistent()
             .set(&DataKey::Epoch(next_epoch), &next_epoch_info);
 
-        // Emit epoch-sealed event
+        // Emit epoch_sealed with funded + total_claimable for off-chain verification
         env.events().publish(
             (
                 Symbol::new(&env, "epoch_rewards"),
                 Symbol::new(&env, "epoch_sealed"),
             ),
-            (target_epoch, now, reward_index_at_seal, epoch.total_rewards),
+            (
+                target_epoch,
+                now,
+                reward_index_at_seal,
+                epoch.total_rewards,
+                total_claimable_at_seal,
+            ),
         );
 
-        // Emit carry-forward event if non-zero
-        if carry_forward > 0 {
+        // Emit dust_carried when rounding produced leftover funds
+        if dust > 0 {
             env.events().publish(
                 (
                     Symbol::new(&env, "epoch_rewards"),
-                    Symbol::new(&env, "carry_forward"),
+                    Symbol::new(&env, "dust_carried"),
                 ),
-                (target_epoch, next_epoch, carry_forward),
+                (target_epoch, next_epoch, dust),
             );
         }
 
@@ -448,8 +517,22 @@ impl EpochRewards {
 
     // ── Claim ─────────────────────────────────────────────────────────────────
 
+    /// Claim all pending rewards for `user`.
+    ///
+    /// Requires at least one epoch to have been sealed (current_epoch > 1).
+    /// Idempotent: a second call in the same ledger returns 0.
     pub fn claim(env: Env, user: Address) -> Result<i128, ContractError> {
         user.require_auth();
+
+        // Guard: reject claims before any epoch has been sealed
+        let current_epoch: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::CurrentEpoch)
+            .unwrap_or(1);
+        if current_epoch <= 1 {
+            return Err(ContractError::ClaimBeforeSeal);
+        }
 
         let reward_index = Self::get_reward_index(&env);
         let mut stake = Self::get_user_stake(&env, &user);

--- a/contracts/epoch_rewards/src/tests.rs
+++ b/contracts/epoch_rewards/src/tests.rs
@@ -69,6 +69,16 @@ fn pro_rata_three_stakers() {
     assert!((ra - 500).abs() <= 1, "a expected ~500, got {}", ra);
     assert!((rb - 300).abs() <= 1, "b expected ~300, got {}", rb);
     assert!((rc - 200).abs() <= 1, "c expected ~200, got {}", rc);
+
+    // Conservation: sum of claimable must not exceed funded
+    assert!(
+        ra + rb + rc <= total_reward,
+        "conservation violated: {} + {} + {} > {}",
+        ra,
+        rb,
+        rc,
+        total_reward
+    );
 }
 
 // ── 3. Late joiner ────────────────────────────────────────────────────────────
@@ -105,6 +115,14 @@ fn late_joiner_earns_less() {
     );
     // Late joiner should still earn something (from second funding)
     assert!(late_rewards > 0);
+
+    // Conservation invariant
+    assert!(
+        early_rewards + late_rewards <= 1_000i128,
+        "conservation violated: {} + {} > 1000",
+        early_rewards,
+        late_rewards
+    );
 }
 
 // ── 4. Zero stakers ───────────────────────────────────────────────────────────
@@ -126,6 +144,8 @@ fn zero_stakers_distribute_does_not_panic() {
     let epoch = client.get_epoch(&1).unwrap();
     assert!(epoch.sealed);
     assert_eq!(epoch.total_rewards, 1_000);
+    // All funded amount is dust since no stakers received it
+    assert_eq!(epoch.dust, 1_000);
 }
 
 // ── 5. Epoch boundary ─────────────────────────────────────────────────────────
@@ -241,6 +261,12 @@ fn large_numbers_100_stakers_no_overflow() {
     }
     // Total claimed should be close to total funded (rounding losses ≤ 100)
     assert!((total_claimed - 100_000_000).abs() <= 100);
+    // Conservation: total claimed must never exceed funded
+    assert!(
+        total_claimed <= 100_000_000,
+        "over-distribution: {} > 100_000_000",
+        total_claimed
+    );
 }
 
 // ── 9. Paused state ───────────────────────────────────────────────────────────
@@ -261,4 +287,186 @@ fn distribute_rewards_fails_when_paused() {
     client.unpause(&admin);
     assert!(!client.is_paused());
     assert!(client.try_fund_epoch_rewards(&admin, &1_000).is_ok());
+}
+
+// ── 10. Conservation: uneven stake split ─────────────────────────────────────
+
+#[test]
+fn conservation_uneven_split_sum_never_exceeds_funded() {
+    let env = Env::default();
+    let duration = 100u64;
+    let (admin, client) = setup(&env, duration);
+
+    // Stake amounts that don't divide evenly into the reward
+    let a = Address::generate(&env);
+    let b = Address::generate(&env);
+    let c = Address::generate(&env);
+
+    client.stake(&a, &7);
+    client.stake(&b, &3);
+    client.stake(&c, &1);
+
+    let funded: i128 = 11;
+    client.fund_epoch_rewards(&admin, &funded);
+
+    env.ledger().with_mut(|li| li.timestamp = duration + 1);
+    client.seal_epoch(&admin, &1, &100);
+
+    let ra = client.get_claimable(&a);
+    let rb = client.get_claimable(&b);
+    let rc = client.get_claimable(&c);
+
+    // Core invariant: no over-distribution
+    assert!(
+        ra + rb + rc <= funded,
+        "conservation violated: {} + {} + {} = {} > {}",
+        ra,
+        rb,
+        rc,
+        ra + rb + rc,
+        funded
+    );
+
+    // Dust must be non-negative and equal funded - sum_claimable
+    let epoch = client.get_epoch(&1).unwrap();
+    let dust = epoch.dust;
+    assert!(dust >= 0, "dust should be non-negative, got {}", dust);
+    assert_eq!(
+        dust,
+        funded - ra - rb - rc,
+        "dust mismatch: epoch.dust={} funded-sum={}",
+        dust,
+        funded - ra - rb - rc
+    );
+    assert_eq!(
+        epoch.total_claimable_at_seal,
+        ra + rb + rc,
+        "total_claimable_at_seal should match sum of claimable"
+    );
+}
+
+// ── 11. Dust carry: funded dust is tracked, not silently lost ────────────────
+
+#[test]
+fn dust_tracked_in_epoch_info() {
+    let env = Env::default();
+    let duration = 100u64;
+    let (admin, client) = setup(&env, duration);
+
+    // 3 stakers, total 10 units. Fund 11 → remainder 1 distributes unevenly.
+    let a = Address::generate(&env);
+    let b = Address::generate(&env);
+    let c = Address::generate(&env);
+    client.stake(&a, &4);
+    client.stake(&b, &3);
+    client.stake(&c, &3);
+
+    let funded: i128 = 11;
+    client.fund_epoch_rewards(&admin, &funded);
+
+    env.ledger().with_mut(|li| li.timestamp = duration + 1);
+    client.seal_epoch(&admin, &1, &100);
+
+    let epoch = client.get_epoch(&1).unwrap();
+    assert!(epoch.sealed);
+    // dust must be explicitly tracked
+    assert!(epoch.dust >= 0);
+    // funded = claimable + dust (no funds disappear)
+    assert_eq!(epoch.total_claimable_at_seal + epoch.dust, funded);
+
+    // Next epoch carries the full funded amount (including dust)
+    let epoch2 = client.get_epoch(&2).unwrap();
+    assert_eq!(epoch2.carried_forward, funded);
+}
+
+// ── 12. Claim idempotency ─────────────────────────────────────────────────────
+
+#[test]
+fn claim_is_idempotent() {
+    let env = Env::default();
+    let duration = 100u64;
+    let (admin, client) = setup(&env, duration);
+
+    let user = Address::generate(&env);
+    client.stake(&user, &1_000);
+    client.fund_epoch_rewards(&admin, &500);
+
+    env.ledger().with_mut(|li| li.timestamp = duration + 1);
+    client.seal_epoch(&admin, &1, &100);
+
+    let first = client.claim(&user);
+    assert!(first > 0);
+
+    // Second claim: must return 0 (idempotent, not double-paying)
+    let second = client.claim(&user);
+    assert_eq!(second, 0, "second claim must be 0");
+
+    // Third claim: still 0
+    let third = client.claim(&user);
+    assert_eq!(third, 0, "third claim must be 0");
+}
+
+// ── 13. Claim before seal rejected ───────────────────────────────────────────
+
+#[test]
+fn claim_before_any_seal_is_rejected() {
+    let env = Env::default();
+    let duration = 100u64;
+    let (admin, client) = setup(&env, duration);
+
+    let user = Address::generate(&env);
+    client.stake(&user, &1_000);
+    client.fund_epoch_rewards(&admin, &500);
+
+    // No seal yet — current_epoch is still 1
+    let result = client.try_claim(&user);
+    assert_eq!(
+        result.unwrap_err().unwrap(),
+        ContractError::ClaimBeforeSeal,
+        "claim before any seal must be rejected"
+    );
+}
+
+// ── 14. Full-claim conservation across multiple epochs ───────────────────────
+
+#[test]
+fn full_claim_conservation_multi_epoch() {
+    let env = Env::default();
+    let duration = 100u64;
+    let (admin, client) = setup(&env, duration);
+
+    let a = Address::generate(&env);
+    let b = Address::generate(&env);
+
+    client.stake(&a, &600);
+    client.stake(&b, &400);
+
+    let funded_e1: i128 = 1_000;
+    client.fund_epoch_rewards(&admin, &funded_e1);
+
+    // Seal epoch 1
+    env.ledger().with_mut(|li| li.timestamp = duration + 1);
+    client.seal_epoch(&admin, &1, &100);
+
+    // Epoch 2 funding
+    let funded_e2: i128 = 500;
+    client.fund_epoch_rewards(&admin, &funded_e2);
+
+    // Seal epoch 2
+    env.ledger().with_mut(|li| li.timestamp = 2 * duration + 2);
+    client.seal_epoch(&admin, &2, &100);
+
+    // Both users claim
+    let ra = client.claim(&a);
+    let rb = client.claim(&b);
+
+    let total_funded = funded_e1 + funded_e2;
+    assert!(
+        ra + rb <= total_funded,
+        "over-distribution across epochs: {} + {} = {} > {}",
+        ra,
+        rb,
+        ra + rb,
+        total_funded
+    );
 }

--- a/contracts/multisig_admin/src/lib.rs
+++ b/contracts/multisig_admin/src/lib.rs
@@ -91,6 +91,11 @@ impl MultisigAdmin {
         if !cfg.signers.contains(&proposer) {
             panic!("NotASigner");
         }
+        // Reject proposals with an expiry already in the past
+        let now = env.ledger().timestamp();
+        if expiry != 0 && now >= expiry {
+            panic!("ProposalExpired");
+        }
         let id: u64 = env
             .storage()
             .instance()
@@ -141,6 +146,23 @@ impl MultisigAdmin {
         } else {
             panic!("NotPending");
         }
+        // Reject approval on expired proposals and emit the expired event
+        let now = env.ledger().timestamp();
+        if prop.expiry != 0 && now > prop.expiry {
+            let mut expired_prop = prop.clone();
+            expired_prop.status = ProposalStatus::Expired;
+            env.storage()
+                .instance()
+                .set(&DataKey::Proposal(proposal_id), &expired_prop);
+            env.events().publish(
+                (
+                    Symbol::new(&env, "multisig_admin"),
+                    Symbol::new(&env, "proposal_expired"),
+                ),
+                proposal_id,
+            );
+            panic!("ProposalExpired");
+        }
         let mut approvals: Vec<Address> = env
             .storage()
             .instance()
@@ -162,6 +184,68 @@ impl MultisigAdmin {
             (
                 Symbol::new(&env, "multisig_admin"),
                 Symbol::new(&env, "proposal_approved"),
+            ),
+            (proposal_id, signer),
+        );
+    }
+
+    /// Revoke a prior approval from `signer` for `proposal_id`.
+    ///
+    /// Lowers the live approval count. If count drops below threshold the
+    /// proposal cannot be executed until re-approved. The proposal must still
+    /// be Pending and not expired.
+    pub fn revoke_approval(env: Env, signer: Address, proposal_id: u64) {
+        signer.require_auth();
+        let cfg: Config = env
+            .storage()
+            .instance()
+            .get(&DataKey::Config)
+            .expect("NotInitialized");
+        if !cfg.signers.contains(&signer) {
+            panic!("NotASigner");
+        }
+        let prop: Proposal = env
+            .storage()
+            .instance()
+            .get(&DataKey::Proposal(proposal_id))
+            .expect("UnknownProposal");
+        if let ProposalStatus::Pending = prop.status {
+        } else {
+            panic!("NotPending");
+        }
+        // Reject revocation on already-expired proposals
+        let now = env.ledger().timestamp();
+        if prop.expiry != 0 && now > prop.expiry {
+            panic!("ProposalExpired");
+        }
+        let approvals: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::Approvals(proposal_id))
+            .unwrap_or_else(|| Vec::new(&env));
+        if !approvals.contains(&signer) {
+            panic!("NotApproved");
+        }
+        // Rebuild the approvals list without the revoking signer
+        let mut new_approvals: Vec<Address> = Vec::new(&env);
+        for i in 0..approvals.len() {
+            let addr = approvals.get(i).unwrap();
+            if addr != signer {
+                new_approvals.push_back(addr);
+            }
+        }
+        let mut updated_prop = prop;
+        updated_prop.approval_count = new_approvals.len() as u32;
+        env.storage()
+            .instance()
+            .set(&DataKey::Approvals(proposal_id), &new_approvals);
+        env.storage()
+            .instance()
+            .set(&DataKey::Proposal(proposal_id), &updated_prop);
+        env.events().publish(
+            (
+                Symbol::new(&env, "multisig_admin"),
+                Symbol::new(&env, "approval_revoked"),
             ),
             (proposal_id, signer),
         );
@@ -192,8 +276,16 @@ impl MultisigAdmin {
             env.storage()
                 .instance()
                 .set(&DataKey::Proposal(proposal_id), &prop);
+            env.events().publish(
+                (
+                    Symbol::new(&env, "multisig_admin"),
+                    Symbol::new(&env, "proposal_expired"),
+                ),
+                proposal_id,
+            );
             panic!("ProposalExpired");
         }
+        // Re-check live approval count (may have been lowered by revocations)
         let approvals: Vec<Address> = env
             .storage()
             .instance()
@@ -550,5 +642,163 @@ mod test {
         assert_eq!(client.get_proposal(&id).approval_count, 1);
         client.approve(&b, &id);
         assert_eq!(client.get_proposal(&id).approval_count, 2);
+    }
+
+    // ── TTL / expiry on approve ───────────────────────────────────────────────
+
+    #[test]
+    #[should_panic(expected = "ProposalExpired")]
+    fn expiry_blocks_approve() {
+        let env = Env::default();
+        let (a, b, _c, signers) = setup(&env);
+        env.mock_all_auths();
+        let contract_id = env.register(MultisigAdmin, ());
+        let client = MultisigAdminClient::new(&env, &contract_id);
+        client.init(&signers, &2u32);
+
+        let expiry = env.ledger().timestamp() + 10;
+        let id = client.propose(
+            &a,
+            &OperationType::FreezeAccount,
+            &Bytes::from_slice(&env, b"{}"),
+            &expiry,
+        );
+        // Advance past expiry
+        env.ledger().set_timestamp(expiry + 1);
+        // Approve on an expired proposal must panic
+        client.approve(&b, &id);
+    }
+
+    // ── Revocation ───────────────────────────────────────────────────────────
+
+    #[test]
+    #[should_panic(expected = "NotEnoughApprovals")]
+    fn revoke_below_threshold_blocks_execute() {
+        let env = Env::default();
+        let (a, b, _c, signers) = setup(&env);
+        env.mock_all_auths();
+        let contract_id = env.register(MultisigAdmin, ());
+        let client = MultisigAdminClient::new(&env, &contract_id);
+        client.init(&signers, &2u32);
+
+        let id = client.propose(
+            &a,
+            &OperationType::FreezeAccount,
+            &Bytes::from_slice(&env, b"{}"),
+            &0u64,
+        );
+        client.approve(&a, &id);
+        client.approve(&b, &id);
+        assert_eq!(client.get_proposal(&id).approval_count, 2);
+
+        // Revoke one — drops below threshold
+        client.revoke_approval(&b, &id);
+        assert_eq!(client.get_proposal(&id).approval_count, 1);
+
+        // Execute must fail: only 1 of 2 required approvals
+        client.execute(&a, &id);
+    }
+
+    #[test]
+    fn revoke_then_reapprove_succeeds() {
+        let env = Env::default();
+        let (a, b, _c, signers) = setup(&env);
+        env.mock_all_auths();
+        let contract_id = env.register(MultisigAdmin, ());
+        let client = MultisigAdminClient::new(&env, &contract_id);
+        client.init(&signers, &2u32);
+
+        let id = client.propose(
+            &a,
+            &OperationType::FreezeAccount,
+            &Bytes::from_slice(&env, b"{}"),
+            &0u64,
+        );
+        client.approve(&a, &id);
+        client.approve(&b, &id);
+
+        // B revokes their approval
+        client.revoke_approval(&b, &id);
+        assert_eq!(client.get_proposal(&id).approval_count, 1);
+
+        // B re-approves — count is back to 2
+        client.approve(&b, &id);
+        assert_eq!(client.get_proposal(&id).approval_count, 2);
+
+        // Execute must now succeed
+        client.execute(&a, &id);
+        let prop = client.get_proposal(&id);
+        match prop.status {
+            ProposalStatus::Executed => {}
+            _ => panic!("expected executed"),
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "NotApproved")]
+    fn revoke_without_prior_approval_panics() {
+        let env = Env::default();
+        let (a, b, _c, signers) = setup(&env);
+        env.mock_all_auths();
+        let contract_id = env.register(MultisigAdmin, ());
+        let client = MultisigAdminClient::new(&env, &contract_id);
+        client.init(&signers, &2u32);
+
+        let id = client.propose(
+            &a,
+            &OperationType::FreezeAccount,
+            &Bytes::from_slice(&env, b"{}"),
+            &0u64,
+        );
+        // B never approved — revoke must panic
+        client.revoke_approval(&b, &id);
+    }
+
+    #[test]
+    #[should_panic(expected = "NotASigner")]
+    fn non_signer_cannot_revoke() {
+        let env = Env::default();
+        let (a, _b, _c, signers) = setup(&env);
+        env.mock_all_auths();
+        let contract_id = env.register(MultisigAdmin, ());
+        let client = MultisigAdminClient::new(&env, &contract_id);
+        client.init(&signers, &2u32);
+
+        let id = client.propose(
+            &a,
+            &OperationType::FreezeAccount,
+            &Bytes::from_slice(&env, b"{}"),
+            &0u64,
+        );
+        client.approve(&a, &id);
+        let outsider = Address::generate(&env);
+        client.revoke_approval(&outsider, &id);
+    }
+
+    #[test]
+    fn double_approve_is_idempotent_via_rejection() {
+        let env = Env::default();
+        let (a, b, _c, signers) = setup(&env);
+        env.mock_all_auths();
+        let contract_id = env.register(MultisigAdmin, ());
+        let client = MultisigAdminClient::new(&env, &contract_id);
+        client.init(&signers, &2u32);
+
+        let id = client.propose(
+            &a,
+            &OperationType::FreezeAccount,
+            &Bytes::from_slice(&env, b"{}"),
+            &0u64,
+        );
+        client.approve(&a, &id);
+        // Second approve from same signer is rejected (count stays at 1)
+        let res = client.try_approve(&a, &id);
+        assert!(res.is_err(), "duplicate approve must be rejected");
+        assert_eq!(client.get_proposal(&id).approval_count, 1);
+
+        // Proposal is still live — another signer can still approve
+        client.approve(&b, &id);
+        assert_eq!(client.get_proposal(&id).approval_count, 2);
+        client.execute(&a, &id);
     }
 }

--- a/contracts/oracle_price_feeds/src/lib.rs
+++ b/contracts/oracle_price_feeds/src/lib.rs
@@ -2,6 +2,7 @@
 
 use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, panic_with_error, Address, Env, Symbol,
+    Vec,
 };
 
 pub mod access_control;
@@ -9,6 +10,7 @@ pub mod access_control;
 const DEFAULT_STALENESS_SECONDS: u64 = 600;
 const DEFAULT_MAX_DEVIATION_BPS: u64 = 500; // 5% in basis points
 const PRICE_DECIMALS: u32 = 7;
+const DEFAULT_QUORUM: u32 = 1;
 
 #[contracttype]
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -17,6 +19,15 @@ pub struct PriceFeed {
     pub price: i128,
     pub decimals: u32,
     pub updated_at: u64,
+    pub sequence: u64,
+}
+
+/// Per-source price record stored for aggregation.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SourceData {
+    pub price: i128,
+    pub timestamp: u64,
     pub sequence: u64,
 }
 
@@ -29,6 +40,12 @@ pub enum DataKey {
     MaxDeviationBps,
     Feed(Symbol),
     Sequence(Symbol),
+    /// Registered sources for a feed (Vec<Address>)
+    Sources(Symbol),
+    /// Latest price submitted by a specific source for a feed
+    SourceData(Symbol, Address),
+    /// Minimum number of fresh sources required to compute a valid price
+    Quorum(Symbol),
 }
 
 #[contracterror]
@@ -41,6 +58,10 @@ pub enum ContractError {
     PriceTooStale = 4,
     UnknownPair = 5,
     PriceDeviationTooLarge = 6,
+    /// Fewer fresh sources than the required quorum
+    NoQuorum = 7,
+    /// Source is not registered for this feed
+    UnknownSource = 8,
 }
 
 #[contract]
@@ -85,6 +106,40 @@ fn emit_price_updated(env: &Env, feed: &PriceFeed) {
     );
 }
 
+/// Compute median of a non-empty Vec<i128> without floating point.
+/// Uses selection sort; safe for small source sets (≤ ~10 elements).
+fn median(env: &Env, values: &Vec<i128>) -> i128 {
+    let n = values.len();
+    // Build a sorted copy via selection sort
+    let mut sorted: Vec<i128> = Vec::new(env);
+    // Track which positions have been selected
+    let mut used: Vec<bool> = Vec::new(env);
+    for _ in 0..n {
+        used.push_back(false);
+    }
+    for _ in 0..n {
+        let mut min_val: i128 = i128::MAX;
+        let mut min_idx: u32 = 0;
+        for j in 0..n {
+            if !used.get(j).unwrap() {
+                let v = values.get(j).unwrap();
+                if v < min_val {
+                    min_val = v;
+                    min_idx = j;
+                }
+            }
+        }
+        used.set(min_idx, true);
+        sorted.push_back(min_val);
+    }
+    if n % 2 == 1 {
+        sorted.get(n / 2).unwrap()
+    } else {
+        let mid = n / 2;
+        (sorted.get(mid - 1).unwrap() + sorted.get(mid).unwrap()) / 2
+    }
+}
+
 #[contractimpl]
 impl OraclePriceFeeds {
     pub fn init(
@@ -118,6 +173,116 @@ impl OraclePriceFeeds {
         Ok(())
     }
 
+    // ── Source management (admin-only) ────────────────────────────────────────
+
+    /// Register a new price source for a feed. Admin-only.
+    pub fn add_source(
+        env: Env,
+        caller: Address,
+        pair: Symbol,
+        source: Address,
+    ) -> Result<(), ContractError> {
+        access_control::require_admin_permission(
+            &env,
+            &get_admin(&env),
+            &caller,
+            "add_source",
+        )?;
+        let mut sources: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::Sources(pair.clone()))
+            .unwrap_or_else(|| Vec::new(&env));
+        if !sources.contains(&source) {
+            sources.push_back(source.clone());
+            env.storage()
+                .instance()
+                .set(&DataKey::Sources(pair.clone()), &sources);
+        }
+        env.events().publish(
+            (
+                Symbol::new(&env, "oracle"),
+                Symbol::new(&env, "source_added"),
+                pair,
+            ),
+            source,
+        );
+        Ok(())
+    }
+
+    /// Remove a price source from a feed. Admin-only.
+    pub fn remove_source(
+        env: Env,
+        caller: Address,
+        pair: Symbol,
+        source: Address,
+    ) -> Result<(), ContractError> {
+        access_control::require_admin_permission(
+            &env,
+            &get_admin(&env),
+            &caller,
+            "remove_source",
+        )?;
+        let sources: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::Sources(pair.clone()))
+            .unwrap_or_else(|| Vec::new(&env));
+        let mut new_sources: Vec<Address> = Vec::new(&env);
+        for i in 0..sources.len() {
+            let s = sources.get(i).unwrap();
+            if s != source {
+                new_sources.push_back(s);
+            }
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey::Sources(pair.clone()), &new_sources);
+        env.events().publish(
+            (
+                Symbol::new(&env, "oracle"),
+                Symbol::new(&env, "source_removed"),
+                pair,
+            ),
+            source,
+        );
+        Ok(())
+    }
+
+    /// Set quorum requirement for a feed. Admin-only.
+    pub fn set_quorum(
+        env: Env,
+        caller: Address,
+        pair: Symbol,
+        quorum: u32,
+    ) -> Result<(), ContractError> {
+        access_control::require_admin_permission(
+            &env,
+            &get_admin(&env),
+            &caller,
+            "set_quorum",
+        )?;
+        env.storage()
+            .instance()
+            .set(&DataKey::Quorum(pair), &quorum);
+        Ok(())
+    }
+
+    /// Read registered sources for a feed.
+    pub fn get_sources(env: Env, pair: Symbol) -> Vec<Address> {
+        env.storage()
+            .instance()
+            .get(&DataKey::Sources(pair))
+            .unwrap_or_else(|| Vec::new(&env))
+    }
+
+    // ── Price updates ─────────────────────────────────────────────────────────
+
+    /// Submit a price update.
+    ///
+    /// When sources are registered for a feed the caller must be one of those
+    /// registered sources (per-source heartbeat). Otherwise the existing
+    /// admin-or-operator authentication is used (single-source fallback mode).
     pub fn update_price(
         env: Env,
         caller: Address,
@@ -125,34 +290,76 @@ impl OraclePriceFeeds {
         price: i128,
         sequence: u64,
     ) -> Result<(), ContractError> {
-        access_control::require_admin_or_operator_permission(
-            &env,
-            &get_admin(&env),
-            &get_operator(&env),
-            &caller,
-            "update_price",
-        )?;
-
-        let current_seq: u64 = env
+        let sources: Vec<Address> = env
             .storage()
             .instance()
-            .get(&DataKey::Sequence(pair.clone()))
-            .unwrap_or(0);
+            .get(&DataKey::Sources(pair.clone()))
+            .unwrap_or_else(|| Vec::new(&env));
+
+        if sources.is_empty() {
+            // Legacy single-source mode: admin or operator
+            access_control::require_admin_or_operator_permission(
+                &env,
+                &get_admin(&env),
+                &get_operator(&env),
+                &caller,
+                "update_price",
+            )?;
+        } else {
+            // Multi-source mode: caller must be a registered source
+            if !sources.contains(&caller) {
+                return Err(ContractError::UnknownSource);
+            }
+            caller.require_auth();
+        }
+
+        // Per-source sequence guard
+        let source_key = DataKey::SourceData(pair.clone(), caller.clone());
+        let current_seq: u64 = if let Some(prev_data) = env
+            .storage()
+            .instance()
+            .get::<_, SourceData>(&source_key)
+        {
+            prev_data.sequence
+        } else {
+            0u64
+        };
 
         if sequence <= current_seq {
             return Err(ContractError::InvalidSequence);
         }
 
-        // Check deviation from previous price if it exists
-        if let Some(prev_feed) = env
+        // Also update the feed-level sequence for legacy compatibility
+        let feed_seq: u64 = env
             .storage()
             .instance()
-            .get::<_, PriceFeed>(&DataKey::Feed(pair.clone()))
+            .get(&DataKey::Sequence(pair.clone()))
+            .unwrap_or(0);
+
+        // For single-source mode, enforce strict sequence on feed level
+        if sources.is_empty() && sequence <= feed_seq {
+            return Err(ContractError::InvalidSequence);
+        }
+
+        // Deviation check against the last price for this source
+        let max_deviation_bps = get_max_deviation_bps(&env);
+        let prev_price: Option<i128> = if let Some(prev_data) = env
+            .storage()
+            .instance()
+            .get::<_, SourceData>(&source_key)
         {
-            let max_deviation_bps = get_max_deviation_bps(&env);
-            let old_price = prev_feed.price;
-            // Calculate deviation in basis points: |new - old| * 10000 / old
-            // Use absolute difference and avoid overflow by checking for zero
+            Some(prev_data.price)
+        } else if sources.is_empty() {
+            // Single-source: deviation against the feed-level price
+            env.storage()
+                .instance()
+                .get::<_, PriceFeed>(&DataKey::Feed(pair.clone()))
+                .map(|f| f.price)
+        } else {
+            None
+        };
+
+        if let Some(old_price) = prev_price {
             if old_price != 0 {
                 let diff = if price > old_price {
                     price - old_price
@@ -166,26 +373,115 @@ impl OraclePriceFeeds {
             }
         }
 
-        let feed = PriceFeed {
-            pair: pair.clone(),
-            price,
-            decimals: PRICE_DECIMALS,
-            updated_at: env.ledger().timestamp(),
-            sequence,
-        };
+        let now = env.ledger().timestamp();
 
-        env.storage()
-            .instance()
-            .set(&DataKey::Feed(pair.clone()), &feed);
-        env.storage()
-            .instance()
-            .set(&DataKey::Sequence(pair.clone()), &sequence);
+        // Store per-source data
+        env.storage().instance().set(
+            &source_key,
+            &SourceData {
+                price,
+                timestamp: now,
+                sequence,
+            },
+        );
 
-        emit_price_updated(&env, &feed);
+        // Emit source_reported event
+        env.events().publish(
+            (
+                Symbol::new(&env, "oracle"),
+                Symbol::new(&env, "source_reported"),
+                pair.clone(),
+            ),
+            (caller.clone(), price, sequence, now),
+        );
+
+        if sources.is_empty() {
+            // Update the canonical feed record in single-source mode
+            let feed = PriceFeed {
+                pair: pair.clone(),
+                price,
+                decimals: PRICE_DECIMALS,
+                updated_at: now,
+                sequence,
+            };
+            env.storage()
+                .instance()
+                .set(&DataKey::Feed(pair.clone()), &feed);
+            env.storage()
+                .instance()
+                .set(&DataKey::Sequence(pair.clone()), &sequence);
+            emit_price_updated(&env, &feed);
+        }
+
         Ok(())
     }
 
+    // ── Price queries ─────────────────────────────────────────────────────────
+
+    /// Get the current price for a feed.
+    ///
+    /// When sources are registered, returns the **median** of fresh source
+    /// submissions and fails with `NoQuorum` if fewer than the required quorum
+    /// of sources have fresh data. Otherwise uses the single-source feed record.
     pub fn get_price(env: Env, pair: Symbol) -> PriceFeed {
+        let sources: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::Sources(pair.clone()))
+            .unwrap_or_else(|| Vec::new(&env));
+
+        if !sources.is_empty() {
+            let threshold = get_staleness_threshold(&env);
+            let now = env.ledger().timestamp();
+            let quorum: u32 = env
+                .storage()
+                .instance()
+                .get(&DataKey::Quorum(pair.clone()))
+                .unwrap_or(DEFAULT_QUORUM);
+
+            // Collect fresh source prices
+            let mut fresh_prices: Vec<i128> = Vec::new(&env);
+            for i in 0..sources.len() {
+                let src = sources.get(i).unwrap();
+                if let Some(data) = env
+                    .storage()
+                    .instance()
+                    .get::<_, SourceData>(&DataKey::SourceData(pair.clone(), src))
+                {
+                    if now.saturating_sub(data.timestamp) <= threshold {
+                        fresh_prices.push_back(data.price);
+                    }
+                }
+            }
+
+            if fresh_prices.len() < quorum {
+                panic_with_error!(&env, ContractError::NoQuorum);
+            }
+
+            let aggregated_price = median(&env, &fresh_prices);
+
+            let feed = PriceFeed {
+                pair: pair.clone(),
+                price: aggregated_price,
+                decimals: PRICE_DECIMALS,
+                updated_at: now,
+                sequence: 0,
+            };
+
+            // Emit aggregated price event
+            env.events().publish(
+                (
+                    Symbol::new(&env, "oracle"),
+                    Symbol::new(&env, "aggregated_price"),
+                    pair,
+                ),
+                (aggregated_price, fresh_prices.len(), now),
+            );
+
+            return feed;
+        }
+
+        // Single-source fallback
         let feed = Self::get_price_unsafe(env.clone(), pair);
         let threshold = get_staleness_threshold(&env);
         let now = env.ledger().timestamp();
@@ -203,6 +499,36 @@ impl OraclePriceFeeds {
     }
 
     pub fn is_stale(env: Env, pair: Symbol) -> bool {
+        let sources: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::Sources(pair.clone()))
+            .unwrap_or_else(|| Vec::new(&env));
+
+        if !sources.is_empty() {
+            let threshold = get_staleness_threshold(&env);
+            let now = env.ledger().timestamp();
+            let quorum: u32 = env
+                .storage()
+                .instance()
+                .get(&DataKey::Quorum(pair.clone()))
+                .unwrap_or(DEFAULT_QUORUM);
+            let mut fresh_count: u32 = 0;
+            for i in 0..sources.len() {
+                let src = sources.get(i).unwrap();
+                if let Some(data) = env
+                    .storage()
+                    .instance()
+                    .get::<_, SourceData>(&DataKey::SourceData(pair.clone(), src))
+                {
+                    if now.saturating_sub(data.timestamp) <= threshold {
+                        fresh_count += 1;
+                    }
+                }
+            }
+            return fresh_count < quorum;
+        }
+
         if !env.storage().instance().has(&DataKey::Feed(pair.clone())) {
             return true;
         }
@@ -677,5 +1003,151 @@ mod test {
 
         let feed = client.get_price(&p);
         assert_eq!(feed.price, 1_000_000);
+    }
+
+    // ── Multi-source aggregation tests ────────────────────────────────────────
+
+    fn setup_multi_source(env: &Env) -> (Address, OraclePriceFeedsClient<'_>, Address, Symbol, Address, Address, Address) {
+        let (contract_id, client, admin, _operator, p) = setup(env);
+        let src1 = Address::generate(env);
+        let src2 = Address::generate(env);
+        let src3 = Address::generate(env);
+        env.mock_all_auths();
+        client.add_source(&admin, &p, &src1);
+        client.add_source(&admin, &p, &src2);
+        client.add_source(&admin, &p, &src3);
+        client.set_quorum(&admin, &p, &2u32);
+        (contract_id, client, admin, p, src1, src2, src3)
+    }
+
+    #[test]
+    fn multi_source_quorum_met_returns_median() {
+        let env = Env::default();
+        env.ledger().set_timestamp(1_000);
+        let (_cid, client, _admin, p, src1, src2, src3) = setup_multi_source(&env);
+
+        env.mock_all_auths();
+        // Three sources report: 100, 110, 105 → sorted: 100, 105, 110 → median = 105
+        client.update_price(&src1, &p, &100i128, &1u64);
+        client.update_price(&src2, &p, &110i128, &1u64);
+        client.update_price(&src3, &p, &105i128, &1u64);
+
+        let feed = client.get_price(&p);
+        assert_eq!(feed.price, 105, "expected median 105, got {}", feed.price);
+    }
+
+    #[test]
+    fn multi_source_stale_source_ignored() {
+        let env = Env::default();
+        env.ledger().set_timestamp(1_000);
+        let (_cid, client, _admin, p, src1, src2, src3) = setup_multi_source(&env);
+
+        env.mock_all_auths();
+        // All three sources report at t=1000 with similar prices
+        client.update_price(&src1, &p, &100i128, &1u64);
+        client.update_price(&src2, &p, &100i128, &1u64);
+        client.update_price(&src3, &p, &100i128, &1u64);
+
+        // Advance time so src3 becomes stale (> 600s threshold)
+        env.ledger().set_timestamp(1_000 + 700);
+
+        // src1 and src2 re-report fresh prices (within 5% of 100)
+        client.update_price(&src1, &p, &102i128, &2u64);
+        client.update_price(&src2, &p, &104i128, &2u64);
+        // src3 did NOT re-report → its last data is at t=1000 (stale at t=1700)
+
+        // Quorum = 2: src1 + src2 fresh, src3 stale → median of [102, 104] = 103
+        let feed = client.get_price(&p);
+        assert_eq!(feed.price, 103, "expected median of fresh sources 103, got {}", feed.price);
+    }
+
+    #[test]
+    fn multi_source_below_quorum_returns_error() {
+        let env = Env::default();
+        env.ledger().set_timestamp(1_000);
+        let (_cid, client, admin, p, src1, _src2, _src3) = setup_multi_source(&env);
+
+        env.mock_all_auths();
+        // Set quorum to 3 but only 1 source reports
+        client.set_quorum(&admin, &p, &3u32);
+        client.update_price(&src1, &p, &100i128, &1u64);
+
+        // Only 1 fresh source, quorum=3 → get_price should panic (panic_with_error)
+        // try_get_price returns Err when the contract panics
+        assert!(client.try_get_price(&p).is_err(), "expected NoQuorum error");
+    }
+
+    #[test]
+    fn multi_source_outlier_rejected_by_deviation_bound() {
+        let env = Env::default();
+        env.ledger().set_timestamp(1_000);
+        let (_cid, client, _admin, p, src1, src2, src3) = setup_multi_source(&env);
+
+        env.mock_all_auths();
+        // src1 establishes baseline
+        client.update_price(&src1, &p, &100i128, &1u64);
+        // src2 at similar price
+        client.update_price(&src2, &p, &102i128, &1u64);
+        // src3 tries to submit an outlier (>5% from its previous... but first submission
+        // is exempt from deviation check). Set a more realistic scenario:
+        // src3 first reports 100 then tries to jump to 200 (100% deviation → rejected)
+        client.update_price(&src3, &p, &100i128, &1u64);
+
+        let err = client.try_update_price(&src3, &p, &200i128, &2u64).unwrap_err().unwrap();
+        assert_eq!(err, ContractError::PriceDeviationTooLarge);
+
+        // Median is still based on valid sources: 100, 102 → 101
+        let feed = client.get_price(&p);
+        // src3 still has price 100 (last valid), so median of [100, 102, 100] = 100
+        assert_eq!(feed.price, 100);
+    }
+
+    #[test]
+    fn unregistered_source_cannot_update_price() {
+        let env = Env::default();
+        env.ledger().set_timestamp(1_000);
+        let (_cid, client, _admin, p, _src1, _src2, _src3) = setup_multi_source(&env);
+
+        env.mock_all_auths();
+        let stranger = Address::generate(&env);
+        let err = client
+            .try_update_price(&stranger, &p, &100i128, &1u64)
+            .unwrap_err()
+            .unwrap();
+        assert_eq!(err, ContractError::UnknownSource);
+    }
+
+    #[test]
+    fn add_and_remove_source() {
+        let env = Env::default();
+        env.ledger().set_timestamp(1_000);
+        let (_cid, client, admin, p, src1, src2, src3) = setup_multi_source(&env);
+
+        env.mock_all_auths();
+        let initial = client.get_sources(&p);
+        assert_eq!(initial.len(), 3);
+
+        client.remove_source(&admin, &p, &src2);
+        let after_remove = client.get_sources(&p);
+        assert_eq!(after_remove.len(), 2);
+        assert!(!after_remove.contains(&src2));
+    }
+
+    #[test]
+    fn multi_source_even_count_median_is_average() {
+        let env = Env::default();
+        env.ledger().set_timestamp(1_000);
+        let (contract_id, client, admin, p, src1, src2, _src3) = setup_multi_source(&env);
+
+        env.mock_all_auths();
+        // Set quorum to 2 and use only 2 sources for deterministic even-median
+        client.set_quorum(&admin, &p, &2u32);
+        client.update_price(&src1, &p, &100i128, &1u64);
+        client.update_price(&src2, &p, &200i128, &1u64);
+        // src3 is stale (never reported)
+
+        // Only 2 fresh prices: [100, 200] → median = (100 + 200) / 2 = 150
+        let feed = client.get_price(&p);
+        assert_eq!(feed.price, 150, "expected average median 150, got {}", feed.price);
     }
 }

--- a/contracts/oracle_price_feeds/src/lib.rs
+++ b/contracts/oracle_price_feeds/src/lib.rs
@@ -182,12 +182,7 @@ impl OraclePriceFeeds {
         pair: Symbol,
         source: Address,
     ) -> Result<(), ContractError> {
-        access_control::require_admin_permission(
-            &env,
-            &get_admin(&env),
-            &caller,
-            "add_source",
-        )?;
+        access_control::require_admin_permission(&env, &get_admin(&env), &caller, "add_source")?;
         let mut sources: Vec<Address> = env
             .storage()
             .instance()
@@ -217,12 +212,7 @@ impl OraclePriceFeeds {
         pair: Symbol,
         source: Address,
     ) -> Result<(), ContractError> {
-        access_control::require_admin_permission(
-            &env,
-            &get_admin(&env),
-            &caller,
-            "remove_source",
-        )?;
+        access_control::require_admin_permission(&env, &get_admin(&env), &caller, "remove_source")?;
         let sources: Vec<Address> = env
             .storage()
             .instance()
@@ -256,12 +246,7 @@ impl OraclePriceFeeds {
         pair: Symbol,
         quorum: u32,
     ) -> Result<(), ContractError> {
-        access_control::require_admin_permission(
-            &env,
-            &get_admin(&env),
-            &caller,
-            "set_quorum",
-        )?;
+        access_control::require_admin_permission(&env, &get_admin(&env), &caller, "set_quorum")?;
         env.storage()
             .instance()
             .set(&DataKey::Quorum(pair), &quorum);
@@ -315,15 +300,12 @@ impl OraclePriceFeeds {
 
         // Per-source sequence guard
         let source_key = DataKey::SourceData(pair.clone(), caller.clone());
-        let current_seq: u64 = if let Some(prev_data) = env
-            .storage()
-            .instance()
-            .get::<_, SourceData>(&source_key)
-        {
-            prev_data.sequence
-        } else {
-            0u64
-        };
+        let current_seq: u64 =
+            if let Some(prev_data) = env.storage().instance().get::<_, SourceData>(&source_key) {
+                prev_data.sequence
+            } else {
+                0u64
+            };
 
         if sequence <= current_seq {
             return Err(ContractError::InvalidSequence);
@@ -343,21 +325,18 @@ impl OraclePriceFeeds {
 
         // Deviation check against the last price for this source
         let max_deviation_bps = get_max_deviation_bps(&env);
-        let prev_price: Option<i128> = if let Some(prev_data) = env
-            .storage()
-            .instance()
-            .get::<_, SourceData>(&source_key)
-        {
-            Some(prev_data.price)
-        } else if sources.is_empty() {
-            // Single-source: deviation against the feed-level price
-            env.storage()
-                .instance()
-                .get::<_, PriceFeed>(&DataKey::Feed(pair.clone()))
-                .map(|f| f.price)
-        } else {
-            None
-        };
+        let prev_price: Option<i128> =
+            if let Some(prev_data) = env.storage().instance().get::<_, SourceData>(&source_key) {
+                Some(prev_data.price)
+            } else if sources.is_empty() {
+                // Single-source: deviation against the feed-level price
+                env.storage()
+                    .instance()
+                    .get::<_, PriceFeed>(&DataKey::Feed(pair.clone()))
+                    .map(|f| f.price)
+            } else {
+                None
+            };
 
         if let Some(old_price) = prev_price {
             if old_price != 0 {
@@ -1007,7 +986,17 @@ mod test {
 
     // ── Multi-source aggregation tests ────────────────────────────────────────
 
-    fn setup_multi_source(env: &Env) -> (Address, OraclePriceFeedsClient<'_>, Address, Symbol, Address, Address, Address) {
+    fn setup_multi_source(
+        env: &Env,
+    ) -> (
+        Address,
+        OraclePriceFeedsClient<'_>,
+        Address,
+        Symbol,
+        Address,
+        Address,
+        Address,
+    ) {
         let (contract_id, client, admin, _operator, p) = setup(env);
         let src1 = Address::generate(env);
         let src2 = Address::generate(env);
@@ -1058,7 +1047,11 @@ mod test {
 
         // Quorum = 2: src1 + src2 fresh, src3 stale → median of [102, 104] = 103
         let feed = client.get_price(&p);
-        assert_eq!(feed.price, 103, "expected median of fresh sources 103, got {}", feed.price);
+        assert_eq!(
+            feed.price, 103,
+            "expected median of fresh sources 103, got {}",
+            feed.price
+        );
     }
 
     #[test]
@@ -1093,7 +1086,10 @@ mod test {
         // src3 first reports 100 then tries to jump to 200 (100% deviation → rejected)
         client.update_price(&src3, &p, &100i128, &1u64);
 
-        let err = client.try_update_price(&src3, &p, &200i128, &2u64).unwrap_err().unwrap();
+        let err = client
+            .try_update_price(&src3, &p, &200i128, &2u64)
+            .unwrap_err()
+            .unwrap();
         assert_eq!(err, ContractError::PriceDeviationTooLarge);
 
         // Median is still based on valid sources: 100, 102 → 101
@@ -1148,6 +1144,10 @@ mod test {
 
         // Only 2 fresh prices: [100, 200] → median = (100 + 200) / 2 = 150
         let feed = client.get_price(&p);
-        assert_eq!(feed.price, 150, "expected average median 150, got {}", feed.price);
+        assert_eq!(
+            feed.price, 150,
+            "expected average median 150, got {}",
+            feed.price
+        );
     }
 }

--- a/contracts/slashing_module/src/lib.rs
+++ b/contracts/slashing_module/src/lib.rs
@@ -1,7 +1,8 @@
 #![no_std]
 
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, Address, Bytes, Env, String, Symbol, Vec,
+    contract, contracterror, contractimpl, contracttype, Address, Bytes, BytesN, Env, String,
+    Symbol, Vec,
 };
 
 // ── Storage Keys ─────────────────────────────────────────────────────────────
@@ -13,7 +14,7 @@ pub enum DataKey {
     Paused,
     /// Authorized evidence submitters
     Submitter(Address),
-    /// Slash record keyed by evidence hash (duplicate detection)
+    /// Slash record keyed by commitment hash (duplicate detection)
     SlashRecord(Bytes),
     /// Per-actor slash count (for indexing / audit)
     SlashCount(Address),
@@ -36,6 +37,17 @@ pub enum DataKey {
     ChallengeWindow,
     NextSlashId,
     PendingSlash(u64),
+
+    // ── Commit-Reveal (Issue #1131) ───────────────────────────────────────
+    /// Whether the commitment for a slash has been validly revealed
+    CommitmentRevealed(u64),
+
+    // ── Configurable tier BPS (Issue #1131) ──────────────────────────────
+    TierDoubleSignBps,
+    TierDowntimeBps,
+    TierInvalidBlockBps,
+    /// Hard cap on slash fraction (in bps). No slash may exceed this.
+    MaxSlashBps,
 }
 
 /// Single slash entry recorded against an inspector by the bond contract
@@ -70,6 +82,7 @@ pub struct PendingSlash {
     pub deadline: u64,
     pub status: SlashStatus,
     pub is_validator: bool,
+    /// Commitment hash (sha256 of evidence || salt) stored at commit time.
     pub evidence_hash: Option<Bytes>,
     pub offence: Offence,
     pub submitter: Option<Address>,
@@ -80,12 +93,17 @@ pub struct PendingSlash {
 
 // ── Slashable Offence Types ───────────────────────────────────────────────────
 
-/// Penalty ratios expressed as basis points (1 bp = 0.01%).
-/// Max stake reduction capped at 10_000 bp (100%).
-pub const OFFENCE_DOUBLE_SIGN_BPS: u32 = 1_000; // 10 %
-pub const OFFENCE_DOWNTIME_BPS: u32 = 100; // 1 %
-pub const OFFENCE_INVALID_BLOCK_BPS: u32 = 500; // 5 %
-pub const MAX_BPS: u32 = 10_000;
+/// Default penalty ratios (bps). Overridden by `configure_tiers`.
+pub const DEFAULT_DOUBLE_SIGN_BPS: u32 = 1_000; // 10%
+pub const DEFAULT_DOWNTIME_BPS: u32 = 100;       // 1%
+pub const DEFAULT_INVALID_BLOCK_BPS: u32 = 500;  // 5%
+pub const DEFAULT_MAX_BPS: u32 = 10_000;          // 100%
+
+// Keep legacy exported names for backward compatibility
+pub const OFFENCE_DOUBLE_SIGN_BPS: u32 = DEFAULT_DOUBLE_SIGN_BPS;
+pub const OFFENCE_DOWNTIME_BPS: u32 = DEFAULT_DOWNTIME_BPS;
+pub const OFFENCE_INVALID_BLOCK_BPS: u32 = DEFAULT_INVALID_BLOCK_BPS;
+pub const MAX_BPS: u32 = DEFAULT_MAX_BPS;
 
 // ── Errors ────────────────────────────────────────────────────────────────────
 
@@ -121,6 +139,10 @@ pub enum ContractError {
     SlashAlreadyResolved = 13,
     /// Invalid slash amount (e.g. <= 0)
     InvalidAmount = 14,
+    /// Evidence has not been revealed (commit-reveal not completed)
+    CommitmentNotRevealed = 15,
+    /// Revealed evidence does not match the stored commitment
+    InvalidReveal = 16,
 }
 
 // ── Data Structures ───────────────────────────────────────────────────────────
@@ -135,7 +157,7 @@ pub enum Offence {
     None,
 }
 
-/// Full evidence record stored on-chain (keyed by hash)
+/// Full evidence record stored on-chain (keyed by commitment hash)
 #[contracttype]
 #[derive(Clone)]
 pub struct SlashEvidence {
@@ -199,6 +221,67 @@ impl SlashingModule {
             return Err(ContractError::Paused);
         }
         Ok(())
+    }
+
+    /// Configure tier penalty BPS and global max. Admin-only.
+    /// Call after `init` to override the hardcoded defaults.
+    pub fn configure_tiers(
+        env: Env,
+        admin: Address,
+        double_sign_bps: u32,
+        downtime_bps: u32,
+        invalid_block_bps: u32,
+        max_slash_bps: u32,
+    ) -> Result<(), ContractError> {
+        Self::require_admin(&env, &admin)?;
+        env.storage()
+            .instance()
+            .set(&DataKey::TierDoubleSignBps, &double_sign_bps);
+        env.storage()
+            .instance()
+            .set(&DataKey::TierDowntimeBps, &downtime_bps);
+        env.storage()
+            .instance()
+            .set(&DataKey::TierInvalidBlockBps, &invalid_block_bps);
+        env.storage()
+            .instance()
+            .set(&DataKey::MaxSlashBps, &max_slash_bps);
+        env.events().publish(
+            (
+                Symbol::new(&env, "slashing"),
+                Symbol::new(&env, "tiers_configured"),
+            ),
+            (double_sign_bps, downtime_bps, invalid_block_bps, max_slash_bps),
+        );
+        Ok(())
+    }
+
+    fn get_tier_bps(env: &Env, offence: &Offence) -> u32 {
+        match offence {
+            Offence::DoubleSign => env
+                .storage()
+                .instance()
+                .get(&DataKey::TierDoubleSignBps)
+                .unwrap_or(DEFAULT_DOUBLE_SIGN_BPS),
+            Offence::Downtime => env
+                .storage()
+                .instance()
+                .get(&DataKey::TierDowntimeBps)
+                .unwrap_or(DEFAULT_DOWNTIME_BPS),
+            Offence::InvalidBlock => env
+                .storage()
+                .instance()
+                .get(&DataKey::TierInvalidBlockBps)
+                .unwrap_or(DEFAULT_INVALID_BLOCK_BPS),
+            Offence::None => 0,
+        }
+    }
+
+    fn get_max_slash_bps(env: &Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&DataKey::MaxSlashBps)
+            .unwrap_or(DEFAULT_MAX_BPS)
     }
 
     /// Register an authorized evidence submitter.
@@ -302,33 +385,44 @@ impl SlashingModule {
         next
     }
 
-    // ── Core: submit evidence & slash ─────────────────────────────────────────
+    // ── Commit-Reveal helpers ─────────────────────────────────────────────────
 
-    /// Submit evidence of misbehavior (proposes a validator slash).
+    /// Compute sha256(evidence || salt) as a `Bytes` value suitable for
+    /// comparison with the stored commitment.
+    fn hash_commitment(env: &Env, evidence: &Bytes, salt: &Bytes) -> Bytes {
+        let mut data = Bytes::new(env);
+        data.append(evidence);
+        data.append(salt);
+        let hash: BytesN<32> = env.crypto().sha256(&data).into();
+        Bytes::from(hash)
+    }
+
+    // ── Core: commit evidence ─────────────────────────────────────────────────
+
+    /// Phase 1 of commit-reveal: submit the commitment hash of evidence.
     ///
-    /// * `evidence_hash` – unique fingerprint of the raw evidence bytes (duplicate guard).
-    /// * `actor`         – address being slashed.
-    /// * `offence`       – classification used to look up the penalty ratio.
+    /// `commitment` must equal `sha256(evidence_bytes || salt_bytes)`.
+    /// The actual evidence is only revealed in `reveal_evidence`, preventing
+    /// front-running and griefing of evidence submission.
     pub fn submit_evidence(
         env: Env,
         submitter: Address,
-        evidence_hash: Bytes,
+        commitment: Bytes,
         actor: Address,
         offence: Offence,
     ) -> Result<u64, ContractError> {
         Self::require_submitter(&env, &submitter)?;
 
-        // Duplicate evidence check
+        // Duplicate commitment check (same commitment = same evidence+salt pair)
         if env
             .storage()
             .persistent()
-            .has(&DataKey::SlashRecord(evidence_hash.clone()))
+            .has(&DataKey::SlashRecord(commitment.clone()))
         {
             return Err(ContractError::DuplicateEvidence);
         }
 
-        // Actor must not already be jailed (cannot re-slash a jailed actor for a
-        // new offence until governance unjails them; prevents double-jailing races).
+        // Actor must not already be jailed
         let already_jailed: bool = env
             .storage()
             .persistent()
@@ -338,13 +432,13 @@ impl SlashingModule {
             return Err(ContractError::AlreadyJailed);
         }
 
-        // Determine penalty ratio
-        let penalty_bps: u32 = match offence {
-            Offence::DoubleSign => OFFENCE_DOUBLE_SIGN_BPS,
-            Offence::Downtime => OFFENCE_DOWNTIME_BPS,
-            Offence::InvalidBlock => OFFENCE_INVALID_BLOCK_BPS,
-            Offence::None => return Err(ContractError::UnknownOffence),
-        };
+        // Determine penalty ratio from configurable tiers, bounded by max
+        let raw_bps: u32 = Self::get_tier_bps(&env, &offence);
+        if raw_bps == 0 {
+            return Err(ContractError::UnknownOffence);
+        }
+        let max_bps = Self::get_max_slash_bps(&env);
+        let penalty_bps = raw_bps.min(max_bps);
 
         // Load current staked balance
         let balance: i128 = env
@@ -359,13 +453,13 @@ impl SlashingModule {
 
         // Proportional slash – saturating at full balance (no over-slash)
         let slash_amount = (balance * penalty_bps as i128) / MAX_BPS as i128;
-        let slash_amount = slash_amount.min(balance); // cap at balance
+        let slash_amount = slash_amount.min(balance);
 
         // Generate slash ID
         let slash_id = Self::next_slash_id(&env);
         let deadline = env.ledger().timestamp() + Self::challenge_window(env.clone());
 
-        // Create PendingSlash
+        // Create PendingSlash; revealed = false until reveal_evidence succeeds
         let pending = PendingSlash {
             id: slash_id,
             actor: actor.clone(),
@@ -373,7 +467,7 @@ impl SlashingModule {
             deadline,
             status: SlashStatus::Pending,
             is_validator: true,
-            evidence_hash: Some(evidence_hash.clone()),
+            evidence_hash: Some(commitment.clone()),
             offence: offence.clone(),
             submitter: Some(submitter.clone()),
             penalty_bps,
@@ -381,30 +475,34 @@ impl SlashingModule {
             reason: None,
         };
 
-        // Save PendingSlash
         env.storage()
             .persistent()
             .set(&DataKey::PendingSlash(slash_id), &pending);
 
-        // Mark evidence hash as used/pending to block duplicate proposals with the same hash
+        // Mark commitment as pending (duplicate guard); store minimal evidence record
         let evidence_record = SlashEvidence {
             actor: actor.clone(),
             offence: offence.clone(),
             submitter: submitter.clone(),
             submitted_at: env.ledger().timestamp(),
             penalty_bps,
-            slashed_amount: slash_amount,
+            slashed_amount: 0, // updated at finalization
         };
         env.storage().persistent().set(
-            &DataKey::SlashRecord(evidence_hash.clone()),
+            &DataKey::SlashRecord(commitment.clone()),
             &evidence_record,
         );
 
-        // Emit proposed event
+        // CommitmentRevealed starts false
+        env.storage()
+            .persistent()
+            .set(&DataKey::CommitmentRevealed(slash_id), &false);
+
+        // Emit evidence_committed event
         env.events().publish(
             (
                 Symbol::new(&env, "slashing"),
-                Symbol::new(&env, "proposed"),
+                Symbol::new(&env, "evidence_committed"),
                 actor,
             ),
             (slash_id, slash_amount, deadline),
@@ -413,13 +511,80 @@ impl SlashingModule {
         Ok(slash_id)
     }
 
-    /// Propose a slash for an actor.
-    /// Callable by authorized submitter or registered bond contract or admin.
+    /// Phase 2 of commit-reveal: reveal evidence and salt.
+    ///
+    /// Computes `sha256(evidence || salt)` on-chain and verifies it matches
+    /// the commitment stored at `submit_evidence` time. Must be called before
+    /// `finalize_slash` for validator slashes.
+    pub fn reveal_evidence(
+        env: Env,
+        submitter: Address,
+        slash_id: u64,
+        evidence: Bytes,
+        salt: Bytes,
+    ) -> Result<(), ContractError> {
+        Self::require_submitter(&env, &submitter)?;
+
+        let pending: PendingSlash = env
+            .storage()
+            .persistent()
+            .get(&DataKey::PendingSlash(slash_id))
+            .ok_or(ContractError::SlashNotFound)?;
+
+        if pending.status != SlashStatus::Pending {
+            return Err(ContractError::SlashAlreadyResolved);
+        }
+
+        // Check we haven't already revealed
+        let already_revealed: bool = env
+            .storage()
+            .persistent()
+            .get(&DataKey::CommitmentRevealed(slash_id))
+            .unwrap_or(false);
+
+        // If already revealed, it's a no-op (idempotent)
+        if already_revealed {
+            return Ok(());
+        }
+
+        let computed = Self::hash_commitment(&env, &evidence, &salt);
+
+        let commitment = pending
+            .evidence_hash
+            .clone()
+            .unwrap_or(Bytes::new(&env));
+
+        if computed != commitment {
+            return Err(ContractError::InvalidReveal);
+        }
+
+        // Mark as revealed
+        env.storage()
+            .persistent()
+            .set(&DataKey::CommitmentRevealed(slash_id), &true);
+
+        // Emit evidence_revealed event
+        env.events().publish(
+            (
+                Symbol::new(&env, "slashing"),
+                Symbol::new(&env, "evidence_revealed"),
+                pending.actor,
+            ),
+            (slash_id, pending.penalty_bps),
+        );
+
+        Ok(())
+    }
+
+    /// Propose a slash for an actor with a specific penalty tier (bps).
+    ///
+    /// The `penalty_bps` is bounded by the configured `max_slash_bps`.
+    /// This flow does NOT require commit-reveal (non-validator slash).
     pub fn propose_slash(
         env: Env,
         submitter: Address,
         actor: Address,
-        amount: i128,
+        penalty_bps: u32,
     ) -> Result<u64, ContractError> {
         // Enforce authorization: caller must be Admin, authorized Submitter, or BondContract
         let admin: Address = env
@@ -448,6 +613,23 @@ impl SlashingModule {
         }
         submitter.require_auth();
 
+        let max_bps = Self::get_max_slash_bps(&env);
+        let effective_bps = penalty_bps.min(max_bps);
+
+        // Compute slash amount from the actor's staked balance
+        let balance: i128 = env
+            .storage()
+            .persistent()
+            .get::<_, i128>(&DataKey::StakedBalance(actor.clone()))
+            .unwrap_or(0);
+
+        if balance == 0 {
+            return Err(ContractError::ZeroBalance);
+        }
+
+        let amount = (balance * effective_bps as i128) / MAX_BPS as i128;
+        let amount = amount.min(balance);
+
         if amount <= 0 {
             return Err(ContractError::InvalidAmount);
         }
@@ -465,7 +647,7 @@ impl SlashingModule {
             evidence_hash: None,
             offence: Offence::None,
             submitter: Some(submitter),
-            penalty_bps: 0,
+            penalty_bps: effective_bps,
             inspection_id: None,
             reason: None,
         };
@@ -480,13 +662,16 @@ impl SlashingModule {
                 Symbol::new(&env, "proposed"),
                 actor,
             ),
-            (slash_id, amount, deadline),
+            (slash_id, amount, deadline, effective_bps),
         );
 
         Ok(slash_id)
     }
 
     /// Finalize a pending slash after the challenge window has elapsed.
+    ///
+    /// For validator slashes (`is_validator = true`), the evidence commitment
+    /// must have been validly revealed via `reveal_evidence` before this call.
     pub fn finalize_slash(env: Env, caller: Address, slash_id: u64) -> Result<(), ContractError> {
         // Enforce authorization: caller must be Admin, authorized Submitter, or BondContract
         let admin: Address = env
@@ -527,6 +712,18 @@ impl SlashingModule {
 
         if env.ledger().timestamp() < pending.deadline {
             return Err(ContractError::ChallengeWindowNotElapsed);
+        }
+
+        // Validator slashes require a valid commit-reveal before finalization
+        if pending.is_validator {
+            let revealed: bool = env
+                .storage()
+                .persistent()
+                .get(&DataKey::CommitmentRevealed(slash_id))
+                .unwrap_or(false);
+            if !revealed {
+                return Err(ContractError::CommitmentNotRevealed);
+            }
         }
 
         pending.status = SlashStatus::Finalized;
@@ -575,7 +772,7 @@ impl SlashingModule {
                 .persistent()
                 .set(&DataKey::SlashCount(actor.clone()), &(prev_count + 1));
 
-            // Publish finalized event
+            // Update slash record with finalized amount
             let evidence_record = SlashEvidence {
                 actor: actor.clone(),
                 offence: pending.offence.clone(),
@@ -585,7 +782,6 @@ impl SlashingModule {
                 slashed_amount: actual_slash,
             };
 
-            // Overwrite slash record with finalized amount
             if let Some(hash) = pending.evidence_hash.clone() {
                 env.storage()
                     .persistent()
@@ -615,16 +811,41 @@ impl SlashingModule {
                 ),
                 evidence_record,
             );
+        } else {
+            // Non-validator slash (propose_slash flow): reduce staked balance and track.
+            let actor = pending.actor.clone();
+            let slash_amount = pending.amount;
+            if slash_amount > 0 {
+                let balance: i128 = env
+                    .storage()
+                    .persistent()
+                    .get::<_, i128>(&DataKey::StakedBalance(actor.clone()))
+                    .unwrap_or(0);
+                let actual_slash = slash_amount.min(balance);
+                let new_balance = balance - actual_slash;
+                env.storage()
+                    .persistent()
+                    .set(&DataKey::StakedBalance(actor.clone()), &new_balance);
+                let prev_total: i128 = env
+                    .storage()
+                    .persistent()
+                    .get(&DataKey::SlashedAmount(actor.clone()))
+                    .unwrap_or(0);
+                env.storage().persistent().set(
+                    &DataKey::SlashedAmount(actor.clone()),
+                    &(prev_total + actual_slash),
+                );
+            }
         }
 
-        // Emit general finalized event
+        // Emit slash_finalized with tier and amount
         env.events().publish(
             (
                 Symbol::new(&env, "slashing"),
-                Symbol::new(&env, "finalized"),
+                Symbol::new(&env, "slash_finalized"),
                 pending.actor.clone(),
             ),
-            slash_id,
+            (slash_id, pending.amount, pending.penalty_bps),
         );
 
         Ok(())
@@ -651,6 +872,7 @@ impl SlashingModule {
             .set(&DataKey::PendingSlash(slash_id), &pending);
 
         // If it was a validator slash, remove the duplicate evidence guard
+        // so the same commitment can be re-submitted after cancellation.
         if pending.is_validator {
             if let Some(hash) = pending.evidence_hash {
                 env.storage()
@@ -658,6 +880,11 @@ impl SlashingModule {
                     .remove(&DataKey::SlashRecord(hash));
             }
         }
+
+        // Clear the revealed flag
+        env.storage()
+            .persistent()
+            .remove(&DataKey::CommitmentRevealed(slash_id));
 
         env.events().publish(
             (
@@ -771,12 +998,6 @@ impl SlashingModule {
     }
 
     // ── Inspector bond slashing (Issue #925) ──────────────────────────────────
-    //
-    // Companion flow to the validator slashing above: the `bond_collateral`
-    // contract calls `slash` here when an admin decides an inspector's
-    // collateral should be reduced for a specific inspection. We gate `slash`
-    // to the one registered bond contract so no other caller can record a
-    // slash against an inspector.
 
     /// Register the bond_collateral contract address authorised to call `slash`.
     pub fn set_bond_contract(
@@ -804,9 +1025,7 @@ impl SlashingModule {
         env.storage().instance().get(&DataKey::BondContract)
     }
 
-    /// Record a slash against an inspector for a specific inspection. Only
-    /// callable by the registered bond contract; the caller is checked against
-    /// both Soroban auth and the registered address. Returns the amount slashed.
+    /// Record a slash against an inspector for a specific inspection.
     pub fn slash(
         env: Env,
         caller: Address,
@@ -906,7 +1125,22 @@ mod tests {
     use super::*;
     use soroban_sdk::{testutils::Address as _, testutils::Ledger, Bytes, Env};
 
-    fn evidence(env: &Env, tag: &str) -> Bytes {
+    /// Build a sha256 commitment from raw tag string and a salt.
+    fn make_commitment(env: &Env, evidence_tag: &str, salt_tag: &str) -> Bytes {
+        let evidence = Bytes::from_slice(env, evidence_tag.as_bytes());
+        let salt = Bytes::from_slice(env, salt_tag.as_bytes());
+        let mut data = Bytes::new(env);
+        data.append(&evidence);
+        data.append(&salt);
+        let hash: BytesN<32> = env.crypto().sha256(&data).into();
+        Bytes::from(hash)
+    }
+
+    fn evidence_bytes(env: &Env, tag: &str) -> Bytes {
+        Bytes::from_slice(env, tag.as_bytes())
+    }
+
+    fn salt_bytes(env: &Env, tag: &str) -> Bytes {
         Bytes::from_slice(env, tag.as_bytes())
     }
 
@@ -931,6 +1165,24 @@ mod tests {
         client.set_staked_balance(admin, actor, &amount);
     }
 
+    /// Full commit-reveal helper: submit commitment then immediately reveal.
+    fn commit_and_reveal(
+        env: &Env,
+        client: &SlashingModuleClient<'_>,
+        submitter: &Address,
+        evidence_tag: &str,
+        salt_tag: &str,
+        actor: &Address,
+        offence: &Offence,
+    ) -> u64 {
+        let commitment = make_commitment(env, evidence_tag, salt_tag);
+        let slash_id = client.submit_evidence(submitter, &commitment, actor, offence);
+        let ev = evidence_bytes(env, evidence_tag);
+        let salt = salt_bytes(env, salt_tag);
+        client.reveal_evidence(submitter, &slash_id, &ev, &salt);
+        slash_id
+    }
+
     // ── happy-path slash ──────────────────────────────────────────────────────
 
     #[test]
@@ -941,12 +1193,7 @@ mod tests {
 
         seed_balance(&client, &admin, &actor, 10_000);
 
-        let slash_id = client.submit_evidence(
-            &submitter,
-            &evidence(&env, "ev1"),
-            &actor,
-            &Offence::DoubleSign,
-        );
+        let slash_id = commit_and_reveal(&env, &client, &submitter, "ev1", "salt1", &actor, &Offence::DoubleSign);
 
         // Funds not moved immediately
         assert_eq!(client.staked_balance(&actor), 10_000);
@@ -975,12 +1222,7 @@ mod tests {
 
         seed_balance(&client, &admin, &actor, 100_000);
 
-        let slash_id = client.submit_evidence(
-            &submitter,
-            &evidence(&env, "ev2"),
-            &actor,
-            &Offence::Downtime,
-        );
+        let slash_id = commit_and_reveal(&env, &client, &submitter, "ev2", "salt2", &actor, &Offence::Downtime);
 
         // Advance time
         env.ledger()
@@ -1003,15 +1245,71 @@ mod tests {
         seed_balance(&client, &admin, &actor, 10_000);
         seed_balance(&client, &admin, &actor2, 10_000);
 
-        let ev = evidence(&env, "same_hash");
-        client.submit_evidence(&submitter, &ev, &actor, &Offence::Downtime);
+        let commitment = make_commitment(&env, "same_evidence", "same_salt");
+        client.submit_evidence(&submitter, &commitment, &actor, &Offence::Downtime);
 
-        // Second submission with same hash must fail immediately even if not finalized
-        let result = client.try_submit_evidence(&submitter, &ev, &actor2, &Offence::Downtime);
+        // Second submission with same commitment must fail
+        let result = client.try_submit_evidence(&submitter, &commitment, &actor2, &Offence::Downtime);
         assert_eq!(
             result.unwrap_err().unwrap(),
             ContractError::DuplicateEvidence
         );
+    }
+
+    // ── bad reveal rejected ───────────────────────────────────────────────────
+
+    #[test]
+    fn bad_reveal_rejected() {
+        let env = Env::default();
+        let (admin, submitter, client) = setup(&env);
+        let actor = Address::generate(&env);
+
+        seed_balance(&client, &admin, &actor, 10_000);
+
+        let commitment = make_commitment(&env, "real_ev", "real_salt");
+        let slash_id = client.submit_evidence(&submitter, &commitment, &actor, &Offence::DoubleSign);
+
+        // Reveal with wrong salt → hash mismatch
+        let wrong_salt = salt_bytes(&env, "wrong_salt");
+        let real_ev = evidence_bytes(&env, "real_ev");
+        let err = client
+            .try_reveal_evidence(&submitter, &slash_id, &real_ev, &wrong_salt)
+            .unwrap_err()
+            .unwrap();
+        assert_eq!(err, ContractError::InvalidReveal);
+
+        // Reveal with wrong evidence → hash mismatch
+        let wrong_ev = evidence_bytes(&env, "wrong_ev");
+        let real_salt = salt_bytes(&env, "real_salt");
+        let err2 = client
+            .try_reveal_evidence(&submitter, &slash_id, &wrong_ev, &real_salt)
+            .unwrap_err()
+            .unwrap();
+        assert_eq!(err2, ContractError::InvalidReveal);
+    }
+
+    // ── finalize without reveal rejected ─────────────────────────────────────
+
+    #[test]
+    fn finalize_without_reveal_fails() {
+        let env = Env::default();
+        let (admin, submitter, client) = setup(&env);
+        let actor = Address::generate(&env);
+
+        seed_balance(&client, &admin, &actor, 10_000);
+
+        let commitment = make_commitment(&env, "evX", "saltX");
+        let slash_id = client.submit_evidence(&submitter, &commitment, &actor, &Offence::DoubleSign);
+
+        // Advance past challenge window WITHOUT revealing
+        env.ledger()
+            .set_timestamp(env.ledger().timestamp() + 604_801);
+
+        let err = client
+            .try_finalize_slash(&submitter, &slash_id)
+            .unwrap_err()
+            .unwrap();
+        assert_eq!(err, ContractError::CommitmentNotRevealed);
     }
 
     // ── over-slash boundary ───────────────────────────────────────────────────
@@ -1022,15 +1320,9 @@ mod tests {
         let (admin, submitter, client) = setup(&env);
         let actor = Address::generate(&env);
 
-        // Even if penalty ratio would exceed 100 %, balance must not go negative.
         seed_balance(&client, &admin, &actor, 1); // tiny balance
 
-        let slash_id = client.submit_evidence(
-            &submitter,
-            &evidence(&env, "tiny"),
-            &actor,
-            &Offence::DoubleSign,
-        );
+        let slash_id = commit_and_reveal(&env, &client, &submitter, "tiny", "salttiny", &actor, &Offence::DoubleSign);
 
         env.ledger()
             .set_timestamp(env.ledger().timestamp() + 604_801);
@@ -1049,24 +1341,15 @@ mod tests {
 
         seed_balance(&client, &admin, &actor, 10_000);
 
-        let slash_id = client.submit_evidence(
-            &submitter,
-            &evidence(&env, "ev_j1"),
-            &actor,
-            &Offence::Downtime,
-        );
+        let slash_id = commit_and_reveal(&env, &client, &submitter, "ev_j1", "s1", &actor, &Offence::Downtime);
 
         env.ledger()
             .set_timestamp(env.ledger().timestamp() + 604_801);
         client.finalize_slash(&submitter, &slash_id);
         assert!(client.is_jailed(&actor));
 
-        let result = client.try_submit_evidence(
-            &submitter,
-            &evidence(&env, "ev_j2"),
-            &actor,
-            &Offence::InvalidBlock,
-        );
+        let commitment2 = make_commitment(&env, "ev_j2", "s2");
+        let result = client.try_submit_evidence(&submitter, &commitment2, &actor, &Offence::InvalidBlock);
         assert_eq!(result.unwrap_err().unwrap(), ContractError::AlreadyJailed);
     }
 
@@ -1080,12 +1363,7 @@ mod tests {
 
         seed_balance(&client, &admin, &actor, 10_000);
 
-        let slash_id = client.submit_evidence(
-            &submitter,
-            &evidence(&env, "ev_u1"),
-            &actor,
-            &Offence::Downtime,
-        );
+        let slash_id = commit_and_reveal(&env, &client, &submitter, "ev_u1", "su1", &actor, &Offence::Downtime);
 
         env.ledger()
             .set_timestamp(env.ledger().timestamp() + 604_801);
@@ -1114,12 +1392,7 @@ mod tests {
         let actor = Address::generate(&env);
 
         seed_balance(&client, &admin, &actor, 10_000);
-        let slash_id = client.submit_evidence(
-            &submitter,
-            &evidence(&env, "ev_u2"),
-            &actor,
-            &Offence::Downtime,
-        );
+        let slash_id = commit_and_reveal(&env, &client, &submitter, "ev_u2", "su2", &actor, &Offence::Downtime);
 
         env.ledger()
             .set_timestamp(env.ledger().timestamp() + 604_801);
@@ -1144,12 +1417,8 @@ mod tests {
 
         seed_balance(&client, &admin, &actor, 10_000);
 
-        let result = client.try_submit_evidence(
-            &stranger,
-            &evidence(&env, "ev_s1"),
-            &actor,
-            &Offence::Downtime,
-        );
+        let commitment = make_commitment(&env, "ev_s1", "ss1");
+        let result = client.try_submit_evidence(&stranger, &commitment, &actor, &Offence::Downtime);
         assert_eq!(result.unwrap_err().unwrap(), ContractError::NotAuthorized);
     }
 
@@ -1163,12 +1432,7 @@ mod tests {
 
         seed_balance(&client, &admin, &actor, 10_000);
 
-        let slash_id = client.submit_evidence(
-            &submitter,
-            &evidence(&env, "ev_t1"),
-            &actor,
-            &Offence::DoubleSign,
-        );
+        let slash_id = commit_and_reveal(&env, &client, &submitter, "ev_t1", "st1", &actor, &Offence::DoubleSign);
 
         // Finalizing immediately (before 604,800 seconds) must fail
         let result = client.try_finalize_slash(&submitter, &slash_id);
@@ -1186,8 +1450,8 @@ mod tests {
 
         seed_balance(&client, &admin, &actor, 10_000);
 
-        let ev = evidence(&env, "ev_t2");
-        let slash_id = client.submit_evidence(&submitter, &ev, &actor, &Offence::DoubleSign);
+        let commitment = make_commitment(&env, "ev_t2", "st2");
+        let slash_id = client.submit_evidence(&submitter, &commitment, &actor, &Offence::DoubleSign);
 
         // Cancel during challenge window
         client.cancel_slash(&admin, &slash_id);
@@ -1199,8 +1463,8 @@ mod tests {
         // Staked balance remains unchanged
         assert_eq!(client.staked_balance(&actor), 10_000);
 
-        // Evidence can be submitted again since cancellation cleared the SlashRecord
-        let new_id = client.submit_evidence(&submitter, &ev, &actor, &Offence::DoubleSign);
+        // Commitment can be re-submitted since cancellation cleared the SlashRecord
+        let new_id = client.submit_evidence(&submitter, &commitment, &actor, &Offence::DoubleSign);
         assert_ne!(slash_id, new_id);
     }
 
@@ -1213,12 +1477,7 @@ mod tests {
 
         seed_balance(&client, &admin, &actor, 10_000);
 
-        let slash_id = client.submit_evidence(
-            &submitter,
-            &evidence(&env, "ev_t3"),
-            &actor,
-            &Offence::DoubleSign,
-        );
+        let slash_id = commit_and_reveal(&env, &client, &submitter, "ev_t3", "st3", &actor, &Offence::DoubleSign);
 
         // Stranger cannot finalize
         env.ledger()
@@ -1230,7 +1489,7 @@ mod tests {
         let res_can = client.try_cancel_slash(&stranger, &slash_id);
         assert_eq!(res_can.unwrap_err().unwrap(), ContractError::NotAuthorized);
 
-        // Admin is authorized to cancel or finalize
+        // Admin is authorized to finalize
         client.finalize_slash(&admin, &slash_id);
     }
 
@@ -1249,12 +1508,7 @@ mod tests {
         client.set_challenge_window(&admin, &86_400);
         assert_eq!(client.challenge_window(), 86_400);
 
-        let slash_id = client.submit_evidence(
-            &submitter,
-            &evidence(&env, "ev_t4"),
-            &actor,
-            &Offence::DoubleSign,
-        );
+        let slash_id = commit_and_reveal(&env, &client, &submitter, "ev_t4", "st4", &actor, &Offence::DoubleSign);
 
         // Should fail after 20 hours
         env.ledger()
@@ -1397,12 +1651,7 @@ mod tests {
         client.unpause(&admin);
 
         // submit_evidence should succeed after unpause
-        let slash_id = client.submit_evidence(
-            &submitter,
-            &evidence(&env, "ev_unpause"),
-            &actor,
-            &Offence::Downtime,
-        );
+        let slash_id = commit_and_reveal(&env, &client, &submitter, "ev_unpause", "s_unpause", &actor, &Offence::Downtime);
         // Advance time and finalize the slash
         env.ledger()
             .set_timestamp(env.ledger().timestamp() + 604_801);
@@ -1438,12 +1687,7 @@ mod tests {
         let actor = Address::generate(&env);
 
         seed_balance(&client, &admin, &actor, 10_000);
-        let slash_id = client.submit_evidence(
-            &submitter,
-            &evidence(&env, "ev_getter"),
-            &actor,
-            &Offence::Downtime,
-        );
+        let slash_id = commit_and_reveal(&env, &client, &submitter, "ev_getter", "s_getter", &actor, &Offence::Downtime);
         // Advance time and finalize the slash
         env.ledger()
             .set_timestamp(env.ledger().timestamp() + 604_801);
@@ -1456,5 +1700,125 @@ mod tests {
         assert_eq!(client.slash_count(&actor), 1);
         assert!(client.is_jailed(&actor));
         assert!(client.is_paused());
+    }
+
+    // ── Tiered slashing (Issue #1131) ─────────────────────────────────────────
+
+    #[test]
+    fn configurable_tiers_override_defaults() {
+        let env = Env::default();
+        let (admin, submitter, client) = setup(&env);
+        let actor = Address::generate(&env);
+
+        seed_balance(&client, &admin, &actor, 100_000);
+
+        // Configure: DoubleSign = 5% (500 bps), max = 50% (5000 bps)
+        client.configure_tiers(&admin, &500u32, &100u32, &200u32, &5000u32);
+
+        let slash_id = commit_and_reveal(&env, &client, &submitter, "ev_tier", "st_tier", &actor, &Offence::DoubleSign);
+        env.ledger()
+            .set_timestamp(env.ledger().timestamp() + 604_801);
+        client.finalize_slash(&submitter, &slash_id);
+
+        // 5% of 100_000 = 5_000 slashed → 95_000 remaining
+        assert_eq!(client.staked_balance(&actor), 95_000);
+    }
+
+    #[test]
+    fn max_slash_bps_caps_penalty() {
+        let env = Env::default();
+        let (admin, submitter, client) = setup(&env);
+        let actor = Address::generate(&env);
+
+        seed_balance(&client, &admin, &actor, 100_000);
+
+        // Configure: DoubleSign = 50% but max = 5% → capped at 5%
+        client.configure_tiers(&admin, &5000u32, &100u32, &200u32, &500u32);
+
+        let slash_id = commit_and_reveal(&env, &client, &submitter, "ev_cap", "sc", &actor, &Offence::DoubleSign);
+        env.ledger()
+            .set_timestamp(env.ledger().timestamp() + 604_801);
+        client.finalize_slash(&submitter, &slash_id);
+
+        // Capped at 5% of 100_000 = 5_000 slashed → 95_000 remaining
+        assert_eq!(client.staked_balance(&actor), 95_000);
+    }
+
+    #[test]
+    fn tier_mapping_downtime_vs_double_sign() {
+        let env = Env::default();
+        let (admin, submitter, client) = setup(&env);
+
+        let actor_a = Address::generate(&env);
+        let actor_b = Address::generate(&env);
+        seed_balance(&client, &admin, &actor_a, 100_000);
+        seed_balance(&client, &admin, &actor_b, 100_000);
+
+        // Default tiers: DoubleSign=10%, Downtime=1%
+        let id_a = commit_and_reveal(&env, &client, &submitter, "ev_ds", "ss_ds", &actor_a, &Offence::DoubleSign);
+        let id_b = commit_and_reveal(&env, &client, &submitter, "ev_dt", "ss_dt", &actor_b, &Offence::Downtime);
+
+        env.ledger()
+            .set_timestamp(env.ledger().timestamp() + 604_801);
+        client.finalize_slash(&submitter, &id_a);
+        client.finalize_slash(&submitter, &id_b);
+
+        // DoubleSign slashes more than Downtime
+        let slashed_a = client.total_slashed(&actor_a);
+        let slashed_b = client.total_slashed(&actor_b);
+        assert!(
+            slashed_a > slashed_b,
+            "DoubleSign should slash more: {} vs {}",
+            slashed_a,
+            slashed_b
+        );
+        // DoubleSign = 10_000, Downtime = 1_000
+        assert_eq!(slashed_a, 10_000);
+        assert_eq!(slashed_b, 1_000);
+    }
+
+    // ── propose_slash with tiered bps ─────────────────────────────────────────
+
+    #[test]
+    fn propose_slash_tiered_bps() {
+        let env = Env::default();
+        let (admin, submitter, client) = setup(&env);
+        let actor = Address::generate(&env);
+
+        seed_balance(&client, &admin, &actor, 10_000);
+
+        // Propose with 500 bps (5%)
+        let slash_id = client.propose_slash(&admin, &actor, &500u32);
+
+        env.ledger()
+            .set_timestamp(env.ledger().timestamp() + 604_801);
+        client.finalize_slash(&admin, &slash_id);
+
+        // 5% of 10_000 = 500 slashed
+        assert_eq!(client.total_slashed(&actor), 500);
+    }
+
+    #[test]
+    fn propose_slash_bounded_by_max_bps() {
+        let env = Env::default();
+        let (admin, submitter, client) = setup(&env);
+        let actor = Address::generate(&env);
+
+        seed_balance(&client, &admin, &actor, 10_000);
+
+        // Set max to 10% (1000 bps)
+        client.configure_tiers(&admin, &1000u32, &100u32, &500u32, &1000u32);
+
+        // Propose 50% (5000 bps) → capped to 10% (1000 bps)
+        let slash_id = client.propose_slash(&admin, &actor, &5000u32);
+        let pending = client.get_pending_slash(&slash_id).unwrap();
+        assert_eq!(pending.penalty_bps, 1000, "penalty should be capped at max 1000 bps");
+
+        env.ledger()
+            .set_timestamp(env.ledger().timestamp() + 604_801);
+        client.finalize_slash(&admin, &slash_id);
+
+        // 10% of 10_000 = 1_000 slashed
+        assert_eq!(client.total_slashed(&actor), 1_000);
     }
 }

--- a/contracts/slashing_module/src/lib.rs
+++ b/contracts/slashing_module/src/lib.rs
@@ -95,9 +95,9 @@ pub struct PendingSlash {
 
 /// Default penalty ratios (bps). Overridden by `configure_tiers`.
 pub const DEFAULT_DOUBLE_SIGN_BPS: u32 = 1_000; // 10%
-pub const DEFAULT_DOWNTIME_BPS: u32 = 100;       // 1%
-pub const DEFAULT_INVALID_BLOCK_BPS: u32 = 500;  // 5%
-pub const DEFAULT_MAX_BPS: u32 = 10_000;          // 100%
+pub const DEFAULT_DOWNTIME_BPS: u32 = 100; // 1%
+pub const DEFAULT_INVALID_BLOCK_BPS: u32 = 500; // 5%
+pub const DEFAULT_MAX_BPS: u32 = 10_000; // 100%
 
 // Keep legacy exported names for backward compatibility
 pub const OFFENCE_DOUBLE_SIGN_BPS: u32 = DEFAULT_DOUBLE_SIGN_BPS;
@@ -251,7 +251,12 @@ impl SlashingModule {
                 Symbol::new(&env, "slashing"),
                 Symbol::new(&env, "tiers_configured"),
             ),
-            (double_sign_bps, downtime_bps, invalid_block_bps, max_slash_bps),
+            (
+                double_sign_bps,
+                downtime_bps,
+                invalid_block_bps,
+                max_slash_bps,
+            ),
         );
         Ok(())
     }
@@ -488,10 +493,9 @@ impl SlashingModule {
             penalty_bps,
             slashed_amount: 0, // updated at finalization
         };
-        env.storage().persistent().set(
-            &DataKey::SlashRecord(commitment.clone()),
-            &evidence_record,
-        );
+        env.storage()
+            .persistent()
+            .set(&DataKey::SlashRecord(commitment.clone()), &evidence_record);
 
         // CommitmentRevealed starts false
         env.storage()
@@ -549,10 +553,7 @@ impl SlashingModule {
 
         let computed = Self::hash_commitment(&env, &evidence, &salt);
 
-        let commitment = pending
-            .evidence_hash
-            .clone()
-            .unwrap_or(Bytes::new(&env));
+        let commitment = pending.evidence_hash.clone().unwrap_or(Bytes::new(&env));
 
         if computed != commitment {
             return Err(ContractError::InvalidReveal);
@@ -1193,7 +1194,15 @@ mod tests {
 
         seed_balance(&client, &admin, &actor, 10_000);
 
-        let slash_id = commit_and_reveal(&env, &client, &submitter, "ev1", "salt1", &actor, &Offence::DoubleSign);
+        let slash_id = commit_and_reveal(
+            &env,
+            &client,
+            &submitter,
+            "ev1",
+            "salt1",
+            &actor,
+            &Offence::DoubleSign,
+        );
 
         // Funds not moved immediately
         assert_eq!(client.staked_balance(&actor), 10_000);
@@ -1222,7 +1231,15 @@ mod tests {
 
         seed_balance(&client, &admin, &actor, 100_000);
 
-        let slash_id = commit_and_reveal(&env, &client, &submitter, "ev2", "salt2", &actor, &Offence::Downtime);
+        let slash_id = commit_and_reveal(
+            &env,
+            &client,
+            &submitter,
+            "ev2",
+            "salt2",
+            &actor,
+            &Offence::Downtime,
+        );
 
         // Advance time
         env.ledger()
@@ -1249,7 +1266,8 @@ mod tests {
         client.submit_evidence(&submitter, &commitment, &actor, &Offence::Downtime);
 
         // Second submission with same commitment must fail
-        let result = client.try_submit_evidence(&submitter, &commitment, &actor2, &Offence::Downtime);
+        let result =
+            client.try_submit_evidence(&submitter, &commitment, &actor2, &Offence::Downtime);
         assert_eq!(
             result.unwrap_err().unwrap(),
             ContractError::DuplicateEvidence
@@ -1267,7 +1285,8 @@ mod tests {
         seed_balance(&client, &admin, &actor, 10_000);
 
         let commitment = make_commitment(&env, "real_ev", "real_salt");
-        let slash_id = client.submit_evidence(&submitter, &commitment, &actor, &Offence::DoubleSign);
+        let slash_id =
+            client.submit_evidence(&submitter, &commitment, &actor, &Offence::DoubleSign);
 
         // Reveal with wrong salt → hash mismatch
         let wrong_salt = salt_bytes(&env, "wrong_salt");
@@ -1299,7 +1318,8 @@ mod tests {
         seed_balance(&client, &admin, &actor, 10_000);
 
         let commitment = make_commitment(&env, "evX", "saltX");
-        let slash_id = client.submit_evidence(&submitter, &commitment, &actor, &Offence::DoubleSign);
+        let slash_id =
+            client.submit_evidence(&submitter, &commitment, &actor, &Offence::DoubleSign);
 
         // Advance past challenge window WITHOUT revealing
         env.ledger()
@@ -1322,7 +1342,15 @@ mod tests {
 
         seed_balance(&client, &admin, &actor, 1); // tiny balance
 
-        let slash_id = commit_and_reveal(&env, &client, &submitter, "tiny", "salttiny", &actor, &Offence::DoubleSign);
+        let slash_id = commit_and_reveal(
+            &env,
+            &client,
+            &submitter,
+            "tiny",
+            "salttiny",
+            &actor,
+            &Offence::DoubleSign,
+        );
 
         env.ledger()
             .set_timestamp(env.ledger().timestamp() + 604_801);
@@ -1341,7 +1369,15 @@ mod tests {
 
         seed_balance(&client, &admin, &actor, 10_000);
 
-        let slash_id = commit_and_reveal(&env, &client, &submitter, "ev_j1", "s1", &actor, &Offence::Downtime);
+        let slash_id = commit_and_reveal(
+            &env,
+            &client,
+            &submitter,
+            "ev_j1",
+            "s1",
+            &actor,
+            &Offence::Downtime,
+        );
 
         env.ledger()
             .set_timestamp(env.ledger().timestamp() + 604_801);
@@ -1349,7 +1385,8 @@ mod tests {
         assert!(client.is_jailed(&actor));
 
         let commitment2 = make_commitment(&env, "ev_j2", "s2");
-        let result = client.try_submit_evidence(&submitter, &commitment2, &actor, &Offence::InvalidBlock);
+        let result =
+            client.try_submit_evidence(&submitter, &commitment2, &actor, &Offence::InvalidBlock);
         assert_eq!(result.unwrap_err().unwrap(), ContractError::AlreadyJailed);
     }
 
@@ -1363,7 +1400,15 @@ mod tests {
 
         seed_balance(&client, &admin, &actor, 10_000);
 
-        let slash_id = commit_and_reveal(&env, &client, &submitter, "ev_u1", "su1", &actor, &Offence::Downtime);
+        let slash_id = commit_and_reveal(
+            &env,
+            &client,
+            &submitter,
+            "ev_u1",
+            "su1",
+            &actor,
+            &Offence::Downtime,
+        );
 
         env.ledger()
             .set_timestamp(env.ledger().timestamp() + 604_801);
@@ -1392,7 +1437,15 @@ mod tests {
         let actor = Address::generate(&env);
 
         seed_balance(&client, &admin, &actor, 10_000);
-        let slash_id = commit_and_reveal(&env, &client, &submitter, "ev_u2", "su2", &actor, &Offence::Downtime);
+        let slash_id = commit_and_reveal(
+            &env,
+            &client,
+            &submitter,
+            "ev_u2",
+            "su2",
+            &actor,
+            &Offence::Downtime,
+        );
 
         env.ledger()
             .set_timestamp(env.ledger().timestamp() + 604_801);
@@ -1432,7 +1485,15 @@ mod tests {
 
         seed_balance(&client, &admin, &actor, 10_000);
 
-        let slash_id = commit_and_reveal(&env, &client, &submitter, "ev_t1", "st1", &actor, &Offence::DoubleSign);
+        let slash_id = commit_and_reveal(
+            &env,
+            &client,
+            &submitter,
+            "ev_t1",
+            "st1",
+            &actor,
+            &Offence::DoubleSign,
+        );
 
         // Finalizing immediately (before 604,800 seconds) must fail
         let result = client.try_finalize_slash(&submitter, &slash_id);
@@ -1451,7 +1512,8 @@ mod tests {
         seed_balance(&client, &admin, &actor, 10_000);
 
         let commitment = make_commitment(&env, "ev_t2", "st2");
-        let slash_id = client.submit_evidence(&submitter, &commitment, &actor, &Offence::DoubleSign);
+        let slash_id =
+            client.submit_evidence(&submitter, &commitment, &actor, &Offence::DoubleSign);
 
         // Cancel during challenge window
         client.cancel_slash(&admin, &slash_id);
@@ -1477,7 +1539,15 @@ mod tests {
 
         seed_balance(&client, &admin, &actor, 10_000);
 
-        let slash_id = commit_and_reveal(&env, &client, &submitter, "ev_t3", "st3", &actor, &Offence::DoubleSign);
+        let slash_id = commit_and_reveal(
+            &env,
+            &client,
+            &submitter,
+            "ev_t3",
+            "st3",
+            &actor,
+            &Offence::DoubleSign,
+        );
 
         // Stranger cannot finalize
         env.ledger()
@@ -1508,7 +1578,15 @@ mod tests {
         client.set_challenge_window(&admin, &86_400);
         assert_eq!(client.challenge_window(), 86_400);
 
-        let slash_id = commit_and_reveal(&env, &client, &submitter, "ev_t4", "st4", &actor, &Offence::DoubleSign);
+        let slash_id = commit_and_reveal(
+            &env,
+            &client,
+            &submitter,
+            "ev_t4",
+            "st4",
+            &actor,
+            &Offence::DoubleSign,
+        );
 
         // Should fail after 20 hours
         env.ledger()
@@ -1651,7 +1729,15 @@ mod tests {
         client.unpause(&admin);
 
         // submit_evidence should succeed after unpause
-        let slash_id = commit_and_reveal(&env, &client, &submitter, "ev_unpause", "s_unpause", &actor, &Offence::Downtime);
+        let slash_id = commit_and_reveal(
+            &env,
+            &client,
+            &submitter,
+            "ev_unpause",
+            "s_unpause",
+            &actor,
+            &Offence::Downtime,
+        );
         // Advance time and finalize the slash
         env.ledger()
             .set_timestamp(env.ledger().timestamp() + 604_801);
@@ -1687,7 +1773,15 @@ mod tests {
         let actor = Address::generate(&env);
 
         seed_balance(&client, &admin, &actor, 10_000);
-        let slash_id = commit_and_reveal(&env, &client, &submitter, "ev_getter", "s_getter", &actor, &Offence::Downtime);
+        let slash_id = commit_and_reveal(
+            &env,
+            &client,
+            &submitter,
+            "ev_getter",
+            "s_getter",
+            &actor,
+            &Offence::Downtime,
+        );
         // Advance time and finalize the slash
         env.ledger()
             .set_timestamp(env.ledger().timestamp() + 604_801);
@@ -1715,7 +1809,15 @@ mod tests {
         // Configure: DoubleSign = 5% (500 bps), max = 50% (5000 bps)
         client.configure_tiers(&admin, &500u32, &100u32, &200u32, &5000u32);
 
-        let slash_id = commit_and_reveal(&env, &client, &submitter, "ev_tier", "st_tier", &actor, &Offence::DoubleSign);
+        let slash_id = commit_and_reveal(
+            &env,
+            &client,
+            &submitter,
+            "ev_tier",
+            "st_tier",
+            &actor,
+            &Offence::DoubleSign,
+        );
         env.ledger()
             .set_timestamp(env.ledger().timestamp() + 604_801);
         client.finalize_slash(&submitter, &slash_id);
@@ -1735,7 +1837,15 @@ mod tests {
         // Configure: DoubleSign = 50% but max = 5% → capped at 5%
         client.configure_tiers(&admin, &5000u32, &100u32, &200u32, &500u32);
 
-        let slash_id = commit_and_reveal(&env, &client, &submitter, "ev_cap", "sc", &actor, &Offence::DoubleSign);
+        let slash_id = commit_and_reveal(
+            &env,
+            &client,
+            &submitter,
+            "ev_cap",
+            "sc",
+            &actor,
+            &Offence::DoubleSign,
+        );
         env.ledger()
             .set_timestamp(env.ledger().timestamp() + 604_801);
         client.finalize_slash(&submitter, &slash_id);
@@ -1755,8 +1865,24 @@ mod tests {
         seed_balance(&client, &admin, &actor_b, 100_000);
 
         // Default tiers: DoubleSign=10%, Downtime=1%
-        let id_a = commit_and_reveal(&env, &client, &submitter, "ev_ds", "ss_ds", &actor_a, &Offence::DoubleSign);
-        let id_b = commit_and_reveal(&env, &client, &submitter, "ev_dt", "ss_dt", &actor_b, &Offence::Downtime);
+        let id_a = commit_and_reveal(
+            &env,
+            &client,
+            &submitter,
+            "ev_ds",
+            "ss_ds",
+            &actor_a,
+            &Offence::DoubleSign,
+        );
+        let id_b = commit_and_reveal(
+            &env,
+            &client,
+            &submitter,
+            "ev_dt",
+            "ss_dt",
+            &actor_b,
+            &Offence::Downtime,
+        );
 
         env.ledger()
             .set_timestamp(env.ledger().timestamp() + 604_801);
@@ -1812,7 +1938,10 @@ mod tests {
         // Propose 50% (5000 bps) → capped to 10% (1000 bps)
         let slash_id = client.propose_slash(&admin, &actor, &5000u32);
         let pending = client.get_pending_slash(&slash_id).unwrap();
-        assert_eq!(pending.penalty_bps, 1000, "penalty should be capped at max 1000 bps");
+        assert_eq!(
+            pending.penalty_bps, 1000,
+            "penalty should be capped at max 1000 bps"
+        );
 
         env.ledger()
             .set_timestamp(env.ledger().timestamp() + 604_801);

--- a/pr.md
+++ b/pr.md
@@ -1,0 +1,86 @@
+# Contract Hardening: Reward Conservation, Multisig TTL, Oracle Aggregation, Tiered Slashing
+
+## Summary
+
+Implements four independent contract improvements addressing safety gaps in `epoch_rewards`, `multisig_admin`, `oracle_price_feeds`, and `slashing_module`.
+
+---
+
+## epoch_rewards — Rounding-safe reward distribution and conservation invariants (#1140)
+
+**Problem:** Integer division in pro-rata reward distribution silently discards rounding dust. No invariant guaranteed `Σ claimable(epoch) ≤ funded(epoch)`, and users could call `claim` before any epoch was sealed.
+
+**Changes:**
+- Track `EpochStartIndex(u64)` so seal-time can compute `total_claimable = total_staked × Δindex / SCALE` exactly.
+- Add `dust` and `total_claimable_at_seal` fields to `EpochInfo`; `dust = funded − total_claimable` is always ≥ 0.
+- Carry full funded amount (including dust) to the next epoch via `carried_forward` — no funds are silently lost.
+- Emit `epoch_sealed` event with `(epoch, funded, total_claimable)` for off-chain auditing.
+- Emit `dust_carried` event whenever rounding leaves a remainder.
+- Add `ClaimBeforeSeal` error — `claim()` is rejected until at least one epoch is sealed.
+
+**New tests:** `conservation_uneven_split_sum_never_exceeds_funded`, `dust_tracked_in_epoch_info`, `claim_is_idempotent`, `claim_before_any_seal_is_rejected`, `full_claim_conservation_multi_epoch`.
+
+---
+
+## multisig_admin — Proposal TTL/expiry and approval revocation (#1129)
+
+**Problem:** Approved proposals persisted indefinitely; signers who changed their minds could not withdraw consent; the `approve` path skipped the expiry check.
+
+**Changes:**
+- `approve()` now checks expiry and rejects approvals on expired proposals; emits `proposal_expired`.
+- `revoke_approval(signer, proposal_id)`: removes a signer's prior approval, rebuilds the approvals list, lowers `approval_count`, emits `approval_revoked`.
+- `execute()` re-reads live approvals after potential revocations before checking threshold.
+- Added `multisig_admin` to workspace `Cargo.toml` members.
+
+**New tests:** `expiry_blocks_approve`, `revoke_below_threshold_blocks_execute`, `revoke_then_reapprove_succeeds`, `revoke_without_prior_approval_panics`, `non_signer_cannot_revoke`, `double_approve_is_idempotent_via_rejection`.
+
+---
+
+## oracle_price_feeds — Multi-source median aggregation with quorum and per-source heartbeat (#1130)
+
+**Problem:** A single trusted operator was the entire oracle — single point of failure and manipulation. No resistance to a compromised or stale source.
+
+**Changes:**
+- `add_source(admin, pair, source)` / `remove_source(admin, pair, source)` manage registered sources per feed.
+- `set_quorum(admin, pair, quorum)` configures the minimum number of fresh sources required.
+- `update_price()`: when sources are registered for a feed, authenticates per-source (not admin/operator); applies deviation check against the source's own previous price; emits `source_reported`.
+- `get_price()`: in multi-source mode computes the **median** of fresh source submissions; fails with `NoQuorum` when fewer than quorum sources have fresh data; emits `aggregated_price`. Falls back to legacy single-operator mode when no sources are registered.
+- `is_stale()`: aware of multi-source quorum.
+- New errors: `NoQuorum` (7), `UnknownSource` (8).
+- `median()` helper: selection sort over `Vec<i128>`, no floating point.
+
+**New tests:** quorum-met returns median, stale source ignored, below-quorum errors, outlier rejected by deviation bound, unregistered source rejected, add/remove source, even-count median is average.
+
+---
+
+## slashing_module — Tiered/partial slashing and commit-reveal evidence (#1131)
+
+**Problem:** Slashing was all-or-nothing for a fixed set of tiers with hardcoded BPS; evidence was submitted in the clear enabling front-running; no cap on maximum slash fraction.
+
+**Changes:**
+- **Commit-reveal scheme:**
+  - `submit_evidence(submitter, commitment, actor, offence)` — `commitment = sha256(evidence || salt)`; stores on-chain, never exposes raw evidence.
+  - `reveal_evidence(submitter, slash_id, evidence, salt)` — computes `sha256(evidence || salt)` on-chain and verifies match; marks `CommitmentRevealed(slash_id) = true`.
+  - `finalize_slash()` requires `CommitmentRevealed = true` for validator slashes.
+  - Cancellation clears the commitment entry so re-submission is possible.
+- **Configurable tiers:**
+  - `configure_tiers(admin, double_sign_bps, downtime_bps, invalid_block_bps, max_slash_bps)` overrides hardcoded defaults.
+  - `MaxSlashBps` caps every slash; no slash fraction can exceed it.
+- **`propose_slash(submitter, actor, penalty_bps)`** accepts tier in BPS; computes amount from staked balance; effective BPS capped by `max_slash_bps`.
+- `finalize_slash()` applies balance reduction and tracks `SlashedAmount` for both validator and non-validator slashes.
+- New events: `evidence_committed`, `evidence_revealed`, `slash_finalized(slash_id, amount, penalty_bps)`, `tiers_configured`.
+- New errors: `CommitmentNotRevealed` (15), `InvalidReveal` (16).
+
+**New tests:** `bad_reveal_rejected`, `finalize_without_reveal_fails`, `configurable_tiers_override_defaults`, `max_slash_bps_caps_penalty`, `tier_mapping_downtime_vs_double_sign`, `propose_slash_tiered_bps`, `propose_slash_bounded_by_max_bps`.
+All pre-existing tests updated to use the `commit_and_reveal()` helper.
+
+---
+
+## Test results
+
+```
+epoch_rewards    — 16 passed, 0 failed
+multisig_admin   — 17 passed, 0 failed
+oracle_price_feeds — 19 passed, 0 failed
+slashing_module  — 28 passed, 0 failed
+```


### PR DESCRIPTION
# Contract Hardening: Reward Conservation, Multisig TTL, Oracle Aggregation, Tiered Slashing

## Summary

Implements four independent contract improvements addressing safety gaps in `epoch_rewards`, `multisig_admin`, `oracle_price_feeds`, and `slashing_module`.

closes #1140 
closes #1129 
closes #1130
closes #1131

---

## epoch_rewards — Rounding-safe reward distribution and conservation invariants (#1140)

**Problem:** Integer division in pro-rata reward distribution silently discards rounding dust. No invariant guaranteed `Σ claimable(epoch) ≤ funded(epoch)`, and users could call `claim` before any epoch was sealed.

**Changes:**
- Track `EpochStartIndex(u64)` so seal-time can compute `total_claimable = total_staked × Δindex / SCALE` exactly.
- Add `dust` and `total_claimable_at_seal` fields to `EpochInfo`; `dust = funded − total_claimable` is always ≥ 0.
- Carry full funded amount (including dust) to the next epoch via `carried_forward` — no funds are silently lost.
- Emit `epoch_sealed` event with `(epoch, funded, total_claimable)` for off-chain auditing.
- Emit `dust_carried` event whenever rounding leaves a remainder.
- Add `ClaimBeforeSeal` error — `claim()` is rejected until at least one epoch is sealed.

**New tests:** `conservation_uneven_split_sum_never_exceeds_funded`, `dust_tracked_in_epoch_info`, `claim_is_idempotent`, `claim_before_any_seal_is_rejected`, `full_claim_conservation_multi_epoch`.

---

## multisig_admin — Proposal TTL/expiry and approval revocation (#1129)

**Problem:** Approved proposals persisted indefinitely; signers who changed their minds could not withdraw consent; the `approve` path skipped the expiry check.

**Changes:**
- `approve()` now checks expiry and rejects approvals on expired proposals; emits `proposal_expired`.
- `revoke_approval(signer, proposal_id)`: removes a signer's prior approval, rebuilds the approvals list, lowers `approval_count`, emits `approval_revoked`.
- `execute()` re-reads live approvals after potential revocations before checking threshold.
- Added `multisig_admin` to workspace `Cargo.toml` members.

**New tests:** `expiry_blocks_approve`, `revoke_below_threshold_blocks_execute`, `revoke_then_reapprove_succeeds`, `revoke_without_prior_approval_panics`, `non_signer_cannot_revoke`, `double_approve_is_idempotent_via_rejection`.

---

## oracle_price_feeds — Multi-source median aggregation with quorum and per-source heartbeat (#1130)

**Problem:** A single trusted operator was the entire oracle — single point of failure and manipulation. No resistance to a compromised or stale source.

**Changes:**
- `add_source(admin, pair, source)` / `remove_source(admin, pair, source)` manage registered sources per feed.
- `set_quorum(admin, pair, quorum)` configures the minimum number of fresh sources required.
- `update_price()`: when sources are registered for a feed, authenticates per-source (not admin/operator); applies deviation check against the source's own previous price; emits `source_reported`.
- `get_price()`: in multi-source mode computes the **median** of fresh source submissions; fails with `NoQuorum` when fewer than quorum sources have fresh data; emits `aggregated_price`. Falls back to legacy single-operator mode when no sources are registered.
- `is_stale()`: aware of multi-source quorum.
- New errors: `NoQuorum` (7), `UnknownSource` (8).
- `median()` helper: selection sort over `Vec<i128>`, no floating point.

**New tests:** quorum-met returns median, stale source ignored, below-quorum errors, outlier rejected by deviation bound, unregistered source rejected, add/remove source, even-count median is average.

---

## slashing_module — Tiered/partial slashing and commit-reveal evidence (#1131)

**Problem:** Slashing was all-or-nothing for a fixed set of tiers with hardcoded BPS; evidence was submitted in the clear enabling front-running; no cap on maximum slash fraction.

**Changes:**
- **Commit-reveal scheme:**
  - `submit_evidence(submitter, commitment, actor, offence)` — `commitment = sha256(evidence || salt)`; stores on-chain, never exposes raw evidence.
  - `reveal_evidence(submitter, slash_id, evidence, salt)` — computes `sha256(evidence || salt)` on-chain and verifies match; marks `CommitmentRevealed(slash_id) = true`.
  - `finalize_slash()` requires `CommitmentRevealed = true` for validator slashes.
  - Cancellation clears the commitment entry so re-submission is possible.
- **Configurable tiers:**
  - `configure_tiers(admin, double_sign_bps, downtime_bps, invalid_block_bps, max_slash_bps)` overrides hardcoded defaults.
  - `MaxSlashBps` caps every slash; no slash fraction can exceed it.
- **`propose_slash(submitter, actor, penalty_bps)`** accepts tier in BPS; computes amount from staked balance; effective BPS capped by `max_slash_bps`.
- `finalize_slash()` applies balance reduction and tracks `SlashedAmount` for both validator and non-validator slashes.
- New events: `evidence_committed`, `evidence_revealed`, `slash_finalized(slash_id, amount, penalty_bps)`, `tiers_configured`.
- New errors: `CommitmentNotRevealed` (15), `InvalidReveal` (16).

**New tests:** `bad_reveal_rejected`, `finalize_without_reveal_fails`, `configurable_tiers_override_defaults`, `max_slash_bps_caps_penalty`, `tier_mapping_downtime_vs_double_sign`, `propose_slash_tiered_bps`, `propose_slash_bounded_by_max_bps`.
All pre-existing tests updated to use the `commit_and_reveal()` helper.

---

## Test results

```
epoch_rewards    — 16 passed, 0 failed
multisig_admin   — 17 passed, 0 failed
oracle_price_feeds — 19 passed, 0 failed
slashing_module  — 28 passed, 0 failed
```


## Summary

Briefly describe the change. This section is required for CI PR validation.
If this is a contract upgrade, include:

- Which contract is being upgraded
- Why the upgrade is needed
- Link to any discussion/issues

## Linked issue (recommended)

Example: `Closes #123`

## Changes

This section is required for CI PR validation.

## Contract Upgrade Details (if applicable)

This section is required for CI PR validation if this is a contract upgrade.

### Network

- [ ] Testnet
- [ ] Mainnet

### New Contract

- **Contract ID**: `C...`
- **WASM Hash**: `sha256:...`
- **Deployer Public Key**: `G...`
- **Deploy Transaction**: `[link to transaction explorer]`

### Upgrade Governance

- [ ] Admin/upgrade authority is a multisig requiring maintainer sign-off
- [ ] Maintainer has reviewed and approved the upgrade
- [ ] Upgrade transaction is ready for maintainer signature (provide transaction XDR if applicable)

### Verification Steps

- [ ] New contract deployed successfully
- [ ] All existing tests pass against the new contract
- [ ] Manual testing checklist completed (describe what you tested)
- [ ] No breaking changes for existing integrations (or list them)

## How to test

This section is required for CI PR validation.

- [ ] All automated tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing completed (describe what you tested)

## Security Considerations

This section is required for CI PR validation.

- [ ] No secrets or sensitive data are logged
- [ ] No changes to authentication/authorization logic without review
- [ ] No changes to admin/upgrade logic without review

## Screenshots (if UI)

Include before/after screenshots for any UI changes. For new features, show different states (loading, error, success). For responsive changes, include mobile/tablet/desktop views.

## Checklist

This section is required for CI PR validation.

- [ ] I linked an issue (or explained why one is not needed)
- [ ] I tested locally
- [ ] I did not commit secrets
- [ ] I updated docs if needed
- [ ] Code follows the project's style guidelines
- [ ] CI checks pass
- [ ] If UI changes: I included before/after screenshots
- [ ] If images added/changed: I verified they are optimized and accessible
