### PR TITLE
feat: harden wallet arithmetic, schedule partials, and idempotency gu…

### DIFF
--- a/backend/src/models/ngnWalletStore.ts
+++ b/backend/src/models/ngnWalletStore.ts
@@ -10,19 +10,37 @@ export class InMemoryNgnWalletStore implements NgnWalletStore {
     private wallets: Map<string, NgnWallet> = new Map()
     private ledger: LedgerEntry[] = []
     private locks: Map<string, Promise<void>> = new Map()
+    private walletCreationByUser: Map<string, Promise<NgnWallet>> = new Map()
 
     async createWallet(userId: string): Promise<NgnWallet> {
         const existing = await this.getWalletByUserId(userId)
         if (existing) return existing
 
-        const wallet: NgnWallet = {
-            walletId: crypto.randomUUID(),
-            userId,
-            currency: 'NGN',
-            createdAt: new Date(),
+        const inflight = this.walletCreationByUser.get(userId)
+        if (inflight) {
+            return inflight
         }
-        this.wallets.set(wallet.walletId, wallet)
-        return wallet
+
+        const creation = (async () => {
+            const again = await this.getWalletByUserId(userId)
+            if (again) return again
+
+            const wallet: NgnWallet = {
+                walletId: crypto.randomUUID(),
+                userId,
+                currency: 'NGN',
+                createdAt: new Date(),
+            }
+            this.wallets.set(wallet.walletId, wallet)
+            return wallet
+        })()
+
+        this.walletCreationByUser.set(userId, creation)
+        try {
+            return await creation
+        } finally {
+            this.walletCreationByUser.delete(userId)
+        }
     }
 
     async getWalletByUserId(userId: string): Promise<NgnWallet | null> {
@@ -77,6 +95,7 @@ export class InMemoryNgnWalletStore implements NgnWalletStore {
         this.wallets.clear()
         this.ledger = []
         this.locks.clear()
+        this.walletCreationByUser.clear()
     }
 }
 

--- a/backend/src/services/durableIdempotencyService.test.ts
+++ b/backend/src/services/durableIdempotencyService.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import {
+  durableIdempotencyService,
+  _resetDurableIdempotencyMemory,
+} from './durableIdempotencyService.js'
+
+describe('durableIdempotencyService', () => {
+  beforeEach(() => {
+    _resetDurableIdempotencyMemory()
+  })
+
+  it('executes once and replays stored result on duplicate key', async () => {
+    const scope = 'payments'
+    const key = 'idem-1'
+    const body = { amount: 100 }
+    const hash = durableIdempotencyService.payloadHash(body)
+
+    const first = await durableIdempotencyService.start({
+      scope,
+      idempotencyKey: key,
+      requestBodyHash: hash,
+    })
+    expect(first.type).toBe('proceed')
+
+    await durableIdempotencyService.complete({
+      scope,
+      idempotencyKey: key,
+      httpStatus: 201,
+      body: { ok: true },
+    })
+
+    const second = await durableIdempotencyService.start({
+      scope,
+      idempotencyKey: key,
+      requestBodyHash: hash,
+    })
+    expect(second).toEqual({ type: 'replay', httpStatus: 201, body: { ok: true } })
+  })
+
+  it('returns in_flight while first request is still processing', async () => {
+    const scope = 'payments'
+    const key = 'in-flight'
+    const hash = durableIdempotencyService.payloadHash({ x: 1 })
+
+    const first = await durableIdempotencyService.start({
+      scope,
+      idempotencyKey: key,
+      requestBodyHash: hash,
+    })
+    expect(first.type).toBe('proceed')
+
+    const second = await durableIdempotencyService.start({
+      scope,
+      idempotencyKey: key,
+      requestBodyHash: hash,
+    })
+    expect(second.type).toBe('in_flight')
+  })
+
+  it('allows retry after failed attempt without poisoning the key', async () => {
+    const scope = 'payments'
+    const key = 'retry-key'
+    const hash = durableIdempotencyService.payloadHash({ y: 2 })
+
+    const first = await durableIdempotencyService.start({
+      scope,
+      idempotencyKey: key,
+      requestBodyHash: hash,
+    })
+    expect(first.type).toBe('proceed')
+
+    await durableIdempotencyService.fail({
+      scope,
+      idempotencyKey: key,
+      message: 'transient error',
+    })
+
+    const retry = await durableIdempotencyService.start({
+      scope,
+      idempotencyKey: key,
+      requestBodyHash: hash,
+    })
+    expect(retry.type).toBe('proceed')
+  })
+
+  it('scopes keys independently to prevent cross-operation collisions', async () => {
+    const key = 'shared-key'
+    const hash = durableIdempotencyService.payloadHash({ z: 3 })
+
+    const a = await durableIdempotencyService.start({
+      scope: 'scope-a',
+      idempotencyKey: key,
+      requestBodyHash: hash,
+    })
+    const b = await durableIdempotencyService.start({
+      scope: 'scope-b',
+      idempotencyKey: key,
+      requestBodyHash: hash,
+    })
+
+    expect(a.type).toBe('proceed')
+    expect(b.type).toBe('proceed')
+  })
+
+  it('returns conflict when same key is reused with different payload hash', async () => {
+    const scope = 'payments'
+    const key = 'conflict-key'
+
+    const first = await durableIdempotencyService.start({
+      scope,
+      idempotencyKey: key,
+      requestBodyHash: durableIdempotencyService.payloadHash({ a: 1 }),
+    })
+    expect(first.type).toBe('proceed')
+
+    const conflict = await durableIdempotencyService.start({
+      scope,
+      idempotencyKey: key,
+      requestBodyHash: durableIdempotencyService.payloadHash({ a: 2 }),
+    })
+    expect(conflict.type).toBe('conflict')
+  })
+
+  it('ensures at-most-once side effect under concurrent duplicate starts', async () => {
+    const scope = 'payments'
+    const key = 'concurrent-key'
+    const hash = durableIdempotencyService.payloadHash({ n: 42 })
+    let executions = 0
+
+    const run = async () => {
+      const start = await durableIdempotencyService.start({
+        scope,
+        idempotencyKey: key,
+        requestBodyHash: hash,
+      })
+      if (start.type === 'replay') {
+        return start
+      }
+      if (start.type !== 'proceed') {
+        return start
+      }
+      executions += 1
+      await durableIdempotencyService.complete({
+        scope,
+        idempotencyKey: key,
+        httpStatus: 200,
+        body: { executions },
+      })
+      return { type: 'proceed' as const }
+    }
+
+    const [r1, r2] = await Promise.all([run(), run()])
+    const types = [r1.type, r2.type]
+    expect(types.filter((t) => t === 'proceed').length).toBe(1)
+    expect(executions).toBe(1)
+
+    const replay = await durableIdempotencyService.start({
+      scope,
+      idempotencyKey: key,
+      requestBodyHash: hash,
+    })
+    expect(replay.type).toBe('replay')
+    expect((replay as { body: { executions: number } }).body.executions).toBe(1)
+  })
+
+  it('reclaims stale processing entries via reconcileStale', async () => {
+    vi.useFakeTimers()
+    const scope = 'payments'
+    const key = 'stale-key'
+    const hash = durableIdempotencyService.payloadHash({ stale: true })
+
+    const first = await durableIdempotencyService.start({
+      scope,
+      idempotencyKey: key,
+      requestBodyHash: hash,
+    })
+    expect(first.type).toBe('proceed')
+
+    vi.advanceTimersByTime(16 * 60 * 1000)
+    const { reclaimed } = await durableIdempotencyService.reconcileStale()
+    expect(reclaimed).toBe(1)
+
+    const retry = await durableIdempotencyService.start({
+      scope,
+      idempotencyKey: key,
+      requestBodyHash: hash,
+    })
+    expect(retry.type).toBe('proceed')
+    vi.useRealTimers()
+  })
+})

--- a/backend/src/services/ngnWalletService.concurrency.test.ts
+++ b/backend/src/services/ngnWalletService.concurrency.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { NgnWalletService } from './ngnWalletService.js'
+import { ngnWalletStore } from '../models/ngnWalletStore.js'
+import { depositStore } from '../models/depositStore.js'
+import { userRiskStateStore } from '../models/userRiskStateStore.js'
+import { AppError } from '../errors/AppError.js'
+import { ErrorCode } from '../errors/errorCodes.js'
+
+describe('NgnWalletService - concurrency & balance invariants', () => {
+  let service: NgnWalletService
+  const userId = 'concurrency-user-1'
+
+  beforeEach(async () => {
+    service = new NgnWalletService()
+    await ngnWalletStore.clear()
+    userRiskStateStore.clear()
+    await depositStore.clear()
+  })
+
+  it('allows only one concurrent stake reserve when combined amount exceeds available balance', async () => {
+    const balance = await service.getBalance(userId)
+    const reserveAmount = balance.availableNgn - 1000
+
+    const [first, second] = await Promise.allSettled([
+      service.reserveNgnForStaking(userId, 'staking', 'ref-a', reserveAmount),
+      service.reserveNgnForStaking(userId, 'staking', 'ref-b', reserveAmount),
+    ])
+
+    const successes = [first, second].filter((r) => r.status === 'fulfilled')
+    const failures = [first, second].filter((r) => r.status === 'rejected')
+
+    expect(successes).toHaveLength(1)
+    expect(failures).toHaveLength(1)
+    expect((failures[0] as PromiseRejectedResult).reason).toBeInstanceOf(AppError)
+    expect((failures[0] as PromiseRejectedResult).reason.code).toBe(ErrorCode.VALIDATION_ERROR)
+
+    const after = await service.getBalance(userId)
+    expect(after.availableNgn).toBeGreaterThanOrEqual(0)
+    expect(after.totalNgn).toBeGreaterThanOrEqual(0)
+  })
+
+  it('duplicate top-up reference credits exactly once under concurrent creditTopUp', async () => {
+    const depositId = 'dep-concurrent-1'
+    const reference = 'TOPUP-REF-CONCURRENT'
+
+    const [a, b] = await Promise.all([
+      service.creditTopUp(userId, depositId, 12_000, reference),
+      service.creditTopUp(userId, depositId, 12_000, reference),
+    ])
+
+    const creditedCount = [a, b].filter((r) => r.credited).length
+    expect(creditedCount).toBe(1)
+
+    const ledger = await service.getLedger(userId)
+    const topups = ledger.entries.filter(
+      (e) => e.type === 'TOPUP_CONFIRMED' && e.referenceId === reference,
+    )
+    expect(topups).toHaveLength(1)
+  })
+
+  it('insufficient-funds debit fails cleanly and leaves balance unchanged', async () => {
+    const before = await service.getBalance(userId)
+
+    await expect(
+      service.reserveNgnForStaking(userId, 'staking', 'too-much', before.availableNgn + 1),
+    ).rejects.toMatchObject({
+      code: ErrorCode.VALIDATION_ERROR,
+    })
+
+    const after = await service.getBalance(userId)
+    expect(after.availableNgn).toBe(before.availableNgn)
+    expect(after.totalNgn).toBe(before.totalNgn)
+  })
+
+  it('debit racing reversal serializes through wallet lock without negative balance', async () => {
+    await service.processTopUp(userId, 20_000, 'TOPUP-RACE-CREDIT')
+    await depositStore.confirm({
+      depositId: 'dep-race-1',
+      userId,
+      amountNgn: 20_000,
+      provider: 'onramp',
+      providerRef: 'ONRAMP-RACE-1',
+    })
+
+    const before = await service.getBalance(userId)
+
+    await Promise.all([
+      service.processDepositReversal('onramp', 'ONRAMP-RACE-1', 'REV-RACE-1'),
+      service.reserveNgnForStaking(userId, 'staking', 'race-ref', 5_000),
+    ])
+
+    const after = await service.getBalance(userId)
+    expect(after.totalNgn).toBeGreaterThanOrEqual(0)
+    expect(after.totalNgn).toBe(before.totalNgn - 20_000)
+    expect(after.availableNgn).toBe(before.availableNgn - 20_000 - 5_000)
+    expect(after.heldNgn).toBe(before.heldNgn + 5_000)
+
+    const ledger = await service.getLedger(userId)
+    const reversals = ledger.entries.filter((e) => e.type === 'TOPUP_REVERSED')
+    const reserves = ledger.entries.filter(
+      (e) => e.type === 'STAKE_RESERVE' && e.referenceId === 'race-ref',
+    )
+    expect(reversals).toHaveLength(1)
+    expect(reserves).toHaveLength(1)
+  })
+
+  it('idempotent stake reserve by reference does not apply twice', async () => {
+    const first = await service.reserveNgnForStaking(userId, 'staking', 'idem-ref', 2_000)
+    const second = await service.reserveNgnForStaking(userId, 'staking', 'idem-ref', 2_000)
+
+    expect(first.reserved).toBe(true)
+    expect(second.reserved).toBe(false)
+
+    const ledger = await service.getLedger(userId)
+    const reserves = ledger.entries.filter(
+      (e) => e.type === 'STAKE_RESERVE' && e.referenceId === 'idem-ref',
+    )
+    expect(reserves).toHaveLength(1)
+  })
+})

--- a/backend/src/services/ngnWalletService.ts
+++ b/backend/src/services/ngnWalletService.ts
@@ -195,6 +195,14 @@ export class NgnWalletService {
     const wallet = await this.getOrCreateWallet(userId)
     const release = await ngnWalletStore.acquireLock(wallet.walletId)
     try {
+      const entries = await ngnWalletStore.getLedgerEntriesByWalletId(wallet.walletId)
+      const alreadyCredited = entries.some(
+        (e) => e.type === 'TOPUP_CONFIRMED' && e.referenceId === reference,
+      )
+      if (alreadyCredited) {
+        return
+      }
+
       await ngnWalletStore.createLedgerEntry({
         walletId: wallet.walletId,
         type: 'TOPUP_CONFIRMED',
@@ -248,12 +256,41 @@ export class NgnWalletService {
   }
 
   async creditTopUp(userId: string, depositId: string, amountNgn: number, reference: string): Promise<{ credited: boolean; newBalance: NgnBalanceResponse }> {
-    if (this.creditedDeposits.has(depositId)) {
-      return { credited: false, newBalance: await this.getBalance(userId) }
+    const wallet = await this.getOrCreateWallet(userId)
+    const release = await ngnWalletStore.acquireLock(wallet.walletId)
+    try {
+      if (this.creditedDeposits.has(depositId)) {
+        return { credited: false, newBalance: await this.getBalance(userId) }
+      }
+
+      const entries = await ngnWalletStore.getLedgerEntriesByWalletId(wallet.walletId)
+      const alreadyCredited = entries.some(
+        (e) => e.type === 'TOPUP_CONFIRMED' && e.referenceId === reference,
+      )
+      if (alreadyCredited) {
+        this.creditedDeposits.add(depositId)
+        return { credited: false, newBalance: await this.getBalance(userId) }
+      }
+
+      await ngnWalletStore.createLedgerEntry({
+        walletId: wallet.walletId,
+        type: 'TOPUP_CONFIRMED',
+        amountNgn,
+        referenceType: 'deposit',
+        referenceId: reference
+      })
+      this.creditedDeposits.add(depositId)
+
+      const balance = await this.getBalance(userId)
+      const riskState = await userRiskStateStore.getByUserId(userId)
+      if (riskState?.isFrozen && riskState.freezeReason === 'NEGATIVE_BALANCE' && balance.totalNgn >= 0) {
+        await userRiskStateStore.unfreeze(userId, `Auto-unfrozen after top-up. Balance restored to ${balance.totalNgn} NGN`)
+      }
+
+      return { credited: true, newBalance: balance }
+    } finally {
+      await release()
     }
-    await this.processTopUp(userId, amountNgn, reference)
-    this.creditedDeposits.add(depositId)
-    return { credited: true, newBalance: await this.getBalance(userId) }
   }
 
   async reverseTopUp(userId: string, depositId: string, amountNgn: number, reference: string): Promise<{ reversed: boolean; newBalance: NgnBalanceResponse }> {
@@ -280,6 +317,17 @@ export class NgnWalletService {
     const wallet = await this.getOrCreateWallet(userId)
     const release = await ngnWalletStore.acquireLock(wallet.walletId)
     try {
+      const entries = await ngnWalletStore.getLedgerEntriesByWalletId(wallet.walletId)
+      const alreadyReserved = entries.some(
+        (e) =>
+          e.type === 'STAKE_RESERVE' &&
+          e.referenceType === externalRefSource &&
+          e.referenceId === externalRef,
+      )
+      if (alreadyReserved) {
+        return { reserved: false, newBalance: await this.getBalance(userId) }
+      }
+
       const balance = await this.getBalance(userId)
       if (balance.availableNgn < amountNgn) {
         throw new AppError(ErrorCode.VALIDATION_ERROR, 409, `Insufficient available balance. Available: ${balance.availableNgn}, Requested: ${amountNgn}`)
@@ -333,10 +381,6 @@ export class NgnWalletService {
 
   async initiateWithdrawal(userId: string, request: WithdrawalRequest): Promise<WithdrawalResponse> {
     await this.requireNotFrozen(userId)
-    const balance = await this.getBalance(userId)
-    if (request.amountNgn > balance.availableNgn) {
-      throw new AppError(ErrorCode.VALIDATION_ERROR, 400, `Insufficient balance. Available: ${balance.availableNgn}, Requested: ${request.amountNgn}`)
-    }
 
     const withdrawalId = `wd-${Date.now()}`
     const reference = `WD-${Date.now()}`
@@ -354,6 +398,11 @@ export class NgnWalletService {
     const wallet = await this.getOrCreateWallet(userId)
     const release = await ngnWalletStore.acquireLock(wallet.walletId)
     try {
+      const balance = await this.getBalance(userId)
+      if (request.amountNgn > balance.availableNgn) {
+        throw new AppError(ErrorCode.VALIDATION_ERROR, 400, `Insufficient balance. Available: ${balance.availableNgn}, Requested: ${request.amountNgn}`)
+      }
+
       await ngnWalletStore.createLedgerEntry({
         walletId: wallet.walletId,
         type: 'WITHDRAWAL_PENDING',

--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -1246,6 +1246,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "rent_schedule"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "rent_to_own"
 version = "0.1.0"
 dependencies = [

--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -13,6 +13,7 @@ members = [
   "deal_escrow",
   "contract_access",
   "timelock",
+  "rent_schedule",
   "vesting_schedule",
 
   "schema_registry",

--- a/contracts/rent_schedule/src/lib.rs
+++ b/contracts/rent_schedule/src/lib.rs
@@ -1,16 +1,38 @@
 #![no_std]
 
-use soroban_sdk::{contract, contractimpl, contracttype, Address, BytesN, Env, String, Symbol, Vec};
+use soroban_sdk::{
+    contract, contractimpl, contracttype, Address, BytesN, Env, String, Symbol, Vec,
+};
 
 #[contracttype]
 #[derive(Clone)]
 pub struct ScheduledInstalment {
     pub instalment_number: u32,
     pub due_timestamp: u64,
-    pub amount: i128,
+    pub amount_due: i128,
+    pub amount_paid: i128,
     pub status: InstalmentStatus,
     pub paid_at: Option<u64>,
-    pub tx_id: Option<BytesN<32>>,
+    pub last_tx_id: Option<BytesN<32>>,
+}
+
+#[contracttype]
+#[derive(Clone, Copy, PartialEq, Debug)]
+#[repr(u32)]
+pub enum WaiverReason {
+    Hardship = 1,
+    DisputeResolved = 2,
+    AdminAdjustment = 3,
+    Promotional = 4,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct WaiverAudit {
+    pub actor: Address,
+    pub reason: WaiverReason,
+    pub amount_waived: i128,
+    pub waived_at: u64,
 }
 
 #[contracttype]
@@ -26,6 +48,7 @@ pub enum InstalmentStatus {
 pub enum DataKey {
     Config,
     Schedule(String),
+    Waiver(String, u32),
     Paused,
 }
 
@@ -45,6 +68,16 @@ fn is_paused(env: &Env) -> bool {
 fn require_not_paused(env: &Env) {
     if is_paused(env) {
         panic!("ContractPaused");
+    }
+}
+
+fn instalment_remaining(inst: &ScheduledInstalment) -> i128 {
+    inst.amount_due - inst.amount_paid
+}
+
+fn assert_positive_payment(amount: i128) {
+    if amount <= 0 {
+        panic!("InvalidAmount");
     }
 }
 
@@ -138,7 +171,7 @@ impl RentSchedule {
         {
             panic!("ScheduleExists");
         }
-        let total_amount: i128 = instalments.iter().map(|i| i.amount).sum();
+        let total_amount: i128 = instalments.iter().map(|i| i.amount_due).sum();
         let count = instalments.len();
         env.storage()
             .persistent()
@@ -158,6 +191,7 @@ impl RentSchedule {
         caller: Address,
         deal_id: String,
         instalment_number: u32,
+        amount: i128,
         tx_id: BytesN<32>,
         paid_at: u64,
     ) {
@@ -168,6 +202,8 @@ impl RentSchedule {
             .get(&DataKey::Config)
             .expect("NotInitialized");
         caller.require_auth();
+        assert_positive_payment(amount);
+
         let mut schedule: Vec<ScheduledInstalment> = env
             .storage()
             .persistent()
@@ -178,33 +214,57 @@ impl RentSchedule {
             .position(|i| i.instalment_number == instalment_number)
             .expect("NotFound");
         let mut inst = schedule.get(idx as u32).unwrap();
-        if inst.status != InstalmentStatus::Pending {
+
+        if inst.status == InstalmentStatus::Paid || inst.status == InstalmentStatus::Waived {
             panic!("InvalidStatus");
         }
-        inst.status = InstalmentStatus::Paid;
-        inst.paid_at = Option::Some(paid_at);
-        inst.tx_id = Option::Some(tx_id.clone());
-        let amount = inst.amount;
-        schedule.set(idx as u32, inst);
-        env.storage()
-            .persistent()
-            .set(&DataKey::Schedule(deal_id.clone()), &schedule);
-        env.events().publish(
-            (
-                Symbol::new(&env, "rent_schedule"),
-                Symbol::new(&env, "payment_recorded"),
-                deal_id,
-            ),
-            (instalment_number, amount, tx_id),
-        );
+
+        let remaining = instalment_remaining(&inst);
+        if amount > remaining {
+            panic!("Overpayment");
+        }
+
+        inst.amount_paid += amount;
+        inst.last_tx_id = Option::Some(tx_id.clone());
+
+        if inst.amount_paid == inst.amount_due {
+            inst.status = InstalmentStatus::Paid;
+            inst.paid_at = Option::Some(paid_at);
+            schedule.set(idx as u32, inst.clone());
+            env.storage()
+                .persistent()
+                .set(&DataKey::Schedule(deal_id.clone()), &schedule);
+            env.events().publish(
+                (
+                    Symbol::new(&env, "rent_schedule"),
+                    Symbol::new(&env, "instalment_paid"),
+                    deal_id.clone(),
+                ),
+                (instalment_number, inst.amount_due, tx_id),
+            );
+        } else {
+            schedule.set(idx as u32, inst.clone());
+            env.storage()
+                .persistent()
+                .set(&DataKey::Schedule(deal_id.clone()), &schedule);
+            env.events().publish(
+                (
+                    Symbol::new(&env, "rent_schedule"),
+                    Symbol::new(&env, "partial_payment_recorded"),
+                    deal_id.clone(),
+                ),
+                (
+                    instalment_number,
+                    amount,
+                    inst.amount_paid,
+                    instalment_remaining(&inst),
+                    tx_id,
+                ),
+            );
+        }
     }
 
-    pub fn mark_overdue(
-        env: Env,
-        caller: Address,
-        deal_id: String,
-        instalment_number: u32,
-    ) {
+    pub fn mark_overdue(env: Env, caller: Address, deal_id: String, instalment_number: u32) {
         require_not_paused(&env);
         let cfg: Config = env
             .storage()
@@ -225,10 +285,14 @@ impl RentSchedule {
             .position(|i| i.instalment_number == instalment_number)
             .expect("NotFound");
         let mut inst = schedule.get(idx as u32).unwrap();
-        if inst.status != InstalmentStatus::Pending {
+        if inst.status == InstalmentStatus::Paid || inst.status == InstalmentStatus::Waived {
+            panic!("InvalidStatus");
+        }
+        if instalment_remaining(&inst) <= 0 {
             panic!("InvalidStatus");
         }
         inst.status = InstalmentStatus::Overdue;
+        let remaining = instalment_remaining(&inst);
         schedule.set(idx as u32, inst);
         env.storage()
             .persistent()
@@ -239,7 +303,7 @@ impl RentSchedule {
                 Symbol::new(&env, "instalment_overdue"),
                 deal_id,
             ),
-            instalment_number,
+            (instalment_number, remaining),
         );
     }
 
@@ -248,6 +312,7 @@ impl RentSchedule {
         caller: Address,
         deal_id: String,
         instalment_number: u32,
+        reason: WaiverReason,
     ) {
         let cfg: Config = env
             .storage()
@@ -271,19 +336,53 @@ impl RentSchedule {
         if inst.status == InstalmentStatus::Waived {
             panic!("AlreadyWaived");
         }
+        if inst.status == InstalmentStatus::Paid {
+            panic!("InvalidStatus");
+        }
+
+        let amount_waived = instalment_remaining(&inst);
+        let waived_at = env.ledger().timestamp();
         inst.status = InstalmentStatus::Waived;
         schedule.set(idx as u32, inst);
         env.storage()
             .persistent()
             .set(&DataKey::Schedule(deal_id.clone()), &schedule);
+
+        let audit = WaiverAudit {
+            actor: caller.clone(),
+            reason,
+            amount_waived,
+            waived_at,
+        };
+        env.storage()
+            .persistent()
+            .set(&DataKey::Waiver(deal_id.clone(), instalment_number), &audit);
+
         env.events().publish(
             (
                 Symbol::new(&env, "rent_schedule"),
                 Symbol::new(&env, "instalment_waived"),
                 deal_id,
             ),
-            instalment_number,
+            (
+                instalment_number,
+                caller,
+                reason as u32,
+                amount_waived,
+                waived_at,
+            ),
         );
+    }
+
+    pub fn get_waiver(env: Env, deal_id: String, instalment_number: u32) -> Option<WaiverAudit> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Waiver(deal_id, instalment_number))
+    }
+
+    pub fn instalment_remaining(env: Env, deal_id: String, instalment_number: u32) -> i128 {
+        let inst = Self::get_instalment(env.clone(), deal_id, instalment_number);
+        instalment_remaining(&inst)
     }
 
     /// Returns instalments sorted by instalment_number ascending.
@@ -293,7 +392,6 @@ impl RentSchedule {
             .persistent()
             .get(&DataKey::Schedule(deal_id))
             .unwrap_or(Vec::new(&env));
-        // Insertion-sort by instalment_number
         let len = schedule.len();
         let mut i = 1u32;
         while i < len {
@@ -348,10 +446,11 @@ mod test {
             v.push_back(ScheduledInstalment {
                 instalment_number: i + 1,
                 due_timestamp: (i as u64 + 1) * 30 * 24 * 3600,
-                amount: 100_000i128 * (i as i128 + 1),
+                amount_due: 100_000i128 * (i as i128 + 1),
+                amount_paid: 0,
                 status: InstalmentStatus::Pending,
                 paid_at: Option::None,
-                tx_id: Option::None,
+                last_tx_id: Option::None,
             });
         }
         v
@@ -392,28 +491,72 @@ mod test {
         let deal_id = make_deal_id(&env, "deal_002");
         let instalments = make_instalments(&env, 2);
         client.create_schedule(&admin, &deal_id, &instalments.clone());
-        client.create_schedule(&admin, &deal_id, &instalments); // must panic
+        client.create_schedule(&admin, &deal_id, &instalments);
     }
 
     #[test]
-    fn record_payment_transitions_pending_to_paid() {
+    fn partial_then_full_payment_transitions_to_paid() {
         let env = Env::default();
         env.mock_all_auths();
         let (admin, operator, contract_id) = setup(&env);
         let client = RentScheduleClient::new(&env, &contract_id);
         client.init(&admin, &operator);
 
-        let deal_id = make_deal_id(&env, "deal_003");
-        let instalments = make_instalments(&env, 2);
+        let deal_id = make_deal_id(&env, "deal_partial");
+        let instalments = make_instalments(&env, 1);
         client.create_schedule(&admin, &deal_id, &instalments);
 
-        let tx_id = BytesN::from_array(&env, &[1u8; 32]);
-        client.record_payment(&admin, &deal_id, &1u32, &tx_id, &1_000_000u64);
+        let tx1 = BytesN::from_array(&env, &[1u8; 32]);
+        client.record_payment(&admin, &deal_id, &1u32, &40_000i128, &tx1, &1_000u64);
+        let partial = client.get_instalment(&deal_id, &1u32);
+        assert!(matches!(partial.status, InstalmentStatus::Pending));
+        assert_eq!(partial.amount_paid, 40_000i128);
+        assert_eq!(client.instalment_remaining(&deal_id, &1u32), 60_000i128);
+
+        let tx2 = BytesN::from_array(&env, &[2u8; 32]);
+        client.record_payment(&admin, &deal_id, &1u32, &60_000i128, &tx2, &2_000u64);
+        let paid = client.get_instalment(&deal_id, &1u32);
+        assert!(matches!(paid.status, InstalmentStatus::Paid));
+        assert_eq!(paid.amount_paid, 100_000i128);
+        assert_eq!(client.instalment_remaining(&deal_id, &1u32), 0i128);
+    }
+
+    #[test]
+    #[should_panic(expected = "Overpayment")]
+    fn overpayment_beyond_due_is_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (admin, operator, contract_id) = setup(&env);
+        let client = RentScheduleClient::new(&env, &contract_id);
+        client.init(&admin, &operator);
+
+        let deal_id = make_deal_id(&env, "deal_overpay");
+        let instalments = make_instalments(&env, 1);
+        client.create_schedule(&admin, &deal_id, &instalments);
+
+        let tx = BytesN::from_array(&env, &[3u8; 32]);
+        client.record_payment(&admin, &deal_id, &1u32, &100_001i128, &tx, &1_000u64);
+    }
+
+    #[test]
+    fn mark_overdue_reflects_remaining_on_partial_payment() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (admin, operator, contract_id) = setup(&env);
+        let client = RentScheduleClient::new(&env, &contract_id);
+        client.init(&admin, &operator);
+
+        let deal_id = make_deal_id(&env, "deal_overdue_partial");
+        let instalments = make_instalments(&env, 1);
+        client.create_schedule(&admin, &deal_id, &instalments);
+
+        let tx = BytesN::from_array(&env, &[4u8; 32]);
+        client.record_payment(&admin, &deal_id, &1u32, &25_000i128, &tx, &1_000u64);
+        client.mark_overdue(&admin, &deal_id, &1u32);
 
         let inst = client.get_instalment(&deal_id, &1u32);
-        assert!(matches!(inst.status, InstalmentStatus::Paid));
-        assert!(inst.paid_at.is_some());
-        assert!(inst.tx_id.is_some());
+        assert!(matches!(inst.status, InstalmentStatus::Overdue));
+        assert_eq!(client.instalment_remaining(&deal_id, &1u32), 75_000i128);
     }
 
     #[test]
@@ -430,25 +573,8 @@ mod test {
         client.create_schedule(&admin, &deal_id, &instalments);
 
         let tx_id = BytesN::from_array(&env, &[2u8; 32]);
-        client.record_payment(&admin, &deal_id, &1u32, &tx_id, &1_000_000u64);
-        client.mark_overdue(&admin, &deal_id, &1u32); // must panic: InvalidStatus
-    }
-
-    #[test]
-    fn mark_overdue_transitions_pending_to_overdue() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let (admin, operator, contract_id) = setup(&env);
-        let client = RentScheduleClient::new(&env, &contract_id);
-        client.init(&admin, &operator);
-
-        let deal_id = make_deal_id(&env, "deal_005");
-        let instalments = make_instalments(&env, 1);
-        client.create_schedule(&admin, &deal_id, &instalments);
-
+        client.record_payment(&admin, &deal_id, &1u32, &100_000i128, &tx_id, &1_000_000u64);
         client.mark_overdue(&admin, &deal_id, &1u32);
-        let inst = client.get_instalment(&deal_id, &1u32);
-        assert!(matches!(inst.status, InstalmentStatus::Overdue));
     }
 
     #[test]
@@ -459,32 +585,34 @@ mod test {
         let client = RentScheduleClient::new(&env, &contract_id);
         client.init(&admin, &operator);
 
-        // Create instalments in reverse order
         let deal_id = make_deal_id(&env, "deal_006");
         let mut v: Vec<ScheduledInstalment> = Vec::new(&env);
         v.push_back(ScheduledInstalment {
             instalment_number: 3,
             due_timestamp: 90,
-            amount: 300,
+            amount_due: 300,
+            amount_paid: 0,
             status: InstalmentStatus::Pending,
             paid_at: Option::None,
-            tx_id: Option::None,
+            last_tx_id: Option::None,
         });
         v.push_back(ScheduledInstalment {
             instalment_number: 1,
             due_timestamp: 30,
-            amount: 100,
+            amount_due: 100,
+            amount_paid: 0,
             status: InstalmentStatus::Pending,
             paid_at: Option::None,
-            tx_id: Option::None,
+            last_tx_id: Option::None,
         });
         v.push_back(ScheduledInstalment {
             instalment_number: 2,
             due_timestamp: 60,
-            amount: 200,
+            amount_due: 200,
+            amount_paid: 0,
             status: InstalmentStatus::Pending,
             paid_at: Option::None,
-            tx_id: Option::None,
+            last_tx_id: Option::None,
         });
         client.create_schedule(&admin, &deal_id, &v);
 
@@ -495,20 +623,23 @@ mod test {
     }
 
     #[test]
-    fn waived_instalment_no_further_transitions() {
+    fn waiver_persists_audit_fields() {
         let env = Env::default();
         env.mock_all_auths();
         let (admin, operator, contract_id) = setup(&env);
         let client = RentScheduleClient::new(&env, &contract_id);
         client.init(&admin, &operator);
 
-        let deal_id = make_deal_id(&env, "deal_007");
+        let deal_id = make_deal_id(&env, "deal_waiver");
         let instalments = make_instalments(&env, 1);
         client.create_schedule(&admin, &deal_id, &instalments);
-        client.waive_instalment(&admin, &deal_id, &1u32);
+        client.waive_instalment(&admin, &deal_id, &1u32, &WaiverReason::Hardship);
 
-        let inst = client.get_instalment(&deal_id, &1u32);
-        assert!(matches!(inst.status, InstalmentStatus::Waived));
+        let audit = client.get_waiver(&deal_id, &1u32).unwrap();
+        assert_eq!(audit.actor, admin);
+        assert_eq!(audit.reason, WaiverReason::Hardship);
+        assert_eq!(audit.amount_waived, 100_000i128);
+        assert_eq!(audit.waived_at, env.ledger().timestamp());
     }
 
     #[test]
@@ -523,10 +654,29 @@ mod test {
         let deal_id = make_deal_id(&env, "deal_008");
         let instalments = make_instalments(&env, 1);
         client.create_schedule(&admin, &deal_id, &instalments);
-        client.waive_instalment(&admin, &deal_id, &1u32);
+        client.waive_instalment(&admin, &deal_id, &1u32, &WaiverReason::AdminAdjustment);
 
         let tx_id = BytesN::from_array(&env, &[3u8; 32]);
-        client.record_payment(&admin, &deal_id, &1u32, &tx_id, &1_000_000u64); // must panic
+        client.record_payment(&admin, &deal_id, &1u32, &1_000i128, &tx_id, &1_000_000u64);
+    }
+
+    #[test]
+    #[should_panic(expected = "InvalidStatus")]
+    fn double_pay_on_paid_instalment_fails() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (admin, operator, contract_id) = setup(&env);
+        let client = RentScheduleClient::new(&env, &contract_id);
+        client.init(&admin, &operator);
+
+        let deal_id = make_deal_id(&env, "deal_double_pay");
+        let instalments = make_instalments(&env, 1);
+        client.create_schedule(&admin, &deal_id, &instalments);
+
+        let tx1 = BytesN::from_array(&env, &[5u8; 32]);
+        client.record_payment(&admin, &deal_id, &1u32, &100_000i128, &tx1, &1_000u64);
+        let tx2 = BytesN::from_array(&env, &[6u8; 32]);
+        client.record_payment(&admin, &deal_id, &1u32, &1i128, &tx2, &2_000u64);
     }
 
     #[test]
@@ -544,7 +694,7 @@ mod test {
         client.pause(&admin);
 
         let tx_id = BytesN::from_array(&env, &[4u8; 32]);
-        client.record_payment(&admin, &deal_id, &1u32, &tx_id, &1_000_000u64); // must panic
+        client.record_payment(&admin, &deal_id, &1u32, &1_000i128, &tx_id, &1_000_000u64);
     }
 
     #[test]
@@ -560,7 +710,7 @@ mod test {
         let instalments = make_instalments(&env, 1);
         client.create_schedule(&admin, &deal_id, &instalments);
         client.pause(&admin);
-        client.mark_overdue(&admin, &deal_id, &1u32); // must panic
+        client.mark_overdue(&admin, &deal_id, &1u32);
     }
 
     #[test]
@@ -578,7 +728,7 @@ mod test {
         client.unpause(&admin);
 
         let tx_id = BytesN::from_array(&env, &[5u8; 32]);
-        client.record_payment(&admin, &deal_id, &1u32, &tx_id, &1_000_000u64);
+        client.record_payment(&admin, &deal_id, &1u32, &100_000i128, &tx_id, &1_000_000u64);
         let inst = client.get_instalment(&deal_id, &1u32);
         assert!(matches!(inst.status, InstalmentStatus::Paid));
     }

--- a/contracts/rent_wallet/src/lib.rs
+++ b/contracts/rent_wallet/src/lib.rs
@@ -73,6 +73,8 @@ pub enum ContractError {
     UpgradeDelayNotMet = 8,
     /// Amount exceeds the allowed maximum (prevents overflow cascades)
     AmountTooLarge = 9,
+    /// Credit would overflow the stored balance (checked arithmetic)
+    BalanceOverflow = 17,
     /// Time/lock value exceeds the safe upper bound
     InvalidTimeValue = 10,
     /// String field was empty
@@ -183,12 +185,13 @@ impl RentWallet {
         let current_admin = get_admin(&env);
         access_control::require_admin_permission(&env, &current_admin, &admin, "credit")?;
         require_not_paused(&env)?;
-        if amount <= 0 {
-            return Err(ContractError::InvalidAmount);
-        }
+        validation::validate_amount(amount)?;
 
         let cur = get_balance(&env, &user);
-        put_balance(&env, &user, cur + amount);
+        let new_balance = cur
+            .checked_add(amount)
+            .ok_or(ContractError::BalanceOverflow)?;
+        put_balance(&env, &user, new_balance);
 
         env.events().publish(
             (
@@ -211,15 +214,14 @@ impl RentWallet {
         let current_admin = get_admin(&env);
         access_control::require_admin_permission(&env, &current_admin, &admin, "debit")?;
         require_not_paused(&env)?;
-        if amount <= 0 {
-            return Err(ContractError::InvalidAmount);
-        }
+        validation::validate_amount(amount)?;
 
         let cur = get_balance(&env, &user);
         if cur < amount {
             return Err(ContractError::InsufficientBalance);
         }
-        put_balance(&env, &user, cur - amount);
+        let new_balance = cur - amount;
+        put_balance(&env, &user, new_balance);
 
         env.events().publish(
             (
@@ -533,7 +535,7 @@ impl RentWallet {
 mod test {
     extern crate std;
 
-    use super::{ContractError, RentWallet, RentWalletClient};
+    use super::{validation, ContractError, DataKey, RentWallet, RentWalletClient};
     use soroban_sdk::testutils::{Address as _, MockAuth, MockAuthInvoke};
     use soroban_sdk::{Address, BytesN, Env, IntoVal};
 
@@ -1399,5 +1401,242 @@ mod test {
             .unwrap_err()
             .unwrap();
         assert_eq!(err2, ContractError::UpgradeAlreadyPending);
+    }
+
+    // ============================================================================
+    // Arithmetic safety & property invariants (#1141)
+    // ============================================================================
+
+    fn mock_admin_credit(
+        env: &Env,
+        contract_id: &Address,
+        client: &RentWalletClient,
+        admin: &Address,
+        user: &Address,
+        amount: i128,
+    ) {
+        env.mock_auths(&[MockAuth {
+            address: admin,
+            invoke: &MockAuthInvoke {
+                contract: contract_id,
+                fn_name: "credit",
+                args: (admin.clone(), user.clone(), amount).into_val(env),
+                sub_invokes: &[],
+            },
+        }]);
+        client.try_credit(admin, user, &amount).unwrap().unwrap();
+    }
+
+    #[test]
+    fn credit_overflow_returns_error_without_mutating_balance() {
+        let env = Env::default();
+        let (contract_id, client, admin, user, _non_admin) = setup(&env);
+
+        env.as_contract(&contract_id, || {
+            env.storage()
+                .persistent()
+                .set(&DataKey::Balance(user.clone()), &(i128::MAX - 1));
+        });
+
+        env.mock_auths(&[MockAuth {
+            address: &admin,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "credit",
+                args: (admin.clone(), user.clone(), 2i128).into_val(&env),
+                sub_invokes: &[],
+            },
+        }]);
+        let err = client
+            .try_credit(&admin, &user, &2i128)
+            .unwrap_err()
+            .unwrap();
+        assert_eq!(err, ContractError::BalanceOverflow);
+        assert_eq!(client.balance(&user), i128::MAX - 1);
+    }
+
+    #[test]
+    fn credit_at_max_amount_boundary_succeeds_from_zero() {
+        let env = Env::default();
+        let (contract_id, client, admin, user, _non_admin) = setup(&env);
+        mock_admin_credit(
+            &env,
+            &contract_id,
+            &client,
+            &admin,
+            &user,
+            validation::MAX_AMOUNT,
+        );
+        assert_eq!(client.balance(&user), validation::MAX_AMOUNT);
+    }
+
+    #[test]
+    fn debit_exact_balance_succeeds_and_debit_over_balance_is_rejected() {
+        let env = Env::default();
+        let (contract_id, client, admin, user, _non_admin) = setup(&env);
+        mock_admin_credit(&env, &contract_id, &client, &admin, &user, 75i128);
+
+        env.mock_auths(&[MockAuth {
+            address: &admin,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "debit",
+                args: (admin.clone(), user.clone(), 75i128).into_val(&env),
+                sub_invokes: &[],
+            },
+        }]);
+        client.try_debit(&admin, &user, &75i128).unwrap().unwrap();
+        assert_eq!(client.balance(&user), 0i128);
+
+        let before = client.balance(&user);
+        env.mock_auths(&[MockAuth {
+            address: &admin,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "debit",
+                args: (admin.clone(), user.clone(), 1i128).into_val(&env),
+                sub_invokes: &[],
+            },
+        }]);
+        let err = client
+            .try_debit(&admin, &user, &1i128)
+            .unwrap_err()
+            .unwrap();
+        assert_eq!(err, ContractError::InsufficientBalance);
+        assert_eq!(client.balance(&user), before);
+    }
+
+    #[test]
+    fn rejected_credit_and_debit_leave_balance_unchanged() {
+        let env = Env::default();
+        let (contract_id, client, admin, user, _non_admin) = setup(&env);
+        mock_admin_credit(&env, &contract_id, &client, &admin, &user, 40i128);
+        let before = client.balance(&user);
+
+        env.mock_auths(&[MockAuth {
+            address: &admin,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "credit",
+                args: (admin.clone(), user.clone(), 0i128).into_val(&env),
+                sub_invokes: &[],
+            },
+        }]);
+        assert_eq!(
+            client
+                .try_credit(&admin, &user, &0i128)
+                .unwrap_err()
+                .unwrap(),
+            ContractError::InvalidAmount
+        );
+        assert_eq!(client.balance(&user), before);
+
+        env.mock_auths(&[MockAuth {
+            address: &admin,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "debit",
+                args: (admin.clone(), user.clone(), 100i128).into_val(&env),
+                sub_invokes: &[],
+            },
+        }]);
+        assert_eq!(
+            client
+                .try_debit(&admin, &user, &100i128)
+                .unwrap_err()
+                .unwrap(),
+            ContractError::InsufficientBalance
+        );
+        assert_eq!(client.balance(&user), before);
+    }
+
+    #[test]
+    fn non_admin_cannot_credit_or_debit() {
+        let env = Env::default();
+        let (contract_id, client, admin, user, non_admin) = setup(&env);
+        mock_admin_credit(&env, &contract_id, &client, &admin, &user, 10i128);
+
+        env.mock_auths(&[MockAuth {
+            address: &non_admin,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "credit",
+                args: (non_admin.clone(), user.clone(), 5i128).into_val(&env),
+                sub_invokes: &[],
+            },
+        }]);
+        assert_eq!(
+            client
+                .try_credit(&non_admin, &user, &5i128)
+                .unwrap_err()
+                .unwrap(),
+            ContractError::NotAuthorized
+        );
+
+        env.mock_auths(&[MockAuth {
+            address: &non_admin,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "debit",
+                args: (non_admin.clone(), user.clone(), 1i128).into_val(&env),
+                sub_invokes: &[],
+            },
+        }]);
+        assert_eq!(
+            client
+                .try_debit(&non_admin, &user, &1i128)
+                .unwrap_err()
+                .unwrap(),
+            ContractError::NotAuthorized
+        );
+        assert_eq!(client.balance(&user), 10i128);
+    }
+
+    #[test]
+    fn property_randomized_credit_debit_sequence_preserves_balance_invariant() {
+        let env = Env::default();
+        let (contract_id, client, admin, user, _non_admin) = setup(&env);
+
+        let mut rng: u64 = 0xC0FFEE_u64;
+        let mut net_applied: i128 = 0;
+        const OPS: u32 = 200;
+
+        for step in 0..OPS {
+            rng = rng.wrapping_mul(1_103_515_245).wrapping_add(12_345);
+            let roll = (rng % 100) as u32;
+            let amount = ((rng % 50) + 1) as i128;
+
+            if roll < 45 {
+                env.mock_auths(&[MockAuth {
+                    address: &admin,
+                    invoke: &MockAuthInvoke {
+                        contract: &contract_id,
+                        fn_name: "credit",
+                        args: (admin.clone(), user.clone(), amount).into_val(&env),
+                        sub_invokes: &[],
+                    },
+                }]);
+                if matches!(client.try_credit(&admin, &user, &amount), Ok(Ok(()))) {
+                    net_applied += amount;
+                }
+            } else {
+                env.mock_auths(&[MockAuth {
+                    address: &admin,
+                    invoke: &MockAuthInvoke {
+                        contract: &contract_id,
+                        fn_name: "debit",
+                        args: (admin.clone(), user.clone(), amount).into_val(&env),
+                        sub_invokes: &[],
+                    },
+                }]);
+                if matches!(client.try_debit(&admin, &user, &amount), Ok(Ok(()))) {
+                    net_applied -= amount;
+                }
+            }
+
+            let balance = client.balance(&user);
+            assert!(balance >= 0, "negative balance at step {}", step);
+            assert_eq!(balance, net_applied, "balance drift at step {}", step);
+        }
     }
 }


### PR DESCRIPTION
## Summary

Hardens core money primitives across contracts and backend:

- **#1141** — `rent_wallet` checked arithmetic + property/boundary invariant tests
- **#1142** — `rent_schedule` partial payments, waiver audit trail, and lifecycle events
- **#1146** — `durableIdempotencyService` concurrency/idempotency regression tests
- **#1147** — `NgnWalletService` concurrency guards and balance invariant tests

Closes #1141
Closes #1142
Closes #1146
Closes #1147

## Changes

### Contracts
- `rent_wallet`: use `validate_amount` + `checked_add` for credit; explicit `BalanceOverflow`; randomized sequence invariant tests; boundary/auth coverage
- `rent_schedule`: track `amount_paid` vs `amount_due`; partial/full payment flow; overpayment rejection; structured waiver audit (`actor`, `reason`, `amount_waived`, `waived_at`); events `partial_payment_recorded`, `instalment_paid`, `instalment_waived`
- Added `rent_schedule` to contracts workspace `Cargo.toml`

### Backend
- `ngnWalletService`: atomic top-up idempotency (depositId + reference), withdrawal balance check under lock, reserve idempotency by reference
- `ngnWalletStore`: race-safe wallet creation for concurrent first access
- New tests: `durableIdempotencyService.test.ts`, `ngnWalletService.concurrency.test.ts`

## How to test

- [ ] `cargo test -p rent_wallet -p rent_schedule --manifest-path contracts/Cargo.toml`
- [ ] `cd backend && npm test -- src/services/durableIdempotencyService.test.ts src/services/ngnWalletService.concurrency.test.ts`
- [ ] `cargo fmt --all --manifest-path contracts/Cargo.toml -- --check`

## Security Considerations

- [x] Prevents balance overflow and over-debit at contract layer
- [x] Rejected wallet ops leave state unchanged (tested)
- [x] Idempotent top-up/reserve paths reduce double-spend risk under concurrency
- [x] Durable idempotency at-most-once semantics covered by regression tests

## Checklist

- [x] I linked issues (`Closes #1141`, `Closes #1142`, `Closes #1146`, `Closes #1147`)
- [x] I tested locally
- [x] I did not commit secrets
- [x] Code follows project style guidelines
- [ ] CI checks pass