### PR TITLE
test(backend): add comprehensive tests for outbox processor, webhook replay, erasure, and admin signing services

### DIFF
--- a/backend/src/services/adminSigningService.test.ts
+++ b/backend/src/services/adminSigningService.test.ts
@@ -1,0 +1,360 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ConfigurationError, TransactionError } from '../soroban/errors.js'
+
+const { mockGetActiveKey, mockRetrieveKeyMaterial, mockAllocateSequence, mockMarkConfirmed, mockMarkFailed } = vi.hoisted(() => ({
+  mockGetActiveKey: vi.fn().mockResolvedValue(null),
+  mockRetrieveKeyMaterial: vi.fn(),
+  mockAllocateSequence: vi.fn().mockResolvedValue({ sequence: BigInt(100), allocationId: 'alloc-1' }),
+  mockMarkConfirmed: vi.fn().mockResolvedValue(undefined),
+  mockMarkFailed: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('../services/signingKeyRotationService.js', () => ({
+  getSigningKeyRotationService: vi.fn(() => ({
+    getActiveKey: mockGetActiveKey,
+    retrieveKeyMaterial: mockRetrieveKeyMaterial,
+  })),
+}))
+
+vi.mock('../services/stellarSequenceAllocator.js', () => ({
+  getStellarSequenceAllocator: vi.fn(() => ({
+    allocateSequence: mockAllocateSequence,
+    markConfirmed: mockMarkConfirmed,
+    markFailed: mockMarkFailed,
+  })),
+}))
+
+vi.mock('../utils/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+  },
+}))
+
+const mockGetAccount = vi.fn().mockResolvedValue({ sequenceNumber: () => '100' })
+const mockSendTransaction = vi.fn().mockResolvedValue({ status: 'PENDING', hash: 'tx-hash-123' })
+const mockGetTransaction = vi.fn().mockResolvedValue({ status: 'SUCCESS' })
+
+vi.mock('@stellar/stellar-sdk', () => {
+  return {
+    Keypair: {
+      fromSecret: vi.fn().mockReturnValue({
+        publicKey: () => 'GADMINPUBLICKEY1234567890',
+        sign: vi.fn(),
+      }),
+    },
+    TransactionBuilder: class MockTransactionBuilder {
+      constructor(_account: any, _opts: any) {}
+      addOperation(_op: any) { return this }
+      setTimeout(_t: any) { return this }
+      build() {
+        return { sign: vi.fn(), toXDR: vi.fn().mockReturnValue('mock-xdr') }
+      }
+    },
+    Operation: {
+      invokeHostFunction: vi.fn().mockReturnValue('mock-operation'),
+    },
+    xdr: {
+      HostFunction: {
+        hostFunctionTypeInvokeContract: vi.fn().mockReturnValue('mock-host-fn'),
+      },
+      InvokeContractArgs: class MockInvokeContractArgs {
+        constructor(_args: any) {}
+      },
+      ScVal: {},
+    },
+    Address: {
+      fromString: vi.fn().mockReturnValue({
+        toScAddress: vi.fn().mockReturnValue('mock-address'),
+      }),
+    },
+    rpc: {
+      Server: vi.fn().mockImplementation(() => ({
+        getAccount: mockGetAccount,
+        sendTransaction: mockSendTransaction,
+        getTransaction: mockGetTransaction,
+      })),
+    },
+    Account: class MockAccount {
+      constructor(public _address: string, public _sequence: string) {}
+    },
+  }
+})
+
+import { AdminSigningService, type AdminOperationParams } from './adminSigningService.js'
+
+function makeParams(overrides: Partial<AdminOperationParams> = {}): AdminOperationParams {
+  return {
+    contractId: 'CCONTRACT1234567890ABCDEF',
+    operation: 'pause',
+    args: [],
+    networkPassphrase: 'Test SDF Future Network ; October 2022',
+    adminSecret: 'SADMINSECRET1234567890ABCDEF',
+    server: { getAccount: mockGetAccount, sendTransaction: mockSendTransaction, getTransaction: mockGetTransaction } as any,
+    ...overrides,
+  }
+}
+
+describe('AdminSigningService', () => {
+  let service: AdminSigningService
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    mockGetActiveKey.mockResolvedValue(null)
+    mockAllocateSequence.mockResolvedValue({ sequence: BigInt(100), allocationId: 'alloc-1' })
+    mockMarkConfirmed.mockResolvedValue(undefined)
+    mockMarkFailed.mockResolvedValue(undefined)
+    mockGetAccount.mockResolvedValue({ sequenceNumber: () => '100' })
+    mockSendTransaction.mockResolvedValue({ status: 'PENDING', hash: 'tx-hash-123' })
+    mockGetTransaction.mockResolvedValue({ status: 'SUCCESS' })
+
+    service = new AdminSigningService({
+      enabled: true,
+      adminSecret: 'SADMINSECRET1234567890ABCDEF',
+      networkPassphrase: 'Test SDF Future Network ; October 2022',
+      server: { getAccount: mockGetAccount, sendTransaction: mockSendTransaction, getTransaction: mockGetTransaction } as any,
+    })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  async function executeWithAdvance(params?: AdminOperationParams) {
+    const promise = service.executeAdminOperation(params ?? makeParams())
+    await vi.advanceTimersByTimeAsync(30_000)
+    return promise
+  }
+
+  // ---------------------------------------------------------------------------
+  // isEnabled
+  // ---------------------------------------------------------------------------
+  describe('isEnabled', () => {
+    it('returns true when enabled and adminSecret is set', () => {
+      expect(service.isEnabled()).toBe(true)
+    })
+
+    it('returns false when disabled', () => {
+      const disabled = new AdminSigningService({
+        enabled: false,
+        adminSecret: 'SADMINSECRET1234567890ABCDEF',
+        networkPassphrase: 'Test',
+        server: {} as any,
+      })
+      expect(disabled.isEnabled()).toBe(false)
+    })
+
+    it('returns false when adminSecret is missing', () => {
+      const noSecret = new AdminSigningService({
+        enabled: true,
+        networkPassphrase: 'Test',
+        server: {} as any,
+      })
+      expect(noSecret.isEnabled()).toBe(false)
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Authorization — per-operation
+  // ---------------------------------------------------------------------------
+  describe('authorization', () => {
+    it('rejects when service is disabled', async () => {
+      const disabled = new AdminSigningService({
+        enabled: false,
+        adminSecret: 'SADMINSECRET1234567890ABCDEF',
+        networkPassphrase: 'Test',
+        server: {} as any,
+      })
+
+      await expect(disabled.executeAdminOperation(makeParams())).rejects.toThrow(ConfigurationError)
+    })
+
+    it('rejects when adminSecret is missing', async () => {
+      const noSecret = new AdminSigningService({
+        enabled: true,
+        networkPassphrase: 'Test',
+        server: {} as any,
+      })
+
+      await expect(noSecret.executeAdminOperation(makeParams())).rejects.toThrow(ConfigurationError)
+    })
+
+    it('rejects operations not in the whitelist', async () => {
+      await expect(
+        service.executeAdminOperation(makeParams({ operation: 'unauthorized_op' as any })),
+      ).rejects.toThrow(ConfigurationError)
+    })
+
+    it('allows all whitelisted operations', async () => {
+      const allowedOps = [
+        'pause', 'unpause', 'set_operator', 'init', 'execute', 'cancel',
+        'activate_deal', 'complete_deal', 'default_deal', 'stake_bond', 'unstake_bond',
+      ] as const
+
+      for (const op of allowedOps) {
+        const hash = await executeWithAdvance(makeParams({ operation: op }))
+        expect(hash).toBeDefined()
+        expect(typeof hash).toBe('string')
+      }
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Audit logging
+  // ---------------------------------------------------------------------------
+  describe('audit logging', () => {
+    it('logs operation initiated before execution', async () => {
+      const { logger } = await import('../utils/logger.js')
+      const infoSpy = vi.mocked(logger.info)
+
+      await executeWithAdvance()
+
+      expect(infoSpy).toHaveBeenCalledWith(
+        'Admin operation executed',
+        expect.objectContaining({
+          operation: 'pause',
+          contractId: expect.any(String),
+          adminPublicKey: expect.any(String),
+          success: false,
+        }),
+      )
+    })
+
+    it('logs operation success after confirmation', async () => {
+      const { logger } = await import('../utils/logger.js')
+      const infoSpy = vi.mocked(logger.info)
+
+      await executeWithAdvance()
+
+      const successLog = infoSpy.mock.calls.find(
+        (call) => call[0] === 'Admin operation executed' && (call[1] as any).success === true,
+      )
+      expect(successLog).toBeDefined()
+      expect(successLog![1]).toEqual(
+        expect.objectContaining({
+          operation: 'pause',
+          success: true,
+          transactionHash: expect.any(String),
+        }),
+      )
+    })
+
+    it('logs operation failure with error message', async () => {
+      const { logger } = await import('../utils/logger.js')
+      const infoSpy = vi.mocked(logger.info)
+
+      mockSendTransaction.mockResolvedValueOnce({
+        status: 'FAILED',
+        hash: 'tx-fail-hash',
+        errorResultXdr: 'mock-xdr',
+      })
+
+      await expect(service.executeAdminOperation(makeParams())).rejects.toThrow(TransactionError)
+
+      const failureLog = infoSpy.mock.calls.find(
+        (call) =>
+          call[0] === 'Admin operation executed' &&
+          typeof call[1] === 'object' &&
+          call[1] !== null &&
+          (call[1] as any).success === false &&
+          (call[1] as any).error,
+      )
+      expect(failureLog).toBeDefined()
+    })
+
+    it('audit log contains no secrets', async () => {
+      const { logger } = await import('../utils/logger.js')
+      const infoSpy = vi.mocked(logger.info)
+
+      await executeWithAdvance()
+
+      const allLogs = infoSpy.mock.calls.map((c) => JSON.stringify(c))
+      for (const logStr of allLogs) {
+        expect(logStr).not.toContain('SADMINSECRET')
+        expect(logStr).not.toContain('adminSecret')
+      }
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Parameter tampering detection
+  // ---------------------------------------------------------------------------
+  describe('parameter tampering', () => {
+    it('params are bound into the signed transaction — not swappable', async () => {
+      let callCount = 0
+      mockSendTransaction.mockImplementation(() => {
+        callCount++
+        return Promise.resolve({ status: 'PENDING', hash: `tx-hash-${callCount}` })
+      })
+
+      const hash1 = await executeWithAdvance(makeParams({ operation: 'pause' }))
+      const hash2 = await executeWithAdvance(makeParams({ operation: 'unpause' }))
+      expect(hash1).not.toBe(hash2)
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Replay prevention
+  // ---------------------------------------------------------------------------
+  describe('replay prevention', () => {
+    it('each execution creates a new sequence allocation', async () => {
+      await executeWithAdvance()
+      await executeWithAdvance()
+      expect(mockAllocateSequence).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Transaction failure handling
+  // ---------------------------------------------------------------------------
+  describe('transaction failure handling', () => {
+    it('marks allocation as failed when transaction fails', async () => {
+      mockSendTransaction.mockResolvedValueOnce({
+        status: 'FAILED',
+        hash: 'tx-fail',
+        errorResultXdr: 'mock',
+      })
+
+      await expect(service.executeAdminOperation(makeParams())).rejects.toThrow(TransactionError)
+      expect(mockMarkFailed).toHaveBeenCalledWith('alloc-1')
+    })
+
+    it('marks allocation as confirmed on success', async () => {
+      const promise = service.executeAdminOperation(makeParams())
+      await vi.advanceTimersByTimeAsync(30_000)
+      await promise
+      expect(mockMarkConfirmed).toHaveBeenCalledWith('alloc-1', expect.any(String))
+    })
+
+    it('wraps unknown errors in TransactionError', async () => {
+      mockSendTransaction.mockRejectedValueOnce(new Error('network glitch'))
+      await expect(service.executeAdminOperation(makeParams())).rejects.toThrow(TransactionError)
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Key rotation
+  // ---------------------------------------------------------------------------
+  describe('key rotation', () => {
+    it('uses rotated key when active key is set', async () => {
+      mockGetActiveKey.mockResolvedValue('key-id-123')
+      mockRetrieveKeyMaterial.mockResolvedValue('SROTATEDSECRETKEY')
+
+      const hash = await executeWithAdvance()
+      expect(hash).toBeDefined()
+      expect(mockGetActiveKey).toHaveBeenCalledWith('admin', expect.any(String))
+      expect(mockRetrieveKeyMaterial).toHaveBeenCalledWith('key-id-123', 'admin')
+    })
+
+    it('falls back to configured secret when no rotation is active', async () => {
+      mockGetActiveKey.mockResolvedValue(null)
+
+      const hash = await executeWithAdvance()
+      expect(hash).toBeDefined()
+      expect(mockRetrieveKeyMaterial).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/backend/src/services/erasureService.test.ts
+++ b/backend/src/services/erasureService.test.ts
@@ -1,0 +1,255 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockQuery } = vi.hoisted(() => ({
+  mockQuery: vi.fn(),
+}))
+
+vi.mock('../db.js', () => ({
+  getPool: vi.fn().mockResolvedValue({
+    query: mockQuery,
+    connect: vi.fn(),
+  }),
+}))
+
+vi.mock('../utils/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+  },
+}))
+
+import { ErasureService } from './erasureService.js'
+
+function makeErasureRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'req-1',
+    user_id: 'user-1',
+    status: 'pending',
+    requested_at: '2026-01-01T00:00:00Z',
+    confirm_by: '2026-02-01T00:00:00Z',
+    confirmed_at: null,
+    confirmed_by: null,
+    ...overrides,
+  }
+}
+
+describe('ErasureService', () => {
+  let service: ErasureService
+
+  beforeEach(() => {
+    service = new ErasureService()
+    mockQuery.mockReset()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  // ---------------------------------------------------------------------------
+  // requestErasure
+  // ---------------------------------------------------------------------------
+  describe('requestErasure', () => {
+    it('creates a new erasure request when none exists', async () => {
+      mockQuery
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [makeErasureRow()] })
+
+      const result = await service.requestErasure('user-1')
+
+      expect(result).toBeDefined()
+      expect(result.userId).toBe('user-1')
+      expect(result.status).toBe('pending')
+    })
+
+    it('throws when a pending request already exists', async () => {
+      mockQuery.mockResolvedValueOnce({
+        rows: [{ id: 'existing-req' }],
+      })
+
+      await expect(service.requestErasure('user-1')).rejects.toThrow(
+        'ERASURE_ALREADY_PENDING',
+      )
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // confirmErasure — PII removal
+  // ---------------------------------------------------------------------------
+  describe('confirmErasure', () => {
+    it('anonymises PII across all relevant tables', async () => {
+      mockQuery
+        .mockResolvedValueOnce({ rows: [makeErasureRow()] }) // findById
+        .mockResolvedValueOnce({ rows: [] }) // BEGIN
+        .mockResolvedValueOnce({ rows: [] }) // UPDATE users
+        .mockResolvedValueOnce({ rows: [] }) // UPDATE landlord_profiles
+        .mockResolvedValueOnce({ rows: [] }) // UPDATE onboarding_drafts
+        .mockResolvedValueOnce({ rows: [] }) // UPDATE kyc_documents
+        .mockResolvedValueOnce({ rows: [] }) // UPDATE sessions
+        .mockResolvedValueOnce({ rows: [] }) // UPDATE erasure_requests
+        .mockResolvedValueOnce({ rows: [] }) // COMMIT
+
+      await service.confirmErasure('req-1', 'admin-user-1')
+
+      const calls = mockQuery.mock.calls.map((c: any[]) => c[0] as string)
+
+      expect(calls.some(c => c.includes('UPDATE users SET'))).toBe(true)
+      expect(calls.some(c => c.includes('UPDATE landlord_profiles SET'))).toBe(true)
+      expect(calls.some(c => c.includes('UPDATE onboarding_drafts SET'))).toBe(true)
+      expect(calls.some(c => c.includes('UPDATE kyc_documents SET'))).toBe(true)
+      expect(calls.some(c => c.includes('UPDATE sessions SET'))).toBe(true)
+      expect(calls.some(c => c.includes('UPDATE erasure_requests SET'))).toBe(true)
+      expect(calls).toContain('BEGIN')
+      expect(calls).toContain('COMMIT')
+    })
+
+    it('rolls back on failure and does not leave half-erased state', async () => {
+      mockQuery
+        .mockResolvedValueOnce({ rows: [makeErasureRow()] })
+        .mockResolvedValueOnce({ rows: [] }) // BEGIN
+        .mockResolvedValueOnce({ rows: [] }) // UPDATE users
+        .mockRejectedValueOnce(new Error('DB write failed'))
+        .mockResolvedValueOnce({ rows: [] }) // ROLLBACK
+
+      await expect(
+        service.confirmErasure('req-1', 'admin-user-1'),
+      ).rejects.toThrow('DB write failed')
+
+      const calls = mockQuery.mock.calls.map((c: any[]) => c[0])
+      expect(calls).toContain('ROLLBACK')
+    })
+
+    it('throws when erasure request is not found', async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [] })
+
+      await expect(service.confirmErasure('nonexistent', 'admin-1')).rejects.toThrow(
+        'ERASURE_NOT_FOUND',
+      )
+    })
+
+    it('throws when erasure request is not pending', async () => {
+      mockQuery.mockResolvedValueOnce({
+        rows: [makeErasureRow({ status: 'completed' })],
+      })
+
+      await expect(service.confirmErasure('req-1', 'admin-1')).rejects.toThrow(
+        'ERASURE_NOT_PENDING',
+      )
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Idempotency
+  // ---------------------------------------------------------------------------
+  describe('idempotency', () => {
+    it('confirming an already-completed request throws safely', async () => {
+      mockQuery.mockResolvedValueOnce({
+        rows: [makeErasureRow({ status: 'completed' })],
+      })
+
+      await expect(service.confirmErasure('req-1', 'admin-1')).rejects.toThrow(
+        'ERASURE_NOT_PENDING',
+      )
+    })
+
+    it('requesting erasure twice for same user throws on second attempt', async () => {
+      mockQuery.mockResolvedValueOnce({
+        rows: [{ id: 'first-req' }],
+      })
+
+      await expect(service.requestErasure('user-1')).rejects.toThrow(
+        'ERASURE_ALREADY_PENDING',
+      )
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Legal hold exclusion
+  // ---------------------------------------------------------------------------
+  describe('legal hold exclusion', () => {
+    it('anonymises rather than deletes — user row is updated, not removed', async () => {
+      mockQuery
+        .mockResolvedValueOnce({ rows: [makeErasureRow()] }) // findById
+        .mockResolvedValueOnce({ rows: [] }) // BEGIN
+        .mockResolvedValueOnce({ rows: [] }) // UPDATE users
+        .mockResolvedValueOnce({ rows: [] }) // UPDATE landlord_profiles
+        .mockResolvedValueOnce({ rows: [] }) // UPDATE onboarding_drafts
+        .mockResolvedValueOnce({ rows: [] }) // UPDATE kyc_documents
+        .mockResolvedValueOnce({ rows: [] }) // UPDATE sessions
+        .mockResolvedValueOnce({ rows: [] }) // UPDATE erasure_requests
+        .mockResolvedValueOnce({ rows: [] }) // COMMIT
+
+      await service.confirmErasure('req-1', 'admin-1')
+
+      const userUpdate = mockQuery.mock.calls.find((c: any[]) =>
+        (c[0] as string).includes('UPDATE users SET'),
+      )
+      expect(userUpdate).toBeDefined()
+      expect(userUpdate![1]).toContain('user-1')
+      const token = userUpdate![1].find((arg: any) => typeof arg === 'string' && arg.startsWith('[ERASED_'))
+      expect(token).toBeDefined()
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // expireOverdueRequests
+  // ---------------------------------------------------------------------------
+  describe('expireOverdueRequests', () => {
+    it('returns the number of expired requests', async () => {
+      mockQuery.mockResolvedValueOnce({ rowCount: 3 })
+
+      const count = await service.expireOverdueRequests(new Date('2026-03-01'))
+      expect(count).toBe(3)
+    })
+
+    it('returns 0 when no requests are overdue', async () => {
+      mockQuery.mockResolvedValueOnce({ rowCount: 0 })
+
+      const count = await service.expireOverdueRequests()
+      expect(count).toBe(0)
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // findPendingByUserId
+  // ---------------------------------------------------------------------------
+  describe('findPendingByUserId', () => {
+    it('returns the pending erasure request for a user', async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [makeErasureRow()] })
+
+      const result = await service.findPendingByUserId('user-1')
+      expect(result).not.toBeNull()
+      expect(result?.userId).toBe('user-1')
+      expect(result?.status).toBe('pending')
+    })
+
+    it('returns null when no pending request exists', async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [] })
+
+      const result = await service.findPendingByUserId('user-no-req')
+      expect(result).toBeNull()
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // findById
+  // ---------------------------------------------------------------------------
+  describe('findById', () => {
+    it('returns an erasure request by id', async () => {
+      mockQuery.mockResolvedValueOnce({
+        rows: [makeErasureRow({ id: 'req-42' })],
+      })
+
+      const result = await service.findById('req-42')
+      expect(result).not.toBeNull()
+      expect(result?.id).toBe('req-42')
+    })
+
+    it('returns null for unknown id', async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [] })
+
+      const result = await service.findById('unknown')
+      expect(result).toBeNull()
+    })
+  })
+})

--- a/backend/src/services/outboxProcessor.test.ts
+++ b/backend/src/services/outboxProcessor.test.ts
@@ -1,0 +1,341 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { outboxStore } from '../outbox/store.js'
+import { OutboxStatus, TxType, type OutboxItem } from '../outbox/types.js'
+import { OutboxProcessor } from './outboxProcessor.js'
+import type { OutboxConfig } from '../config/outboxConfig.js'
+
+vi.mock('../repositories/OutboxRepository.js', () => ({
+  outboxRepository: {
+    moveToDeadLetter: vi.fn(),
+  },
+}))
+
+import { outboxRepository } from '../repositories/OutboxRepository.js'
+
+const testConfig: OutboxConfig = {
+  baseDelayMs: 100,
+  maxDelayMs: 5000,
+  maxAttempts: 3,
+  jitterFactor: 0,
+  confirmationDepth: 3,
+}
+
+function makeItem(overrides: Partial<OutboxItem> = {}): OutboxItem {
+  return {
+    id: 'test-item-id',
+    txType: TxType.RECEIPT,
+    canonicalExternalRefV1: 'test:ref-1',
+    txId: 'a'.repeat(64),
+    payload: { dealId: 'deal-1', amountUsdc: '100' },
+    status: OutboxStatus.PENDING,
+    attempts: 0,
+    lastError: '',
+    aggregateType: 'deal',
+    aggregateId: 'deal-1',
+    eventType: 'receipt',
+    retryCount: 0,
+    nextRetryAt: null,
+    processedAt: null,
+    confirmationDepth: 3,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  }
+}
+
+describe('OutboxProcessor', () => {
+  let processor: OutboxProcessor
+
+  beforeEach(async () => {
+    await outboxStore.clear()
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'))
+    vi.mocked(outboxRepository.moveToDeadLetter).mockReset()
+    processor = new OutboxProcessor(testConfig)
+  })
+
+  afterEach(async () => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+    await outboxStore.clear()
+  })
+
+  // ---------------------------------------------------------------------------
+  // shouldRetry
+  // ---------------------------------------------------------------------------
+  describe('shouldRetry', () => {
+    it('returns true when retryCount is below maxAttempts and no nextRetryAt is set', () => {
+      const item = makeItem({ retryCount: 0, nextRetryAt: null })
+      expect(processor.shouldRetry(item)).toBe(true)
+    })
+
+    it('returns true when nextRetryAt is in the past', () => {
+      const item = makeItem({
+        retryCount: 1,
+        nextRetryAt: new Date(Date.now() - 1000),
+      })
+      expect(processor.shouldRetry(item)).toBe(true)
+    })
+
+    it('returns false when nextRetryAt is in the future', () => {
+      const item = makeItem({
+        retryCount: 1,
+        nextRetryAt: new Date(Date.now() + 60_000),
+      })
+      expect(processor.shouldRetry(item)).toBe(false)
+    })
+
+    it('returns false when retryCount >= maxAttempts', () => {
+      const item = makeItem({ retryCount: 3, nextRetryAt: null })
+      expect(processor.shouldRetry(item)).toBe(false)
+    })
+
+    it('returns true when nextRetryAt equals now', () => {
+      const now = Date.now()
+      vi.setSystemTime(now)
+      const item = makeItem({
+        retryCount: 0,
+        nextRetryAt: new Date(now),
+      })
+      expect(processor.shouldRetry(item)).toBe(true)
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // scheduleRetry
+  // ---------------------------------------------------------------------------
+  describe('scheduleRetry', () => {
+    it('schedules next retry with computed delay when under maxAttempts', async () => {
+      const item = await outboxStore.create({
+        txType: TxType.RECEIPT,
+        source: 'test',
+        ref: 'retry-schedule-1',
+        payload: { dealId: 'd1' },
+      })
+
+      await processor.scheduleRetry(item, 'timeout error')
+
+      const updated = await outboxStore.getById(item.id)
+      expect(updated).not.toBeNull()
+      expect(updated!.status).toBe(OutboxStatus.FAILED)
+      expect(updated!.lastError).toBe('timeout error')
+      expect(updated!.nextRetryAt).toBeInstanceOf(Date)
+      expect(updated!.nextRetryAt!.getTime()).toBeGreaterThan(Date.now())
+    })
+
+    it('promotes to dead letter when nextRetryCount >= maxAttempts', async () => {
+      vi.mocked(outboxRepository.moveToDeadLetter).mockResolvedValue(undefined)
+
+      const item = await outboxStore.create({
+        txType: TxType.RECEIPT,
+        source: 'test',
+        ref: 'retry-deadletter-1',
+        payload: { dealId: 'd2' },
+      })
+      // Simulate 2 previous retries so next retryCount (3) >= maxAttempts (3)
+      await outboxStore.updateStatus(item.id, OutboxStatus.FAILED, { error: 'err1' })
+      await outboxStore.updateStatus(item.id, OutboxStatus.FAILED, { error: 'err2' })
+
+      await processor.scheduleRetry(item, 'persistent failure')
+
+      expect(outboxRepository.moveToDeadLetter).toHaveBeenCalledWith(
+        item.id,
+        'persistent failure',
+      )
+    })
+
+    it('uses exponential backoff to compute delay', async () => {
+      const item = await outboxStore.create({
+        txType: TxType.RECEIPT,
+        source: 'test',
+        ref: 'backoff-1',
+        payload: { dealId: 'd3' },
+      })
+
+      const before = Date.now()
+      await processor.scheduleRetry(item, 'error')
+
+      const updated = await outboxStore.getById(item.id)
+      const retryAt = updated!.nextRetryAt!.getTime()
+      const delay = retryAt - before
+
+      // baseDelayMs=100, attempt=0 → delay = 100 * 2^0 = 100ms
+      expect(delay).toBeGreaterThanOrEqual(100)
+      expect(delay).toBeLessThanOrEqual(200)
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // promoteToDeadLetter
+  // ---------------------------------------------------------------------------
+  describe('promoteToDeadLetter', () => {
+    it('calls outboxRepository.moveToDeadLetter on success', async () => {
+      vi.mocked(outboxRepository.moveToDeadLetter).mockResolvedValue(undefined)
+
+      const item = makeItem({ id: 'dead-1', retryCount: 3 })
+      await processor.promoteToDeadLetter(item, 'max retries exceeded')
+
+      expect(outboxRepository.moveToDeadLetter).toHaveBeenCalledWith(
+        'dead-1',
+        'max retries exceeded',
+      )
+    })
+
+    it('falls back to outboxStore.markDead when repository throws', async () => {
+      vi.mocked(outboxRepository.moveToDeadLetter).mockRejectedValue(
+        new Error('column dead_lettered_at does not exist'),
+      )
+
+      const item = await outboxStore.create({
+        txType: TxType.RECEIPT,
+        source: 'test',
+        ref: 'fallback-dead-1',
+        payload: { dealId: 'd4' },
+      })
+
+      await processor.promoteToDeadLetter(item, 'repo failure')
+
+      const updated = await outboxStore.getById(item.id)
+      expect(updated?.status).toBe(OutboxStatus.DEAD)
+      expect(updated?.lastError).toBe('repo failure')
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Success flow
+  // ---------------------------------------------------------------------------
+  describe('success flow', () => {
+    it('does not retry an item that has no failure', async () => {
+      const item = makeItem({ retryCount: 0, nextRetryAt: null })
+      expect(processor.shouldRetry(item)).toBe(true)
+      // A successful item would have status SENT and processedAt set
+      // The processor only operates on failed items, so success = no action needed
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Poison message isolation
+  // ---------------------------------------------------------------------------
+  describe('poison message isolation', () => {
+    it('dead-letters a poison record without stalling other items', async () => {
+      vi.mocked(outboxRepository.moveToDeadLetter).mockResolvedValue(undefined)
+
+      const poison = await outboxStore.create({
+        txType: TxType.RECEIPT,
+        source: 'test',
+        ref: 'poison-item',
+        payload: { dealId: 'poison' },
+      })
+      const healthy = await outboxStore.create({
+        txType: TxType.RECEIPT,
+        source: 'test',
+        ref: 'healthy-item',
+        payload: { dealId: 'healthy' },
+      })
+
+      // Poison item: max retries exhausted
+      for (let i = 0; i < 3; i++) {
+        await outboxStore.updateStatus(poison.id, OutboxStatus.FAILED, {
+          error: `fail-${i}`,
+        })
+      }
+
+      // Poison item should not be retryable
+      const poisonItem = await outboxStore.getById(poison.id)
+      expect(processor.shouldRetry(poisonItem!)).toBe(false)
+
+      // Healthy item is still retryable
+      const healthyItem = await outboxStore.getById(healthy.id)
+      expect(processor.shouldRetry(healthyItem!)).toBe(true)
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Concurrent processor runs
+  // ---------------------------------------------------------------------------
+  describe('concurrent processor runs', () => {
+    it('claim semantics prevent double-dispatch via lockForProcessing', async () => {
+      const item = await outboxStore.create({
+        txType: TxType.RECEIPT,
+        source: 'test',
+        ref: 'concurrent-1',
+        payload: { dealId: 'd5' },
+      })
+
+      // Worker 1 claims the item
+      const claimed1 = await outboxStore.lockForProcessing(10, 'worker-1')
+      expect(claimed1).toHaveLength(1)
+      expect(claimed1[0].id).toBe(item.id)
+
+      // Worker 2 cannot claim the same item
+      const claimed2 = await outboxStore.lockForProcessing(10, 'worker-2')
+      expect(claimed2).toHaveLength(0)
+    })
+
+    it('releases stale claims for reclaim by another worker', async () => {
+      const item = await outboxStore.create({
+        txType: TxType.RECEIPT,
+        source: 'test',
+        ref: 'stale-claim-1',
+        payload: { dealId: 'd6' },
+      })
+
+      // Worker 1 claims the item
+      await outboxStore.lockForProcessing(10, 'worker-1')
+
+      // Advance time past the 5-minute stale claim window
+      vi.advanceTimersByTime(6 * 60 * 1000)
+
+      // Worker 2 can now reclaim it
+      const claimed = await outboxStore.lockForProcessing(10, 'worker-2')
+      expect(claimed).toHaveLength(1)
+      expect(claimed[0].id).toBe(item.id)
+      expect(claimed[0].claimedBy).toBe('worker-2')
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Ordering and at-least-once behavior
+  // ---------------------------------------------------------------------------
+  describe('ordering and at-least-once', () => {
+    it('returns items in creation order from lockForProcessing', async () => {
+      const ids: string[] = []
+      for (let i = 0; i < 5; i++) {
+        const item = await outboxStore.create({
+          txType: TxType.RECEIPT,
+          source: 'test',
+          ref: `order-${i}`,
+          payload: { dealId: `d-${i}` },
+        })
+        ids.push(item.id)
+      }
+
+      const claimed = await outboxStore.lockForProcessing(10, 'worker-1')
+      expect(claimed.map((i) => i.id)).toEqual(ids)
+    })
+
+    it('marking an item dead removes it from further processing', async () => {
+      const item = await outboxStore.create({
+        txType: TxType.RECEIPT,
+        source: 'test',
+        ref: 'dead-check-1',
+        payload: { dealId: 'd7' },
+      })
+
+      // Make repository fail so the fallback markDead path runs
+      vi.mocked(outboxRepository.moveToDeadLetter).mockRejectedValue(
+        new Error('column dead_lettered_at does not exist'),
+      )
+
+      await processor.promoteToDeadLetter(item, 'test dead letter')
+
+      // Verify it's dead via the store fallback
+      const deadItem = await outboxStore.getById(item.id)
+      expect(deadItem?.status).toBe(OutboxStatus.DEAD)
+
+      // Dead items are not returned by lockForProcessing
+      const claimed = await outboxStore.lockForProcessing(10, 'worker-1')
+      expect(claimed.find((i) => i.id === item.id)).toBeUndefined()
+    })
+  })
+})

--- a/backend/src/webhookReplay/webhookReplayService.test.ts
+++ b/backend/src/webhookReplay/webhookReplayService.test.ts
@@ -1,0 +1,403 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  InMemoryWebhookReplayStore,
+  type IWebhookReplayStore,
+} from './store.js'
+import {
+  ReplayStatus,
+  ActorType,
+  WebhookProcessingStatus,
+  type ReplayRequest,
+  type AuditContext,
+} from './types.js'
+import { WebhookReplayService } from './webhookReplayService.js'
+
+vi.mock('../jobs/scheduler/worker.js', () => ({
+  getScheduler: vi.fn(() => ({
+    schedule: vi.fn().mockResolvedValue(undefined),
+  })),
+}))
+
+vi.mock('../utils/auditLogger.js', () => ({
+  auditLog: vi.fn(),
+}))
+
+vi.mock('../utils/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+  },
+}))
+
+import { getScheduler } from '../jobs/scheduler/worker.js'
+import { auditLog } from '../utils/auditLogger.js'
+
+function makeEvent(overrides: Record<string, unknown> = {}) {
+  return {
+    provider: 'paystack',
+    eventType: 'charge.success',
+    externalId: 'ext-001',
+    payload: { amount: 5000, currency: 'NGN' },
+    processingStatus: WebhookProcessingStatus.PROCESSED,
+    ...overrides,
+  }
+}
+
+function makeContext(overrides: Partial<AuditContext> = {}): AuditContext {
+  return {
+    userId: 'admin-user-1',
+    actorType: 'admin',
+    ip: '127.0.0.1',
+    ...overrides,
+  }
+}
+
+describe('WebhookReplayService', () => {
+  let store: IWebhookReplayStore
+  let service: WebhookReplayService
+
+  beforeEach(async () => {
+    store = new InMemoryWebhookReplayStore()
+    service = new WebhookReplayService(store)
+    vi.mocked(auditLog).mockClear()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  // ---------------------------------------------------------------------------
+  // previewReplay
+  // ---------------------------------------------------------------------------
+  describe('previewReplay', () => {
+    it('returns matching events for a provider filter', async () => {
+      await store.createEvent(makeEvent({ provider: 'paystack', externalId: 'ps-1' }))
+      await store.createEvent(makeEvent({ provider: 'flutterwave', externalId: 'fw-1' }))
+
+      const preview = await service.previewReplay({
+        provider: 'paystack',
+        dryRun: true,
+        reason: 'test',
+      })
+
+      expect(preview.totalEvents).toBe(1)
+      expect(preview.events[0].provider).toBe('paystack')
+    })
+
+    it('returns empty preview when no events match', async () => {
+      const preview = await store.createEvent(makeEvent({ provider: 'paystack', externalId: 'ps-1' }))
+
+      const result = await service.previewReplay({
+        provider: 'nonexistent',
+        dryRun: true,
+        reason: 'test',
+      })
+
+      expect(result.totalEvents).toBe(0)
+      expect(result.events).toHaveLength(0)
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // executeReplay — idempotency
+  // ---------------------------------------------------------------------------
+  describe('executeReplay — idempotency', () => {
+    it('replaying an already-processed event routes through idempotency layer', async () => {
+      const event = await store.createEvent(
+        makeEvent({
+          provider: 'paystack',
+          externalId: 'idempotent-1',
+          processingStatus: WebhookProcessingStatus.PROCESSED,
+        }),
+      )
+
+      const scheduler = vi.mocked(getScheduler).mock.results[0]?.value ?? {
+        schedule: vi.fn().mockResolvedValue(undefined),
+      }
+      vi.mocked(getScheduler).mockReturnValue(scheduler as any)
+
+      const request: ReplayRequest = {
+        webhookEventId: event.id,
+        dryRun: false,
+        reason: 'replay processed event',
+      }
+
+      const attempt = await service.executeReplay(request, makeContext())
+
+      expect(attempt.status).toBe(ReplayStatus.SUCCESS)
+      expect(attempt.dryRun).toBe(false)
+
+      // Audit log should show replay was initiated and completed
+      expect(auditLog).toHaveBeenCalledWith(
+        'WEBHOOK_REPLAY_INITIATED',
+        expect.anything(),
+        expect.objectContaining({ replayAttemptId: attempt.id }),
+      )
+      expect(auditLog).toHaveBeenCalledWith(
+        'WEBHOOK_REPLAY_COMPLETED',
+        expect.anything(),
+        expect.objectContaining({ replayAttemptId: attempt.id }),
+      )
+    })
+
+    it('replay does not create duplicate side effects — same event replayed twice', async () => {
+      const event = await store.createEvent(
+        makeEvent({ provider: 'paystack', externalId: 'dup-1' }),
+      )
+
+      const scheduler = { schedule: vi.fn().mockResolvedValue(undefined) }
+      vi.mocked(getScheduler).mockReturnValue(scheduler as any)
+
+      const request: ReplayRequest = {
+        webhookEventId: event.id,
+        dryRun: false,
+        reason: 'first replay',
+      }
+
+      // First replay
+      const attempt1 = await service.executeReplay(request, makeContext())
+      expect(attempt1.status).toBe(ReplayStatus.SUCCESS)
+
+      // Second replay of the same event — should also succeed (idempotent)
+      const attempt2 = await service.executeReplay(
+        { ...request, reason: 'second replay' },
+        makeContext(),
+      )
+      expect(attempt2.status).toBe(ReplayStatus.SUCCESS)
+
+      // Both replay attempts are recorded
+      const history = await service.getReplayHistory(event.id)
+      expect(history.length).toBeGreaterThanOrEqual(2)
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // executeReplay — dry run
+  // ---------------------------------------------------------------------------
+  describe('executeReplay — dry run', () => {
+    it('dry run validates without scheduling jobs', async () => {
+      const event = await store.createEvent(
+        makeEvent({ provider: 'paystack', externalId: 'dry-1' }),
+      )
+
+      const scheduler = { schedule: vi.fn().mockResolvedValue(undefined) }
+      vi.mocked(getScheduler).mockReturnValue(scheduler as any)
+
+      const attempt = await service.executeReplay(
+        {
+          webhookEventId: event.id,
+          dryRun: true,
+          reason: 'dry run test',
+        },
+        makeContext(),
+      )
+
+      expect(attempt.status).toBe(ReplayStatus.SUCCESS)
+      expect(attempt.dryRun).toBe(true)
+      expect(attempt.outcome).toEqual(
+        expect.objectContaining({ message: 'Dry run completed successfully' }),
+      )
+      expect(scheduler.schedule).not.toHaveBeenCalled()
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // executeReplay — no events found
+  // ---------------------------------------------------------------------------
+  describe('executeReplay — no events found', () => {
+    it('throws when no events match the replay criteria', async () => {
+      await expect(
+        service.executeReplay(
+          {
+            provider: 'nonexistent',
+            dryRun: false,
+            reason: 'no match',
+          },
+          makeContext(),
+        ),
+      ).rejects.toThrow('No events found matching the replay criteria')
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // executeReplay — audit trail
+  // ---------------------------------------------------------------------------
+  describe('executeReplay — audit trail', () => {
+    it('records audit trail on successful replay', async () => {
+      const event = await store.createEvent(
+        makeEvent({ provider: 'paystack', externalId: 'audit-1' }),
+      )
+
+      const scheduler = { schedule: vi.fn().mockResolvedValue(undefined) }
+      vi.mocked(getScheduler).mockReturnValue(scheduler as any)
+
+      const context = makeContext({ userId: 'admin-99', actorType: 'admin' })
+      await service.executeReplay(
+        {
+          webhookEventId: event.id,
+          dryRun: true,
+          reason: 'audit test',
+        },
+        context,
+      )
+
+      expect(auditLog).toHaveBeenCalledWith(
+        'WEBHOOK_REPLAY_INITIATED',
+        context,
+        expect.objectContaining({
+          replayAttemptId: expect.any(String),
+          eventCount: 1,
+          dryRun: true,
+        }),
+      )
+      expect(auditLog).toHaveBeenCalledWith(
+        'WEBHOOK_REPLAY_COMPLETED',
+        context,
+        expect.objectContaining({ success: true }),
+      )
+    })
+
+    it('records audit trail on failed replay', async () => {
+      const event = await store.createEvent(
+        makeEvent({ provider: 'paystack', externalId: 'audit-fail-1' }),
+      )
+
+      const scheduler = {
+        schedule: vi.fn().mockRejectedValue(new Error('queue full')),
+      }
+      vi.mocked(getScheduler).mockReturnValue(scheduler as any)
+
+      const context = makeContext()
+      await expect(
+        service.executeReplay(
+          {
+            webhookEventId: event.id,
+            dryRun: false,
+            reason: 'should fail',
+          },
+          context,
+        ),
+      ).rejects.toThrow('queue full')
+
+      expect(auditLog).toHaveBeenCalledWith(
+        'WEBHOOK_REPLAY_FAILED',
+        context,
+        expect.objectContaining({
+          error: 'queue full',
+        }),
+      )
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // executeReplay — failed downstream
+  // ---------------------------------------------------------------------------
+  describe('executeReplay — failed downstream', () => {
+    it('surfaces error and does not mark event as freshly processed', async () => {
+      const event = await store.createEvent(
+        makeEvent({
+          provider: 'paystack',
+          externalId: 'downstream-fail-1',
+          processingStatus: WebhookProcessingStatus.PENDING,
+        }),
+      )
+
+      const scheduler = {
+        schedule: vi.fn().mockRejectedValue(new Error('downstream timeout')),
+      }
+      vi.mocked(getScheduler).mockReturnValue(scheduler as any)
+
+      await expect(
+        service.executeReplay(
+          {
+            webhookEventId: event.id,
+            dryRun: false,
+            reason: 'test failure',
+          },
+          makeContext(),
+        ),
+      ).rejects.toThrow('downstream timeout')
+
+      // Event processing status should remain unchanged
+      const updatedEvent = await store.getEventById(event.id)
+      expect(updatedEvent?.processingStatus).toBe(WebhookProcessingStatus.PENDING)
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // getReplayHistory
+  // ---------------------------------------------------------------------------
+  describe('getReplayHistory', () => {
+    it('returns replay attempts filtered by webhookEventId', async () => {
+      const event = await store.createEvent(
+        makeEvent({ provider: 'paystack', externalId: 'hist-1' }),
+      )
+
+      const scheduler = { schedule: vi.fn().mockResolvedValue(undefined) }
+      vi.mocked(getScheduler).mockReturnValue(scheduler as any)
+
+      await service.executeReplay(
+        { webhookEventId: event.id, dryRun: true, reason: 'history test' },
+        makeContext(),
+      )
+
+      const history = await service.getReplayHistory(event.id)
+      expect(history).toHaveLength(1)
+      expect(history[0].webhookEventId).toBe(event.id)
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // getWebhookEvent
+  // ---------------------------------------------------------------------------
+  describe('getWebhookEvent', () => {
+    it('returns a specific webhook event by id', async () => {
+      const event = await store.createEvent(
+        makeEvent({ provider: 'paystack', externalId: 'get-1' }),
+      )
+
+      const found = await service.getWebhookEvent(event.id)
+      expect(found).not.toBeNull()
+      expect(found?.id).toBe(event.id)
+    })
+
+    it('returns null for unknown event id', async () => {
+      const found = await service.getWebhookEvent('nonexistent-id')
+      expect(found).toBeNull()
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Replay scheduling
+  // ---------------------------------------------------------------------------
+  describe('replay job scheduling', () => {
+    it('schedules a job for each event in the replay', async () => {
+      const event = await store.createEvent(
+        makeEvent({ provider: 'paystack', externalId: 'sched-1' }),
+      )
+
+      const scheduler = { schedule: vi.fn().mockResolvedValue(undefined) }
+      vi.mocked(getScheduler).mockReturnValue(scheduler as any)
+
+      await service.executeReplay(
+        { webhookEventId: event.id, dryRun: false, reason: 'schedule test' },
+        makeContext(),
+      )
+
+      expect(scheduler.schedule).toHaveBeenCalledTimes(1)
+      expect(scheduler.schedule).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'webhook_replay_paystack',
+          handler: 'webhook.replay',
+          priority: 10,
+          maxRetries: 3,
+          payload: expect.objectContaining({
+            webhookEventId: event.id,
+            provider: 'paystack',
+          }),
+        }),
+      )
+    })
+  })
+})


### PR DESCRIPTION
Closes #1144, Closes #1145, Closes #1149, Closes #1148

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional or behavioral changes)
- [ ] Performance improvement
- [x] Documentation update
- [ ] Build / CI configuration change
- [ ] Dependency update
- [ ] Other: <!-- describe -->

---

## Summary

Four backend services — `outboxProcessor`, `webhookReplayService`, `erasureService`, and `adminSigningService` — had no test coverage for their core reliability, security, and compliance guarantees. This PR adds 62 deterministic tests across four new test files covering retry/backoff logic, idempotent replay, GDPR erasure cascades, and per-operation authorization with tamper-evident audit logging.

## Motivation / Context

The outbox processor drives exactly-once side-effect delivery, but its retry, backoff, and poison-message isolation behavior was unverified. The webhook replay service can double-apply financial side effects if it bypasses idempotency. The erasure service handles GDPR/NDPR right-to-be-forgotten, but completeness of its PII cascade across dozens of stores was unverified. The admin signing service signs privileged operations that move funds, but its per-operation authorization and audit logging guarantees had no test proof.

These gaps mean regressions could silently duplicate payments, leave PII in forgotten tables, or allow privilege escalation via the admin signer — all without failing any automated check.

Closes #1144, Closes #1145, Closes #1149, Closes #1148