### PR TITLE
fix: resolve staking rewards and escrow test issues

### DIFF
--- a/contracts/deal_escrow/src/lib.rs
+++ b/contracts/deal_escrow/src/lib.rs
@@ -2802,14 +2802,9 @@ mod test {
             .unwrap()
             .unwrap();
         // Advance past the challenge window.
-        env.ledger()
-            .set_timestamp(env.ledger().timestamp() + 10);
+        env.ledger().set_timestamp(env.ledger().timestamp() + 10);
         let err = client
-            .try_challenge_rent_release(
-                &depositor,
-                &deal_id,
-                &String::from_str(&env, "evidence"),
-            )
+            .try_challenge_rent_release(&depositor, &deal_id, &String::from_str(&env, "evidence"))
             .unwrap_err()
             .unwrap();
         assert_eq!(err, ContractError::DisputeNotAllowed);
@@ -2861,8 +2856,7 @@ mod test {
             .unwrap()
             .unwrap();
         // Advance only 5 seconds (window = 10).
-        env.ledger()
-            .set_timestamp(env.ledger().timestamp() + 5);
+        env.ledger().set_timestamp(env.ledger().timestamp() + 5);
         let err = client
             .try_settle_rent_release_timeout(&deal_id)
             .unwrap_err()
@@ -2904,10 +2898,7 @@ mod test {
             .try_configure_dispute_windows(&admin, &5u64, &20u64)
             .unwrap()
             .unwrap();
-        client
-            .try_set_resolver(&admin, &resolver)
-            .unwrap()
-            .unwrap();
+        client.try_set_resolver(&admin, &resolver).unwrap().unwrap();
         client
             .try_request_rent_release(
                 &operator,
@@ -2920,19 +2911,13 @@ mod test {
             .unwrap()
             .unwrap();
         // Challenge within the 5s window (advance 2s).
-        env.ledger()
-            .set_timestamp(env.ledger().timestamp() + 2);
+        env.ledger().set_timestamp(env.ledger().timestamp() + 2);
         client
-            .try_challenge_rent_release(
-                &depositor,
-                &deal_id,
-                &String::from_str(&env, "evidence"),
-            )
+            .try_challenge_rent_release(&depositor, &deal_id, &String::from_str(&env, "evidence"))
             .unwrap()
             .unwrap();
         // Advance 10 more seconds — dispute timeout is 20s, so still early.
-        env.ledger()
-            .set_timestamp(env.ledger().timestamp() + 10);
+        env.ledger().set_timestamp(env.ledger().timestamp() + 10);
         let err = client
             .try_settle_dispute_timeout(&deal_id)
             .unwrap_err()
@@ -2986,21 +2971,18 @@ mod test {
             .unwrap()
             .unwrap();
         // Challenge within the 5s window.
-        env.ledger()
-            .set_timestamp(env.ledger().timestamp() + 2);
+        env.ledger().set_timestamp(env.ledger().timestamp() + 2);
         client
-            .try_challenge_rent_release(
-                &depositor,
-                &deal_id,
-                &String::from_str(&env, "evidence"),
-            )
+            .try_challenge_rent_release(&depositor, &deal_id, &String::from_str(&env, "evidence"))
             .unwrap()
             .unwrap();
         // Advance well past dispute timeout (20s).
-        env.ledger()
-            .set_timestamp(env.ledger().timestamp() + 25);
+        env.ledger().set_timestamp(env.ledger().timestamp() + 25);
         // settle_dispute_timeout refunds depositor.
-        client.try_settle_dispute_timeout(&deal_id).unwrap().unwrap();
+        client
+            .try_settle_dispute_timeout(&deal_id)
+            .unwrap()
+            .unwrap();
         assert_eq!(token_client.balance(&depositor), 100i128);
         // Cannot settle again.
         let err = client
@@ -3085,12 +3067,17 @@ mod test {
         env.mock_all_auths();
         let (_, client, admin, _, _, _, _) = setup(&env);
         let drain_hash = BytesN::from_array(&env, &[3u8; 32]);
-        client.try_set_recovery_delay(&admin, &100u64).unwrap().unwrap();
+        client
+            .try_set_recovery_delay(&admin, &100u64)
+            .unwrap()
+            .unwrap();
         client.try_freeze(&admin).unwrap().unwrap();
-        client.try_propose_drain(&admin, &drain_hash).unwrap().unwrap();
+        client
+            .try_propose_drain(&admin, &drain_hash)
+            .unwrap()
+            .unwrap();
         // Advance only 50s — delay is 100s.
-        env.ledger()
-            .set_timestamp(env.ledger().timestamp() + 50);
+        env.ledger().set_timestamp(env.ledger().timestamp() + 50);
         let err = client
             .try_execute_drain(&admin, &drain_hash)
             .unwrap_err()
@@ -3104,14 +3091,22 @@ mod test {
         env.mock_all_auths();
         let (_, client, admin, _, _, _, _) = setup(&env);
         let drain_hash = BytesN::from_array(&env, &[4u8; 32]);
-        client.try_set_recovery_delay(&admin, &100u64).unwrap().unwrap();
+        client
+            .try_set_recovery_delay(&admin, &100u64)
+            .unwrap()
+            .unwrap();
         client.try_freeze(&admin).unwrap().unwrap();
         assert_eq!(client.get_circuit_breaker_state(), 1u32); // Frozen
-        client.try_propose_drain(&admin, &drain_hash).unwrap().unwrap();
+        client
+            .try_propose_drain(&admin, &drain_hash)
+            .unwrap()
+            .unwrap();
         // Advance past the 100s delay.
-        env.ledger()
-            .set_timestamp(env.ledger().timestamp() + 101);
-        client.try_execute_drain(&admin, &drain_hash).unwrap().unwrap();
+        env.ledger().set_timestamp(env.ledger().timestamp() + 101);
+        client
+            .try_execute_drain(&admin, &drain_hash)
+            .unwrap()
+            .unwrap();
         // Contract must be unfrozen after drain executes.
         assert_eq!(client.get_circuit_breaker_state(), 0u32); // Unfrozen
         assert!(!client.is_frozen());
@@ -3125,7 +3120,10 @@ mod test {
         let stranger = Address::generate(&env);
         let drain_hash = BytesN::from_array(&env, &[5u8; 32]);
         client.try_freeze(&admin).unwrap().unwrap();
-        client.try_propose_drain(&admin, &drain_hash).unwrap().unwrap();
+        client
+            .try_propose_drain(&admin, &drain_hash)
+            .unwrap()
+            .unwrap();
         // Advance past default delay (24 hours).
         env.ledger()
             .set_timestamp(env.ledger().timestamp() + 86_401);
@@ -3163,10 +3161,16 @@ mod test {
 
         // After drain executes: back to Unfrozen (0).
         let drain_hash = BytesN::from_array(&env, &[6u8; 32]);
-        client.try_propose_drain(&admin, &drain_hash).unwrap().unwrap();
+        client
+            .try_propose_drain(&admin, &drain_hash)
+            .unwrap()
+            .unwrap();
         env.ledger()
             .set_timestamp(env.ledger().timestamp() + 100_000);
-        client.try_execute_drain(&admin, &drain_hash).unwrap().unwrap();
+        client
+            .try_execute_drain(&admin, &drain_hash)
+            .unwrap()
+            .unwrap();
         assert_eq!(client.get_circuit_breaker_state(), 0u32);
         assert!(!client.is_frozen());
     }

--- a/contracts/deal_escrow/src/lib.rs
+++ b/contracts/deal_escrow/src/lib.rs
@@ -2556,4 +2556,618 @@ mod test {
             .unwrap();
         assert_eq!(err, ContractError::NoPendingRelease);
     }
+
+    // ── #1186 Storage-schema migration safety ────────────────────────────────
+
+    #[test]
+    fn migrate_wrong_source_version_rejected() {
+        let env = Env::default();
+        let (contract_id, client, admin, _, _, _, _) = setup(&env);
+        // Downgrade stored version to V2, then try to migrate from V1 → mismatch.
+        env.as_contract(&contract_id, || {
+            env.storage()
+                .instance()
+                .set(&DataKey::StorageSchemaVersion, &2u32);
+        });
+        let deal_ids = soroban_sdk::Vec::<String>::new(&env);
+        env.mock_auths(&[MockAuth {
+            address: &admin,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "migrate_storage_schema",
+                args: (admin.clone(), 1u32, deal_ids.clone()).into_val(&env),
+                sub_invokes: &[],
+            },
+        }]);
+        let err = client
+            .try_migrate_storage_schema(&admin, &1u32, &deal_ids)
+            .unwrap_err()
+            .unwrap();
+        assert_eq!(err, ContractError::InvalidSchemaVersion);
+        // Version must not have advanced.
+        assert_eq!(client.storage_schema_version(), 2u32);
+    }
+
+    #[test]
+    fn migrate_v2_to_v3_preserves_per_deal_balance() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, client, admin, _, token, token_admin, _) = setup(&env);
+        let depositor = Address::generate(&env);
+        let deal_id = String::from_str(&env, "v2-balance-deal");
+        let token_sac = soroban_sdk::token::StellarAssetClient::new(&env, &token);
+        token_sac.mint(&depositor, &300i128);
+
+        env.mock_auths(&[MockAuth {
+            address: &depositor,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "deposit",
+                args: (depositor.clone(), deal_id.clone(), 300i128).into_val(&env),
+                sub_invokes: &[MockAuthInvoke {
+                    contract: &token,
+                    fn_name: "transfer",
+                    args: (depositor.clone(), contract_id.clone(), 300i128).into_val(&env),
+                    sub_invokes: &[],
+                }],
+            },
+        }]);
+        client
+            .try_deposit(&depositor, &deal_id, &300i128)
+            .unwrap()
+            .unwrap();
+
+        // Simulate V2 layout: set schema to V2 and write legacy fields (both 0).
+        env.as_contract(&contract_id, || {
+            env.storage()
+                .instance()
+                .set(&DataKey::StorageSchemaVersion, &2u32);
+            env.storage()
+                .persistent()
+                .set(&DataKey::LegacyLockedAmountV2(deal_id.clone()), &0i128);
+            env.storage()
+                .persistent()
+                .set(&DataKey::LegacyPendingPayoutV2(deal_id.clone()), &0i128);
+        });
+
+        assert_eq!(client.balance(&deal_id), 300i128);
+
+        let deal_ids = soroban_sdk::Vec::from_array(&env, [deal_id.clone()]);
+        env.mock_all_auths();
+        client
+            .try_migrate_storage_schema(&admin, &2u32, &deal_ids)
+            .unwrap()
+            .unwrap();
+
+        // Balance must be preserved after migration.
+        assert_eq!(client.balance(&deal_id), 300i128);
+        assert_eq!(client.storage_schema_version(), 3u32);
+    }
+
+    #[test]
+    fn migrate_non_admin_rejected() {
+        let env = Env::default();
+        let (contract_id, client, _, _, _, _, _) = setup(&env);
+        let stranger = Address::generate(&env);
+        env.as_contract(&contract_id, || {
+            env.storage()
+                .instance()
+                .set(&DataKey::StorageSchemaVersion, &1u32);
+        });
+        let deal_ids = soroban_sdk::Vec::<String>::new(&env);
+        env.mock_auths(&[MockAuth {
+            address: &stranger,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "migrate_storage_schema",
+                args: (stranger.clone(), 1u32, deal_ids.clone()).into_val(&env),
+                sub_invokes: &[],
+            },
+        }]);
+        let err = client
+            .try_migrate_storage_schema(&stranger, &1u32, &deal_ids)
+            .unwrap_err()
+            .unwrap();
+        assert_eq!(err, ContractError::NotAuthorized);
+    }
+
+    #[test]
+    fn migrate_already_at_v3_is_noop() {
+        // Current schema is V3 after init; any migration call is a no-op.
+        let env = Env::default();
+        env.mock_all_auths();
+        let (_, client, admin, _, _, _, _) = setup(&env);
+        let deal_ids = soroban_sdk::Vec::<String>::new(&env);
+        client
+            .try_migrate_storage_schema(&admin, &3u32, &deal_ids)
+            .unwrap()
+            .unwrap();
+        assert_eq!(client.storage_schema_version(), 3u32);
+    }
+
+    #[test]
+    fn migrate_v1_balance_conservation_across_multiple_deals() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, client, admin, _, token, token_admin, _) = setup(&env);
+        let depositor = Address::generate(&env);
+        let token_sac = soroban_sdk::token::StellarAssetClient::new(&env, &token);
+        token_sac.mint(&depositor, &500i128);
+
+        // Deposit into two deals.
+        let deal_a = String::from_str(&env, "v1-deal-a");
+        let deal_b = String::from_str(&env, "v1-deal-b");
+        env.mock_auths(&[MockAuth {
+            address: &depositor,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "deposit",
+                args: (depositor.clone(), deal_a.clone(), 200i128).into_val(&env),
+                sub_invokes: &[MockAuthInvoke {
+                    contract: &token,
+                    fn_name: "transfer",
+                    args: (depositor.clone(), contract_id.clone(), 200i128).into_val(&env),
+                    sub_invokes: &[],
+                }],
+            },
+        }]);
+        client
+            .try_deposit(&depositor, &deal_a, &200i128)
+            .unwrap()
+            .unwrap();
+        env.mock_auths(&[MockAuth {
+            address: &depositor,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "deposit",
+                args: (depositor.clone(), deal_b.clone(), 300i128).into_val(&env),
+                sub_invokes: &[MockAuthInvoke {
+                    contract: &token,
+                    fn_name: "transfer",
+                    args: (depositor.clone(), contract_id.clone(), 300i128).into_val(&env),
+                    sub_invokes: &[],
+                }],
+            },
+        }]);
+        client
+            .try_deposit(&depositor, &deal_b, &300i128)
+            .unwrap()
+            .unwrap();
+
+        // Rewind schema to V1.
+        env.as_contract(&contract_id, || {
+            env.storage()
+                .instance()
+                .set(&DataKey::StorageSchemaVersion, &1u32);
+        });
+
+        let deal_ids = soroban_sdk::Vec::from_array(&env, [deal_a.clone(), deal_b.clone()]);
+        env.mock_all_auths();
+        client
+            .try_migrate_storage_schema(&admin, &1u32, &deal_ids)
+            .unwrap()
+            .unwrap();
+
+        // Per-deal balances are intact after migration.
+        assert_eq!(client.balance(&deal_a), 200i128);
+        assert_eq!(client.balance(&deal_b), 300i128);
+        assert_eq!(client.storage_schema_version(), 3u32);
+    }
+
+    // ── #1185 Dispute timeouts and circuit-breaker drain governance ──────────
+
+    #[test]
+    fn challenge_after_window_is_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, client, admin, operator, token, token_admin, _) = setup(&env);
+        let depositor = Address::generate(&env);
+        let landlord = Address::generate(&env);
+        let deal_id = String::from_str(&env, "chall-window-1");
+        let token_sac = soroban_sdk::token::StellarAssetClient::new(&env, &token);
+        token_sac.mint(&depositor, &100i128);
+        env.mock_auths(&[MockAuth {
+            address: &depositor,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "deposit",
+                args: (depositor.clone(), deal_id.clone(), 100i128).into_val(&env),
+                sub_invokes: &[MockAuthInvoke {
+                    contract: &token,
+                    fn_name: "transfer",
+                    args: (depositor.clone(), contract_id.clone(), 100i128).into_val(&env),
+                    sub_invokes: &[],
+                }],
+            },
+        }]);
+        client
+            .try_deposit(&depositor, &deal_id, &100i128)
+            .unwrap()
+            .unwrap();
+        env.mock_all_auths();
+        // Configure a 5-second challenge window.
+        client
+            .try_configure_dispute_windows(&admin, &5u64, &100u64)
+            .unwrap()
+            .unwrap();
+        client
+            .try_request_rent_release(
+                &operator,
+                &deal_id,
+                &landlord,
+                &100i128,
+                &Symbol::new(&env, "rent"),
+                &String::from_str(&env, "inv-cw1"),
+            )
+            .unwrap()
+            .unwrap();
+        // Advance past the challenge window.
+        env.ledger()
+            .set_timestamp(env.ledger().timestamp() + 10);
+        let err = client
+            .try_challenge_rent_release(
+                &depositor,
+                &deal_id,
+                &String::from_str(&env, "evidence"),
+            )
+            .unwrap_err()
+            .unwrap();
+        assert_eq!(err, ContractError::DisputeNotAllowed);
+    }
+
+    #[test]
+    fn settle_release_timeout_before_window_expires_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, client, admin, operator, token, token_admin, _) = setup(&env);
+        let depositor = Address::generate(&env);
+        let landlord = Address::generate(&env);
+        let deal_id = String::from_str(&env, "settle-early-1");
+        let token_sac = soroban_sdk::token::StellarAssetClient::new(&env, &token);
+        token_sac.mint(&depositor, &100i128);
+        env.mock_auths(&[MockAuth {
+            address: &depositor,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "deposit",
+                args: (depositor.clone(), deal_id.clone(), 100i128).into_val(&env),
+                sub_invokes: &[MockAuthInvoke {
+                    contract: &token,
+                    fn_name: "transfer",
+                    args: (depositor.clone(), contract_id.clone(), 100i128).into_val(&env),
+                    sub_invokes: &[],
+                }],
+            },
+        }]);
+        client
+            .try_deposit(&depositor, &deal_id, &100i128)
+            .unwrap()
+            .unwrap();
+        env.mock_all_auths();
+        // Window = 10 seconds.
+        client
+            .try_configure_dispute_windows(&admin, &10u64, &100u64)
+            .unwrap()
+            .unwrap();
+        client
+            .try_request_rent_release(
+                &operator,
+                &deal_id,
+                &landlord,
+                &100i128,
+                &Symbol::new(&env, "rent"),
+                &String::from_str(&env, "inv-se1"),
+            )
+            .unwrap()
+            .unwrap();
+        // Advance only 5 seconds (window = 10).
+        env.ledger()
+            .set_timestamp(env.ledger().timestamp() + 5);
+        let err = client
+            .try_settle_rent_release_timeout(&deal_id)
+            .unwrap_err()
+            .unwrap();
+        assert_eq!(err, ContractError::InvalidReleaseWindow);
+    }
+
+    #[test]
+    fn settle_dispute_timeout_before_expiry_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, client, admin, operator, token, token_admin, _) = setup(&env);
+        let depositor = Address::generate(&env);
+        let landlord = Address::generate(&env);
+        let resolver = Address::generate(&env);
+        let deal_id = String::from_str(&env, "disp-timeout-early");
+        let token_sac = soroban_sdk::token::StellarAssetClient::new(&env, &token);
+        token_sac.mint(&depositor, &100i128);
+        env.mock_auths(&[MockAuth {
+            address: &depositor,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "deposit",
+                args: (depositor.clone(), deal_id.clone(), 100i128).into_val(&env),
+                sub_invokes: &[MockAuthInvoke {
+                    contract: &token,
+                    fn_name: "transfer",
+                    args: (depositor.clone(), contract_id.clone(), 100i128).into_val(&env),
+                    sub_invokes: &[],
+                }],
+            },
+        }]);
+        client
+            .try_deposit(&depositor, &deal_id, &100i128)
+            .unwrap()
+            .unwrap();
+        env.mock_all_auths();
+        client
+            .try_configure_dispute_windows(&admin, &5u64, &20u64)
+            .unwrap()
+            .unwrap();
+        client
+            .try_set_resolver(&admin, &resolver)
+            .unwrap()
+            .unwrap();
+        client
+            .try_request_rent_release(
+                &operator,
+                &deal_id,
+                &landlord,
+                &100i128,
+                &Symbol::new(&env, "rent"),
+                &String::from_str(&env, "inv-dt1"),
+            )
+            .unwrap()
+            .unwrap();
+        // Challenge within the 5s window (advance 2s).
+        env.ledger()
+            .set_timestamp(env.ledger().timestamp() + 2);
+        client
+            .try_challenge_rent_release(
+                &depositor,
+                &deal_id,
+                &String::from_str(&env, "evidence"),
+            )
+            .unwrap()
+            .unwrap();
+        // Advance 10 more seconds — dispute timeout is 20s, so still early.
+        env.ledger()
+            .set_timestamp(env.ledger().timestamp() + 10);
+        let err = client
+            .try_settle_dispute_timeout(&deal_id)
+            .unwrap_err()
+            .unwrap();
+        assert_eq!(err, ContractError::InvalidReleaseWindow);
+    }
+
+    #[test]
+    fn settle_dispute_timeout_after_expiry_refunds_depositor() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, client, admin, operator, token, token_admin, _) = setup(&env);
+        let depositor = Address::generate(&env);
+        let landlord = Address::generate(&env);
+        let deal_id = String::from_str(&env, "disp-timeout-ok");
+        let token_sac = soroban_sdk::token::StellarAssetClient::new(&env, &token);
+        let token_client = TokenClient::new(&env, &token);
+        token_sac.mint(&depositor, &100i128);
+        env.mock_auths(&[MockAuth {
+            address: &depositor,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "deposit",
+                args: (depositor.clone(), deal_id.clone(), 100i128).into_val(&env),
+                sub_invokes: &[MockAuthInvoke {
+                    contract: &token,
+                    fn_name: "transfer",
+                    args: (depositor.clone(), contract_id.clone(), 100i128).into_val(&env),
+                    sub_invokes: &[],
+                }],
+            },
+        }]);
+        client
+            .try_deposit(&depositor, &deal_id, &100i128)
+            .unwrap()
+            .unwrap();
+        env.mock_all_auths();
+        client
+            .try_configure_dispute_windows(&admin, &5u64, &20u64)
+            .unwrap()
+            .unwrap();
+        client
+            .try_request_rent_release(
+                &operator,
+                &deal_id,
+                &landlord,
+                &100i128,
+                &Symbol::new(&env, "rent"),
+                &String::from_str(&env, "inv-dt2"),
+            )
+            .unwrap()
+            .unwrap();
+        // Challenge within the 5s window.
+        env.ledger()
+            .set_timestamp(env.ledger().timestamp() + 2);
+        client
+            .try_challenge_rent_release(
+                &depositor,
+                &deal_id,
+                &String::from_str(&env, "evidence"),
+            )
+            .unwrap()
+            .unwrap();
+        // Advance well past dispute timeout (20s).
+        env.ledger()
+            .set_timestamp(env.ledger().timestamp() + 25);
+        // settle_dispute_timeout refunds depositor.
+        client.try_settle_dispute_timeout(&deal_id).unwrap().unwrap();
+        assert_eq!(token_client.balance(&depositor), 100i128);
+        // Cannot settle again.
+        let err = client
+            .try_settle_dispute_timeout(&deal_id)
+            .unwrap_err()
+            .unwrap();
+        assert_eq!(err, ContractError::NoOpenDispute);
+    }
+
+    #[test]
+    fn freeze_blocks_release_but_not_deposit() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, client, admin, operator, token, token_admin, _) = setup(&env);
+        let depositor = Address::generate(&env);
+        let to = Address::generate(&env);
+        let platform = Address::generate(&env);
+        let reporter = Address::generate(&env);
+        let deal_id = String::from_str(&env, "freeze-rel");
+        let token_sac = soroban_sdk::token::StellarAssetClient::new(&env, &token);
+        token_sac.mint(&depositor, &100i128);
+        env.mock_auths(&[MockAuth {
+            address: &depositor,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "deposit",
+                args: (depositor.clone(), deal_id.clone(), 100i128).into_val(&env),
+                sub_invokes: &[MockAuthInvoke {
+                    contract: &token,
+                    fn_name: "transfer",
+                    args: (depositor.clone(), contract_id.clone(), 100i128).into_val(&env),
+                    sub_invokes: &[],
+                }],
+            },
+        }]);
+        client
+            .try_deposit(&depositor, &deal_id, &100i128)
+            .unwrap()
+            .unwrap();
+        env.mock_all_auths();
+        // Freeze the contract.
+        client.try_freeze(&admin).unwrap().unwrap();
+        assert!(client.is_frozen());
+        assert_eq!(client.get_circuit_breaker_state(), 1u32); // Frozen = 1
+
+        // Release is blocked while frozen.
+        let err = client
+            .try_release(
+                &operator,
+                &deal_id,
+                &to,
+                &100i128,
+                &platform,
+                &0i128,
+                &reporter,
+                &0i128,
+                &Symbol::new(&env, "rent"),
+                &String::from_str(&env, "ref-freeze"),
+            )
+            .unwrap_err()
+            .unwrap();
+        assert_eq!(err, ContractError::Frozen);
+    }
+
+    #[test]
+    fn propose_drain_requires_frozen_state() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (_, client, admin, _, _, _, _) = setup(&env);
+        let drain_hash = BytesN::from_array(&env, &[2u8; 32]);
+        // propose_drain while unfrozen must fail.
+        let err = client
+            .try_propose_drain(&admin, &drain_hash)
+            .unwrap_err()
+            .unwrap();
+        assert_eq!(err, ContractError::InvalidGovernanceDrain);
+    }
+
+    #[test]
+    fn execute_drain_before_recovery_delay_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (_, client, admin, _, _, _, _) = setup(&env);
+        let drain_hash = BytesN::from_array(&env, &[3u8; 32]);
+        client.try_set_recovery_delay(&admin, &100u64).unwrap().unwrap();
+        client.try_freeze(&admin).unwrap().unwrap();
+        client.try_propose_drain(&admin, &drain_hash).unwrap().unwrap();
+        // Advance only 50s — delay is 100s.
+        env.ledger()
+            .set_timestamp(env.ledger().timestamp() + 50);
+        let err = client
+            .try_execute_drain(&admin, &drain_hash)
+            .unwrap_err()
+            .unwrap();
+        assert_eq!(err, ContractError::RecoveryDelayNotMet);
+    }
+
+    #[test]
+    fn execute_drain_after_delay_succeeds_and_unfreezes() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (_, client, admin, _, _, _, _) = setup(&env);
+        let drain_hash = BytesN::from_array(&env, &[4u8; 32]);
+        client.try_set_recovery_delay(&admin, &100u64).unwrap().unwrap();
+        client.try_freeze(&admin).unwrap().unwrap();
+        assert_eq!(client.get_circuit_breaker_state(), 1u32); // Frozen
+        client.try_propose_drain(&admin, &drain_hash).unwrap().unwrap();
+        // Advance past the 100s delay.
+        env.ledger()
+            .set_timestamp(env.ledger().timestamp() + 101);
+        client.try_execute_drain(&admin, &drain_hash).unwrap().unwrap();
+        // Contract must be unfrozen after drain executes.
+        assert_eq!(client.get_circuit_breaker_state(), 0u32); // Unfrozen
+        assert!(!client.is_frozen());
+    }
+
+    #[test]
+    fn unauthorized_drain_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, client, admin, _, _, _, _) = setup(&env);
+        let stranger = Address::generate(&env);
+        let drain_hash = BytesN::from_array(&env, &[5u8; 32]);
+        client.try_freeze(&admin).unwrap().unwrap();
+        client.try_propose_drain(&admin, &drain_hash).unwrap().unwrap();
+        // Advance past default delay (24 hours).
+        env.ledger()
+            .set_timestamp(env.ledger().timestamp() + 86_401);
+        // Non-admin execute_drain must fail.
+        env.mock_auths(&[MockAuth {
+            address: &stranger,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "execute_drain",
+                args: (stranger.clone(), drain_hash.clone()).into_val(&env),
+                sub_invokes: &[],
+            },
+        }]);
+        let err = client
+            .try_execute_drain(&stranger, &drain_hash)
+            .unwrap_err()
+            .unwrap();
+        assert_eq!(err, ContractError::NotAuthorized);
+    }
+
+    #[test]
+    fn circuit_breaker_state_transitions_unfrozen_frozen_unfrozen() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (_, client, admin, _, _, _, _) = setup(&env);
+
+        // Initially unfrozen (0).
+        assert_eq!(client.get_circuit_breaker_state(), 0u32);
+        assert!(!client.is_frozen());
+
+        // After freeze: Frozen (1).
+        client.try_freeze(&admin).unwrap().unwrap();
+        assert_eq!(client.get_circuit_breaker_state(), 1u32);
+        assert!(client.is_frozen());
+
+        // After drain executes: back to Unfrozen (0).
+        let drain_hash = BytesN::from_array(&env, &[6u8; 32]);
+        client.try_propose_drain(&admin, &drain_hash).unwrap().unwrap();
+        env.ledger()
+            .set_timestamp(env.ledger().timestamp() + 100_000);
+        client.try_execute_drain(&admin, &drain_hash).unwrap().unwrap();
+        assert_eq!(client.get_circuit_breaker_state(), 0u32);
+        assert!(!client.is_frozen());
+    }
 }

--- a/contracts/staking_rewards/src/lib.rs
+++ b/contracts/staking_rewards/src/lib.rs
@@ -43,10 +43,16 @@ pub enum ContractError {
 pub struct UserStake {
     pub amount: i128,
     pub user_index: i128,
+    /// Rewards settled on partial-unstake or re-stake, awaiting the next claim.
+    pub pending_amount: i128,
 }
 
 const REWARD_INDEX: &str = "REWARD_IDX";
 const TOTAL_STAKED: &str = "TOTAL_STK";
+/// Remainder tokens that could not increment the index; carried into the next distribution.
+const PENDING_DUST: &str = "DUST";
+/// Monotonically increasing total of all tokens ever passed to fund_rewards/distribute_rewards.
+const TOTAL_FUNDED: &str = "FUNDED";
 const SCALE: i128 = 1_000_000_000;
 
 pub mod formal_properties;
@@ -211,6 +217,9 @@ impl StakingRewards {
         let mut user_stake = Self::get_user_stake(&env, &user);
         let reward_index = Self::get_reward_index(&env);
 
+        // Settle any rewards earned so far at the current stake before the index resets.
+        let earned = Self::calc_pending(&user_stake, reward_index);
+        user_stake.pending_amount += earned;
         user_stake.amount += amount;
         user_stake.user_index = reward_index;
 
@@ -246,6 +255,11 @@ impl StakingRewards {
             panic!("Insufficient staked amount");
         }
 
+        // Settle rewards earned on the full stake before the amount changes.
+        let reward_index = Self::get_reward_index(&env);
+        let earned = Self::calc_pending(&user_stake, reward_index);
+        user_stake.pending_amount += earned;
+        user_stake.user_index = reward_index;
         user_stake.amount -= amount;
 
         env.storage().persistent().set(&user, &user_stake);
@@ -274,14 +288,29 @@ impl StakingRewards {
             return Err(ContractError::InvalidAmount);
         }
 
+        // Track cumulative funded for the conservation invariant.
+        let total_funded = Self::get_total_funded_inner(&env);
+        env.storage()
+            .persistent()
+            .set(&TOTAL_FUNDED, &(total_funded + amount));
+
         let total = Self::get_total_staked(&env);
         if total == 0 {
             return Ok(());
         }
 
         let reward_index = Self::get_reward_index(&env);
-        let new_index = reward_index + (amount * SCALE / total);
-        env.storage().persistent().set(&REWARD_INDEX, &new_index);
+        // Carry forward any remainder from the previous distribution so dust
+        // is not permanently lost when amount * SCALE is not divisible by total.
+        let dust = Self::get_pending_dust_inner(&env);
+        let total_to_dist = amount + dust;
+        let index_increment = total_to_dist * SCALE / total;
+        let committed = index_increment * total / SCALE;
+        let new_dust = total_to_dist - committed;
+        env.storage()
+            .persistent()
+            .set(&REWARD_INDEX, &(reward_index + index_increment));
+        env.storage().persistent().set(&PENDING_DUST, &new_dust);
 
         env.events().publish(
             (
@@ -302,14 +331,27 @@ impl StakingRewards {
             return Err(ContractError::InvalidAmount);
         }
 
+        // Track cumulative funded for the conservation invariant.
+        let total_funded = Self::get_total_funded_inner(&env);
+        env.storage()
+            .persistent()
+            .set(&TOTAL_FUNDED, &(total_funded + amount));
+
         let total = Self::get_total_staked(&env);
         if total == 0 {
             return Ok(());
         }
 
         let reward_index = Self::get_reward_index(&env);
-        let new_index = reward_index + (amount * SCALE / total);
-        env.storage().persistent().set(&REWARD_INDEX, &new_index);
+        let dust = Self::get_pending_dust_inner(&env);
+        let total_to_dist = amount + dust;
+        let index_increment = total_to_dist * SCALE / total;
+        let committed = index_increment * total / SCALE;
+        let new_dust = total_to_dist - committed;
+        env.storage()
+            .persistent()
+            .set(&REWARD_INDEX, &(reward_index + index_increment));
+        env.storage().persistent().set(&PENDING_DUST, &new_dust);
 
         env.events().publish(
             (
@@ -329,8 +371,9 @@ impl StakingRewards {
         let mut user_stake = Self::get_user_stake(&env, &user);
         let reward_index = Self::get_reward_index(&env);
 
-        let claimable = Self::calc_pending(&user_stake, reward_index);
+        let claimable = Self::calc_pending(&user_stake, reward_index) + user_stake.pending_amount;
         user_stake.user_index = reward_index;
+        user_stake.pending_amount = 0;
 
         env.storage().persistent().set(&user, &user_stake);
 
@@ -348,7 +391,15 @@ impl StakingRewards {
     pub fn get_claimable(env: Env, user: Address) -> i128 {
         let user_stake = Self::get_user_stake(&env, &user);
         let reward_index = Self::get_reward_index(&env);
-        Self::calc_pending(&user_stake, reward_index)
+        Self::calc_pending(&user_stake, reward_index) + user_stake.pending_amount
+    }
+
+    pub fn get_total_funded(env: Env) -> i128 {
+        Self::get_total_funded_inner(&env)
+    }
+
+    pub fn get_pending_dust(env: Env) -> i128 {
+        Self::get_pending_dust_inner(&env)
     }
 
     fn calc_pending(user_stake: &UserStake, reward_index: i128) -> i128 {
@@ -359,6 +410,7 @@ impl StakingRewards {
         env.storage().persistent().get(user).unwrap_or(UserStake {
             amount: 0,
             user_index: 0,
+            pending_amount: 0,
         })
     }
 
@@ -368,6 +420,14 @@ impl StakingRewards {
 
     fn get_total_staked(env: &Env) -> i128 {
         env.storage().persistent().get(&TOTAL_STAKED).unwrap_or(0)
+    }
+
+    fn get_pending_dust_inner(env: &Env) -> i128 {
+        env.storage().persistent().get(&PENDING_DUST).unwrap_or(0)
+    }
+
+    fn get_total_funded_inner(env: &Env) -> i128 {
+        env.storage().persistent().get(&TOTAL_FUNDED).unwrap_or(0)
     }
 
     // ── Upgrade governance (#392) ──────────────────────────────────────────────

--- a/contracts/staking_rewards/src/tests.rs
+++ b/contracts/staking_rewards/src/tests.rs
@@ -342,7 +342,10 @@ fn unstake_settles_outstanding_rewards_before_reducing_stake() {
 
     // Outstanding rewards on the full 1000 must be claimable after partial unstake.
     let claimable = client.get_claimable(&user);
-    assert_eq!(claimable, 1000, "rewards on pre-unstake stake must be preserved");
+    assert_eq!(
+        claimable, 1000,
+        "rewards on pre-unstake stake must be preserved"
+    );
 
     // Claim settles everything.
     let claimed = client.claim(&user);

--- a/contracts/staking_rewards/src/tests.rs
+++ b/contracts/staking_rewards/src/tests.rs
@@ -230,3 +230,164 @@ fn claim_rewards_when_paused() {
         _ => panic!("Expected ContractError::Paused"),
     }
 }
+
+// ── #1189 Rounding-safe distribution and conservation invariants ─────────────
+
+#[test]
+fn sum_claimable_never_exceeds_total_funded() {
+    let env = Env::default();
+    let (_contract_id, client) = setup(&env);
+
+    let user1 = Address::generate(&env);
+    let user2 = Address::generate(&env);
+    let user3 = Address::generate(&env);
+    let user4 = Address::generate(&env);
+    let user5 = Address::generate(&env);
+
+    // Uneven stake split to stress rounding
+    client.stake(&user1, &100);
+    client.stake(&user2, &333);
+    client.stake(&user3, &500);
+    client.stake(&user4, &1);
+    client.stake(&user5, &66);
+
+    client.distribute_rewards(&1000);
+    client.distribute_rewards(&777);
+    client.distribute_rewards(&13);
+
+    let total_funded: i128 = 1000 + 777 + 13;
+    let total_claimable = client.get_claimable(&user1)
+        + client.get_claimable(&user2)
+        + client.get_claimable(&user3)
+        + client.get_claimable(&user4)
+        + client.get_claimable(&user5);
+
+    assert!(
+        total_claimable <= total_funded,
+        "total claimable {} must not exceed total funded {}",
+        total_claimable,
+        total_funded
+    );
+}
+
+#[test]
+fn dust_carried_forward_not_silently_dropped() {
+    let env = Env::default();
+    let (_contract_id, client) = setup(&env);
+
+    let user = Address::generate(&env);
+    // Stake more than SCALE so a 1-token distribution has zero index increment.
+    let big_stake: i128 = 1_000_000_001; // > SCALE
+    client.stake(&user, &big_stake);
+
+    // Distributing 1 token: index_incr = 1 * SCALE / big_stake = 0.
+    // Without carry-forward this token is permanently lost.
+    client.distribute_rewards(&1);
+    // Pending dust should now be 1.
+    assert_eq!(client.get_pending_dust(), 1);
+
+    // Distributing big_stake - 1 more: total_to_dist = big_stake (exact).
+    // With carry-forward, index_incr = big_stake * SCALE / big_stake = SCALE.
+    client.distribute_rewards(&(big_stake - 1));
+
+    let claimable = client.get_claimable(&user);
+    let total_funded: i128 = 1 + (big_stake - 1);
+    // Dust was carried forward; claimable should equal total funded exactly.
+    assert_eq!(
+        claimable, total_funded,
+        "carry-forward dust must reach the user: claimable={} funded={}",
+        claimable, total_funded
+    );
+    assert_eq!(client.get_pending_dust(), 0);
+    // total_funded tracker must be correct.
+    assert_eq!(client.get_total_funded(), total_funded);
+}
+
+#[test]
+fn claim_idempotency_second_claim_is_zero() {
+    let env = Env::default();
+    let (_contract_id, client) = setup(&env);
+
+    let user = Address::generate(&env);
+    client.stake(&user, &1000);
+    client.distribute_rewards(&500);
+
+    let first = client.claim(&user);
+    assert_eq!(first, 500);
+
+    // Immediate second claim must return 0, not 500 again.
+    let second = client.claim(&user);
+    assert_eq!(second, 0);
+
+    // Fresh distribution then claim works correctly.
+    client.distribute_rewards(&200);
+    let third = client.claim(&user);
+    assert_eq!(third, 200);
+
+    let fourth = client.claim(&user);
+    assert_eq!(fourth, 0);
+}
+
+#[test]
+fn unstake_settles_outstanding_rewards_before_reducing_stake() {
+    let env = Env::default();
+    let (_contract_id, client) = setup(&env);
+
+    let user = Address::generate(&env);
+    client.stake(&user, &1000);
+    client.distribute_rewards(&1000); // user earned 1000
+
+    // Unstake half WITHOUT claiming first.
+    client.unstake(&user, &500);
+
+    // Outstanding rewards on the full 1000 must be claimable after partial unstake.
+    let claimable = client.get_claimable(&user);
+    assert_eq!(claimable, 1000, "rewards on pre-unstake stake must be preserved");
+
+    // Claim settles everything.
+    let claimed = client.claim(&user);
+    assert_eq!(claimed, 1000);
+    assert_eq!(client.get_claimable(&user), 0);
+
+    // Further rewards accrue only on the remaining 500 stake;
+    // user is the sole staker so they get the full 500.
+    client.distribute_rewards(&500);
+    assert_eq!(client.get_claimable(&user), 500);
+}
+
+#[test]
+fn stake_unstake_between_distributions_correct_per_staker_rewards() {
+    let env = Env::default();
+    let (_contract_id, client) = setup(&env);
+
+    let user1 = Address::generate(&env);
+    let user2 = Address::generate(&env);
+
+    // Epoch 1: only user1 staked.
+    client.stake(&user1, &1000);
+    client.distribute_rewards(&1000);
+    // user1 earned 1000.
+
+    // Epoch 2: user2 joins.
+    client.stake(&user2, &1000);
+    client.distribute_rewards(&2000);
+    // Each earns 1000 more.
+
+    assert_eq!(client.get_claimable(&user1), 1000 + 1000);
+    assert_eq!(client.get_claimable(&user2), 1000);
+
+    // Epoch 3: user1 partially unstakes (settles at current reward).
+    client.unstake(&user1, &500); // user1 now has 500 staked
+    client.distribute_rewards(&1500);
+    // user1 (500) + user2 (1000) = 1500 total; user1 gets 500, user2 gets 1000.
+
+    let c1 = client.get_claimable(&user1);
+    let c2 = client.get_claimable(&user2);
+    // user1: 2000 (settled) + 500 new = 2500
+    assert_eq!(c1, 2500);
+    // user2: 1000 (settled) + 1000 new = 2000
+    assert_eq!(c2, 2000);
+
+    // Conservation: total claimable <= total funded.
+    assert!(c1 + c2 <= 1000 + 2000 + 1500);
+}

--- a/contracts/staking_rewards/test_snapshots/test/non_operator_cannot_fund_rewards.1.json
+++ b/contracts/staking_rewards/test_snapshots/test/non_operator_cannot_fund_rewards.1.json
@@ -114,6 +114,17 @@
                     },
                     {
                       "key": {
+                        "symbol": "pending_amount"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 0
+                        }
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "user_index"
                       },
                       "val": {

--- a/contracts/staking_rewards/test_snapshots/test/operator_can_fund_rewards.1.json
+++ b/contracts/staking_rewards/test_snapshots/test/operator_can_fund_rewards.1.json
@@ -92,6 +92,74 @@
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
             "key": {
+              "string": "DUST"
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "string": "DUST"
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 0
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "string": "FUNDED"
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "string": "FUNDED"
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 500
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
               "string": "REWARD_IDX"
             },
             "durability": "persistent"
@@ -186,6 +254,17 @@
                         "i128": {
                           "hi": 0,
                           "lo": 1000
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "pending_amount"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 0
                         }
                       }
                     },

--- a/contracts/staking_rewards/test_snapshots/test/test_claim_does_not_affect_others.1.json
+++ b/contracts/staking_rewards/test_snapshots/test/test_claim_does_not_affect_others.1.json
@@ -116,6 +116,74 @@
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
             "key": {
+              "string": "DUST"
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "string": "DUST"
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 0
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "string": "FUNDED"
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "string": "FUNDED"
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 1000
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
               "string": "REWARD_IDX"
             },
             "durability": "persistent"
@@ -215,6 +283,17 @@
                     },
                     {
                       "key": {
+                        "symbol": "pending_amount"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 0
+                        }
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "user_index"
                       },
                       "val": {
@@ -264,6 +343,17 @@
                         "i128": {
                           "hi": 0,
                           "lo": 1000
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "pending_amount"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 0
                         }
                       }
                     },

--- a/contracts/staking_rewards/test_snapshots/test/test_rewards_distributed_fairly.1.json
+++ b/contracts/staking_rewards/test_snapshots/test/test_rewards_distributed_fairly.1.json
@@ -97,6 +97,74 @@
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
             "key": {
+              "string": "DUST"
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "string": "DUST"
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 0
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "string": "FUNDED"
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "string": "FUNDED"
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 4000
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
               "string": "REWARD_IDX"
             },
             "durability": "persistent"
@@ -196,6 +264,17 @@
                     },
                     {
                       "key": {
+                        "symbol": "pending_amount"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 0
+                        }
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "user_index"
                       },
                       "val": {
@@ -245,6 +324,17 @@
                         "i128": {
                           "hi": 0,
                           "lo": 1000
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "pending_amount"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 0
                         }
                       }
                     },

--- a/contracts/staking_rewards/test_snapshots/test/test_two_users_different_times.1.json
+++ b/contracts/staking_rewards/test_snapshots/test/test_two_users_different_times.1.json
@@ -119,6 +119,74 @@
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
             "key": {
+              "string": "DUST"
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "string": "DUST"
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 0
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "string": "FUNDED"
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "string": "FUNDED"
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 1500
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
               "string": "REWARD_IDX"
             },
             "durability": "persistent"
@@ -218,6 +286,17 @@
                     },
                     {
                       "key": {
+                        "symbol": "pending_amount"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 0
+                        }
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "user_index"
                       },
                       "val": {
@@ -267,6 +346,17 @@
                         "i128": {
                           "hi": 0,
                           "lo": 1000
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "pending_amount"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 0
                         }
                       }
                     },

--- a/contracts/vesting_schedule/src/test.rs
+++ b/contracts/vesting_schedule/src/test.rs
@@ -479,7 +479,10 @@ fn cliff_at_exactly_cliff_time_claimable_matches_vested() {
     let expected = (CLIFF - START) as i128 * TOTAL / (END - START) as i128;
     assert_eq!(calculate_vested_amount(&schedule, CLIFF), expected);
     assert_eq!(calculate_claimable_amount(&schedule, CLIFF), expected);
-    assert_eq!(ctx.contract.get_claimable_amount(&ctx.beneficiary), expected);
+    assert_eq!(
+        ctx.contract.get_claimable_amount(&ctx.beneficiary),
+        expected
+    );
     // Claim at the exact cliff instant must succeed and return the vested amount.
     let claimed = ctx.contract.claim(&ctx.beneficiary);
     assert_eq!(claimed, expected);
@@ -495,7 +498,10 @@ fn cliff_just_after_increases_proportionally() {
     // Vested amount at cliff+1 is ≥ at cliff.
     assert!(at_cliff_plus_one >= at_cliff);
     assert_eq!(calculate_vested_amount(&schedule, CLIFF), at_cliff);
-    assert_eq!(calculate_vested_amount(&schedule, CLIFF + 1), at_cliff_plus_one);
+    assert_eq!(
+        calculate_vested_amount(&schedule, CLIFF + 1),
+        at_cliff_plus_one
+    );
     assert_eq!(
         calculate_claimable_amount(&schedule, CLIFF + 1),
         at_cliff_plus_one
@@ -521,7 +527,7 @@ fn vesting_progression_at_start_mid_and_end() {
     assert_eq!(calculate_vested_amount(&schedule, 9_000), 9_000);
     assert_eq!(calculate_vested_amount(&schedule, 12_000), 12_000);
     assert_eq!(calculate_vested_amount(&schedule, 20_000), 12_000); // capped at total
-    // Claimable mirrors vested when cliff=start and nothing yet claimed.
+                                                                    // Claimable mirrors vested when cliff=start and nothing yet claimed.
     assert_eq!(calculate_claimable_amount(&schedule, 6_000), 6_000);
     assert_eq!(calculate_claimable_amount(&schedule, 12_000), 12_000);
 }

--- a/contracts/vesting_schedule/src/test.rs
+++ b/contracts/vesting_schedule/src/test.rs
@@ -450,3 +450,143 @@ fn revoke_releases_guard_on_error() {
     let returned = ctx.contract.revoke(&ctx.admin, &stranger);
     assert_eq!(returned, TOTAL);
 }
+
+// ── #1188 Cliff-boundary and post-revoke accounting ──────────────────────────
+
+#[test]
+fn cliff_just_before_zero_claimable_exact_boundary() {
+    let ctx = setup();
+    create_default(&ctx, true);
+    // One second strictly before cliff: 0 claimable.
+    set_time(&ctx.env, CLIFF - 1);
+    let schedule = ctx.contract.get_vesting_schedule(&ctx.beneficiary);
+    assert_eq!(calculate_claimable_amount(&schedule, CLIFF - 1), 0);
+    assert_eq!(ctx.contract.get_claimable_amount(&ctx.beneficiary), 0);
+    // Claim also rejected.
+    assert_eq!(
+        ctx.contract.try_claim(&ctx.beneficiary),
+        Err(Ok(ContractError::CliffNotReached))
+    );
+}
+
+#[test]
+fn cliff_at_exactly_cliff_time_claimable_matches_vested() {
+    let ctx = setup();
+    create_default(&ctx, true);
+    set_time(&ctx.env, CLIFF);
+    let schedule = ctx.contract.get_vesting_schedule(&ctx.beneficiary);
+    // Expected vested = elapsed / total_duration * total_amount (exact integer).
+    let expected = (CLIFF - START) as i128 * TOTAL / (END - START) as i128;
+    assert_eq!(calculate_vested_amount(&schedule, CLIFF), expected);
+    assert_eq!(calculate_claimable_amount(&schedule, CLIFF), expected);
+    assert_eq!(ctx.contract.get_claimable_amount(&ctx.beneficiary), expected);
+    // Claim at the exact cliff instant must succeed and return the vested amount.
+    let claimed = ctx.contract.claim(&ctx.beneficiary);
+    assert_eq!(claimed, expected);
+}
+
+#[test]
+fn cliff_just_after_increases_proportionally() {
+    let ctx = setup();
+    create_default(&ctx, true);
+    let schedule = ctx.contract.get_vesting_schedule(&ctx.beneficiary);
+    let at_cliff = (CLIFF - START) as i128 * TOTAL / (END - START) as i128;
+    let at_cliff_plus_one = (CLIFF + 1 - START) as i128 * TOTAL / (END - START) as i128;
+    // Vested amount at cliff+1 is ≥ at cliff.
+    assert!(at_cliff_plus_one >= at_cliff);
+    assert_eq!(calculate_vested_amount(&schedule, CLIFF), at_cliff);
+    assert_eq!(calculate_vested_amount(&schedule, CLIFF + 1), at_cliff_plus_one);
+    assert_eq!(
+        calculate_claimable_amount(&schedule, CLIFF + 1),
+        at_cliff_plus_one
+    );
+}
+
+#[test]
+fn vesting_progression_at_start_mid_and_end() {
+    let env = Env::default();
+    let schedule = VestingSchedule {
+        beneficiary: Address::generate(&env),
+        total_amount: 12_000,
+        claimed_amount: 0,
+        start_time: 0,
+        end_time: 12_000,
+        cliff_time: 0,
+        revocable: true,
+        revoked: false,
+    };
+    assert_eq!(calculate_vested_amount(&schedule, 0), 0);
+    assert_eq!(calculate_vested_amount(&schedule, 3_000), 3_000);
+    assert_eq!(calculate_vested_amount(&schedule, 6_000), 6_000);
+    assert_eq!(calculate_vested_amount(&schedule, 9_000), 9_000);
+    assert_eq!(calculate_vested_amount(&schedule, 12_000), 12_000);
+    assert_eq!(calculate_vested_amount(&schedule, 20_000), 12_000); // capped at total
+    // Claimable mirrors vested when cliff=start and nothing yet claimed.
+    assert_eq!(calculate_claimable_amount(&schedule, 6_000), 6_000);
+    assert_eq!(calculate_claimable_amount(&schedule, 12_000), 12_000);
+}
+
+#[test]
+fn post_revoke_beneficiary_fully_blocked_regardless_of_vested() {
+    let ctx = setup();
+    create_default(&ctx, true);
+
+    // Claim a quarter of vested tokens before revoke.
+    set_time(&ctx.env, START + (END - START) / 4);
+    let claimed = ctx.contract.claim(&ctx.beneficiary);
+    assert_eq!(claimed, TOTAL / 4);
+
+    // Admin revokes; returned = total - already_claimed.
+    let returned = ctx.contract.revoke(&ctx.admin, &ctx.beneficiary);
+    assert_eq!(returned, TOTAL - TOTAL / 4);
+
+    // At or after end the schedule is fully vested but the beneficiary is blocked.
+    set_time(&ctx.env, END);
+    assert_eq!(
+        ctx.contract.try_claim(&ctx.beneficiary),
+        Err(Ok(ContractError::Revoked))
+    );
+}
+
+#[test]
+fn post_revoke_with_no_prior_claims_all_returned_and_blocked() {
+    let ctx = setup();
+    create_default(&ctx, true);
+    // No claims before revoke — full amount returned.
+    let returned = ctx.contract.revoke(&ctx.admin, &ctx.beneficiary);
+    assert_eq!(returned, TOTAL);
+    // Beneficiary cannot claim anything after revoke.
+    set_time(&ctx.env, END);
+    assert_eq!(
+        ctx.contract.try_claim(&ctx.beneficiary),
+        Err(Ok(ContractError::Revoked))
+    );
+}
+
+#[test]
+fn claim_idempotency_never_double_pays() {
+    let ctx = setup();
+    create_default(&ctx, true);
+    set_time(&ctx.env, CLIFF);
+
+    // First claim at cliff: some tokens released.
+    let first = ctx.contract.claim(&ctx.beneficiary);
+    assert!(first > 0);
+
+    // Second claim at the same instant: nothing more to pay.
+    assert_eq!(
+        ctx.contract.try_claim(&ctx.beneficiary),
+        Err(Ok(ContractError::NothingToClaim))
+    );
+
+    // Advance to end and claim the remainder.
+    set_time(&ctx.env, END);
+    let second = ctx.contract.claim(&ctx.beneficiary);
+    assert_eq!(first + second, TOTAL, "total paid must equal total_amount");
+
+    // Another claim at end: nothing left.
+    assert_eq!(
+        ctx.contract.try_claim(&ctx.beneficiary),
+        Err(Ok(ContractError::NothingToClaim))
+    );
+}


### PR DESCRIPTION
 ## Summary

  - **`staking_rewards`**: Fix dust carry-forward in reward distribution and settle pending rewards on unstake/stake (#1189)
  - **`vesting_schedule`**: Add cliff-boundary, post-revoke, and claim-idempotency tests (#1188)
  - **`deal_escrow`**: Add dispute timeout / circuit-breaker drain governance tests (#1185) and storage-schema migration safety
  tests (#1186)

  ## What was done

  ### `staking_rewards` — bug fixes + tests (#1189)
  - Added `pending_amount: i128` to `UserStake` so rewards earned before a partial `unstake` or re-`stake` are not silently lost
  - `unstake()` and `stake()` now settle pending rewards before modifying stake amount / resetting `user_index`
  - `distribute_rewards()` and `fund_rewards()` carry integer-division remainder ("dust") forward via a `PENDING_DUST`
  accumulator, preventing any distributable amount from being permanently dropped
  - Added `TOTAL_FUNDED` tracker enabling the `Σ claimable ≤ Σ funded` conservation invariant
  - Exposed `get_pending_dust()` and `get_total_funded()` public read-only methods for the invariant tests
  - New tests: `sum_claimable_never_exceeds_total_funded`, `dust_carried_forward_not_silently_dropped`,
  `claim_idempotency_second_claim_is_zero`, `unstake_settles_outstanding_rewards_before_reducing_stake`,
  `stake_unstake_between_distributions_correct_per_staker_rewards`

  ### `vesting_schedule` — tests only (#1188)
  - `cliff_just_before_zero_claimable_exact_boundary` — asserts zero claimable at `CLIFF - 1 s`
  - `cliff_at_exactly_cliff_time_claimable_matches_vested` — pins vested amount exactly at cliff boundary
  - `cliff_just_after_increases_proportionally` — verifies monotonicity just past cliff
  - `vesting_progression_at_start_mid_and_end` — pure-function sweep over the full duration
  - `post_revoke_beneficiary_fully_blocked_regardless_of_vested` — revoke after partial claim; beneficiary blocked
  - `post_revoke_with_no_prior_claims_all_returned_and_blocked` — revoke with no prior claims; full amount returned
  - `claim_idempotency_never_double_pays` — second claim returns `NothingToClaim`; partial + remainder == total

  ### `deal_escrow` — tests only (#1185, #1186)

  **Migration safety (#1186)**
  - `migrate_wrong_source_version_rejected` — wrong `from_version` returns `InvalidSchemaVersion`
  - `migrate_v2_to_v3_preserves_per_deal_balance` — balance conserved across migration
  - `migrate_non_admin_rejected` — non-admin call returns `NotAuthorized`
  - `migrate_v1_balance_conservation_across_multiple_deals` — multiple deals preserved

  **Dispute timeout & circuit-breaker (#1185)**
  - `challenge_after_window_is_rejected` — challenge past window returns `DisputeNotAllowed`
  - `settle_release_timeout_before_window_expires_rejected` — early settle returns `InvalidReleaseWindow`
  - `settle_dispute_timeout_before_expiry_rejected` — early dispute-timeout settle returns `InvalidReleaseWindow`
  - `settle_dispute_timeout_after_expiry_refunds_depositor` — full timeout → refund; second attempt `NoOpenDispute`
  - `freeze_blocks_release_but_not_deposit` — frozen contract blocks release, state == 1
  - `propose_drain_requires_frozen_state` — propose while unfrozen returns `InvalidGovernanceDrain`
  - `execute_drain_before_recovery_delay_rejected` — early execute returns `RecoveryDelayNotMet`
  - `execute_drain_after_delay_succeeds_and_unfreezes` — drain after delay succeeds; state returns to 0
  - `unauthorized_drain_rejected` — non-admin execute returns `NotAuthorized`
  - `circuit_breaker_state_transitions_unfrozen_frozen_unfrozen` — verifies 0 → 1 → 0 state machine

  ## Test plan
  
  - [x] `cargo test -p staking_rewards` — 29/29 passed
  - [x] `cargo test -p vesting_schedule` — 29/29 passed
  - [x] `cargo test -p deal_escrow` — 43/43 passed

  Closes #1185
  Closes #1186
  Closes #1188
  Closes #1189

  ---
  All 101 tests pass across the three contracts. The four closing keywords at the bottom will auto-close the linked issues when
  this PR is merged to main.