### PR TITLE
feat: add loading/empty/expired/rate-limited states to public rating …

### DIFF
--- a/frontend/app/rating-card/[token]/layout.tsx
+++ b/frontend/app/rating-card/[token]/layout.tsx
@@ -1,0 +1,28 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Tenant Rating Card — Shelterflex",
+  description:
+    "View this tenant's verified reputation score, payment history, and landlord ratings on Shelterflex.",
+  openGraph: {
+    title: "Tenant Rating Card — Shelterflex",
+    description:
+      "Verified tenant reputation: payment history, property care, and communication scores from past landlords.",
+    siteName: "Shelterflex",
+    type: "profile",
+  },
+  twitter: {
+    card: "summary",
+    title: "Tenant Rating Card — Shelterflex",
+    description:
+      "Verified tenant reputation score on Shelterflex.",
+  },
+};
+
+export default function RatingCardLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
+}

--- a/frontend/app/rating-card/[token]/page.tsx
+++ b/frontend/app/rating-card/[token]/page.tsx
@@ -293,20 +293,25 @@ function SuccessPage({ card }: { card: PublicRatingCard }) {
 
 export default function SharedRatingCardPage() {
   const params = useParams();
-  const token = params.token as string;
-  const [state, setState] = useState<PageState>({ status: "loading" });
+  const token = params.token as string | undefined;
+
+  // derive initial state from token to avoid synchronous setState inside the effect
+  const [state, setState] = useState<PageState>(() =>
+    token ? { status: "loading" } : { status: "expired" }
+  );
 
   useEffect(() => {
-    if (!token) {
-      setState({ status: "expired" });
-      return;
-    }
+    if (!token) return; // nothing to do when token is missing
+
+    let mounted = true;
 
     getSharedRatingCard(token)
       .then((res) => {
+        if (!mounted) return;
         setState({ status: "success", card: res.data });
       })
       .catch((err: unknown) => {
+        if (!mounted) return;
         if (err instanceof ApiError) {
           if (err.status === 429) {
             setState({ status: "rate-limited" });
@@ -319,6 +324,10 @@ export default function SharedRatingCardPage() {
         }
         setState({ status: "expired" });
       });
+
+    return () => {
+      mounted = false;
+    };
   }, [token]);
 
   if (state.status === "loading") return <LoadingSkeleton />;

--- a/frontend/app/rating-card/[token]/page.tsx
+++ b/frontend/app/rating-card/[token]/page.tsx
@@ -3,117 +3,182 @@
 import { useState, useEffect } from "react";
 import { useParams } from "next/navigation";
 import Link from "next/link";
-import { Star, Home, Shield } from "lucide-react";
+import { Star, Home, Shield, Clock } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Empty,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+  EmptyDescription,
+} from "@/components/ui/empty";
+import { Alert, AlertTitle, AlertDescription } from "@/components/ui/alert";
+import { ApiError } from "@/lib/api";
 import {
   getSharedRatingCard,
   type PublicRatingCard,
 } from "@/lib/ratingCardApi";
 
-export default function SharedRatingCardPage() {
-  const params = useParams();
-  const token = params.token as string;
+// "success" covers both populated and empty-ratings cases (empty state is rendered inside SuccessPage)
+type PageState =
+  | { status: "loading" }
+  | { status: "success"; card: PublicRatingCard }
+  | { status: "expired" }
+  | { status: "rate-limited" };
 
-  const [card, setCard] = useState<PublicRatingCard | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+function LoadingSkeleton() {
+  return (
+    <main
+      className="min-h-screen bg-background"
+      aria-label="Loading tenant rating card"
+      aria-busy="true"
+    >
+      <section className="border-b-3 border-foreground bg-muted py-8">
+        <div className="container mx-auto px-4">
+          <Skeleton className="h-4 w-40 mb-2" />
+          <Skeleton className="h-8 w-64 mb-2" />
+          <Skeleton className="h-4 w-48" />
+        </div>
+      </section>
+      <section className="py-12">
+        <div className="container mx-auto px-4 max-w-3xl space-y-8">
+          <Card className="border-3 border-foreground p-8 shadow-[8px_8px_0px_0px_rgba(26,26,26,1)]">
+            <div className="flex flex-col items-center gap-4">
+              <Skeleton className="h-4 w-24" />
+              <Skeleton className="h-12 w-32" />
+              <Skeleton className="h-4 w-20" />
+            </div>
+          </Card>
+          <Card className="border-3 border-foreground p-6 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
+            <Skeleton className="h-5 w-36 mb-4" />
+            <div className="space-y-4">
+              {[1, 2, 3].map((i) => (
+                <div key={i} className="flex items-center gap-3">
+                  <Skeleton className="h-4 w-36" />
+                  <Skeleton className="h-3 flex-1" />
+                  <Skeleton className="h-4 w-8" />
+                </div>
+              ))}
+            </div>
+          </Card>
+        </div>
+      </section>
+    </main>
+  );
+}
 
-  useEffect(() => {
-    if (!token) return;
+function ExpiredState({ rateLimited }: { rateLimited?: boolean }) {
+  return (
+    <main className="min-h-screen bg-background flex items-center justify-center px-4">
+      <Card
+        className="border-3 border-foreground p-8 sm:p-12 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] text-center max-w-md w-full"
+        role="main"
+      >
+        {rateLimited ? (
+          <Clock className="mx-auto h-16 w-16 text-muted-foreground" aria-hidden="true" />
+        ) : (
+          <Shield className="mx-auto h-16 w-16 text-muted-foreground" aria-hidden="true" />
+        )}
+        <h1 className="mt-4 font-mono text-xl font-bold">
+          {rateLimited ? "Too Many Requests" : "Link Unavailable"}
+        </h1>
+        {rateLimited ? (
+          <Alert className="mt-4 text-left">
+            <AlertTitle>Slow down a bit</AlertTitle>
+            <AlertDescription>
+              This page has been viewed too many times recently. Please wait a
+              minute and try again.
+            </AlertDescription>
+          </Alert>
+        ) : (
+          <p className="mt-2 text-muted-foreground">
+            This share link has expired or is no longer valid. Ask the tenant
+            to generate a new link from their Shelterflex profile.
+          </p>
+        )}
+        <Link href="/">
+          <Button className="mt-6 border-3 border-foreground bg-primary font-bold shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
+            <Home className="mr-2 h-4 w-4" aria-hidden="true" />
+            Go to Shelterflex
+          </Button>
+        </Link>
+      </Card>
+    </main>
+  );
+}
 
-    getSharedRatingCard(token)
-      .then((res) => setCard(res.data))
-      .catch((err) => {
-        setError(
-          err.message || "This share link is invalid or has expired.",
-        );
-      })
-      .finally(() => setIsLoading(false));
-  }, [token]);
+function renderStars(score: number) {
+  return (
+    <span className="flex items-center gap-0.5" aria-label={`${score} out of 5 stars`}>
+      {Array.from({ length: 5 }, (_, i) => (
+        <Star
+          key={i}
+          aria-hidden="true"
+          className={`h-5 w-5 ${
+            i < Math.round(score)
+              ? "fill-primary text-primary"
+              : "text-muted-foreground"
+          }`}
+        />
+      ))}
+    </span>
+  );
+}
 
-  const renderStars = (score: number) => {
-    return Array.from({ length: 5 }, (_, i) => (
-      <Star
-        key={i}
-        className={`h-5 w-5 ${
-          i < Math.round(score)
-            ? "fill-primary text-primary"
-            : "text-muted-foreground"
-        }`}
-      />
-    ));
-  };
-
-  const renderScoreBar = (label: string, score: number) => (
+function ScoreBar({ label, score }: { label: string; score: number }) {
+  const pct = Math.round((score / 5) * 100);
+  return (
     <div className="flex items-center gap-3">
-      <span className="w-36 text-sm font-medium text-muted-foreground">
+      <span className="w-36 text-sm font-medium text-muted-foreground shrink-0">
         {label}
       </span>
-      <div className="flex-1 h-3 border-2 border-foreground bg-muted">
+      <div
+        className="flex-1 h-3 border-2 border-foreground bg-muted"
+        role="progressbar"
+        aria-label={`${label}: ${score} out of 5`}
+        aria-valuenow={score}
+        aria-valuemin={0}
+        aria-valuemax={5}
+      >
         <div
           className="h-full bg-primary transition-all"
-          style={{ width: `${(score / 5) * 100}%` }}
+          style={{ width: `${pct}%` }}
         />
       </div>
-      <span className="w-8 text-right font-mono font-bold">{score}</span>
+      <span className="w-8 text-right font-mono font-bold" aria-hidden="true">
+        {score}
+      </span>
     </div>
   );
+}
 
-  const formatDate = (dateStr: string) => {
-    return new Date(dateStr).toLocaleDateString("en-NG", {
-      year: "numeric",
-      month: "short",
-      day: "numeric",
-    });
-  };
+function formatDate(dateStr: string) {
+  return new Date(dateStr).toLocaleDateString("en-NG", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
 
-  if (isLoading) {
-    return (
-      <main className="min-h-screen bg-background flex items-center justify-center">
-        <Card className="border-3 border-foreground p-12 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] animate-pulse">
-          <div className="h-40 w-80 bg-muted rounded" />
-        </Card>
-      </main>
-    );
-  }
-
-  if (error || !card) {
-    return (
-      <main className="min-h-screen bg-background flex items-center justify-center">
-        <Card className="border-3 border-foreground p-12 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] text-center max-w-md">
-          <Shield className="mx-auto h-16 w-16 text-muted-foreground" />
-          <h2 className="mt-4 font-mono text-xl font-bold">
-            Link Unavailable
-          </h2>
-          <p className="mt-2 text-muted-foreground">
-            {error || "This share link is invalid or has expired."}
-          </p>
-          <Link href="/">
-            <Button className="mt-6 border-3 border-foreground bg-primary font-bold shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
-              <Home className="mr-2 h-4 w-4" />
-              Go Home
-            </Button>
-          </Link>
-        </Card>
-      </main>
-    );
-  }
+function SuccessPage({ card }: { card: PublicRatingCard }) {
+  const hasRatings = card.ratings.length > 0;
 
   return (
     <main className="min-h-screen bg-background">
-      {/* Header */}
       <section className="border-b-3 border-foreground bg-muted py-8">
         <div className="container mx-auto px-4">
           <div className="flex items-center gap-2 text-sm text-muted-foreground mb-2">
-            <Shield className="h-4 w-4" />
+            <Shield className="h-4 w-4" aria-hidden="true" />
             <span>Verified Tenant Rating Card</span>
           </div>
           <h1 className="font-mono text-2xl font-black md:text-3xl">
             Tenant <span className="text-primary">Reputation</span>
           </h1>
           <p className="text-muted-foreground">
-            Shared via Shelterflex — {card.totalRatings} landlord rating
+            Shared via Shelterflex —{" "}
+            {card.totalRatings} landlord rating
             {card.totalRatings !== 1 ? "s" : ""}
           </p>
         </div>
@@ -124,92 +189,98 @@ export default function SharedRatingCardPage() {
           {/* Composite Score */}
           <Card className="border-3 border-foreground p-8 shadow-[8px_8px_0px_0px_rgba(26,26,26,1)] mb-8">
             <div className="text-center">
-              <p className="text-sm text-muted-foreground mb-2">
-                Overall Rating
-              </p>
-              <div className="flex items-center justify-center gap-1 mb-3">
+              <p className="text-sm text-muted-foreground mb-2">Overall Rating</p>
+              <div className="flex justify-center mb-3">
                 {renderStars(card.compositeScore)}
               </div>
-              <p className="text-6xl font-mono font-black text-primary">
+              <p
+                className="text-6xl font-mono font-black text-primary"
+                aria-label={`Overall score: ${card.compositeScore} out of 5`}
+              >
                 {card.compositeScore}
               </p>
-              <p className="text-muted-foreground mt-1">out of 5.0</p>
+              <p className="text-muted-foreground mt-1" aria-hidden="true">
+                out of 5.0
+              </p>
             </div>
           </Card>
 
           {/* Score Breakdown */}
           <Card className="border-3 border-foreground p-6 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] mb-8">
-            <h3 className="mb-4 font-bold">Score Breakdown</h3>
+            <h2 className="mb-4 font-bold">Score Breakdown</h2>
             <div className="space-y-4">
-              {renderScoreBar("Payment History", card.paymentScore)}
-              {renderScoreBar("Property Care", card.propertyCareScore)}
-              {renderScoreBar("Communication", card.communicationScore)}
+              <ScoreBar label="Payment History" score={card.paymentScore} />
+              <ScoreBar label="Property Care" score={card.propertyCareScore} />
+              <ScoreBar label="Communication" score={card.communicationScore} />
             </div>
           </Card>
 
-          {/* Individual Ratings */}
+          {/* Individual Ratings or Empty State */}
           <Card className="border-3 border-foreground p-6 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
-            <h3 className="mb-4 font-bold">Rating History</h3>
-            <div className="space-y-4">
-              {card.ratings.map((rating, index) => (
-                <div
-                  key={index}
-                  className="border-2 border-foreground p-4"
-                >
-                  <div className="flex items-center justify-between mb-3">
-                    <div className="flex items-center gap-2">
-                      {renderStars(
-                        (rating.paymentScore +
-                          rating.propertyCareScore +
-                          rating.communicationScore) /
-                          3,
+            <h2 className="mb-4 font-bold">Rating History</h2>
+            {hasRatings ? (
+              <ol className="space-y-4 list-none">
+                {card.ratings.map((rating, index) => {
+                  const avg =
+                    (rating.paymentScore +
+                      rating.propertyCareScore +
+                      rating.communicationScore) /
+                    3;
+                  return (
+                    <li key={index} className="border-2 border-foreground p-4">
+                      <div className="flex flex-wrap items-center justify-between gap-2 mb-3">
+                        {renderStars(avg)}
+                        <time
+                          dateTime={rating.createdAt}
+                          className="text-sm text-muted-foreground"
+                        >
+                          {formatDate(rating.createdAt)}
+                        </time>
+                      </div>
+                      <div className="grid grid-cols-3 gap-4 mb-3">
+                        <div>
+                          <p className="text-xs text-muted-foreground">Payment</p>
+                          <p className="font-mono font-bold">{rating.paymentScore}/5</p>
+                        </div>
+                        <div>
+                          <p className="text-xs text-muted-foreground">Property Care</p>
+                          <p className="font-mono font-bold">{rating.propertyCareScore}/5</p>
+                        </div>
+                        <div>
+                          <p className="text-xs text-muted-foreground">Communication</p>
+                          <p className="font-mono font-bold">{rating.communicationScore}/5</p>
+                        </div>
+                      </div>
+                      {rating.comment && (
+                        <blockquote className="text-sm text-muted-foreground italic border-l-2 border-muted pl-3">
+                          {rating.comment}
+                        </blockquote>
                       )}
-                    </div>
-                    <span className="text-sm text-muted-foreground">
-                      {formatDate(rating.createdAt)}
-                    </span>
-                  </div>
-
-                  <div className="grid grid-cols-3 gap-4 mb-3">
-                    <div>
-                      <p className="text-xs text-muted-foreground">Payment</p>
-                      <p className="font-mono font-bold">
-                        {rating.paymentScore}/5
-                      </p>
-                    </div>
-                    <div>
-                      <p className="text-xs text-muted-foreground">
-                        Property Care
-                      </p>
-                      <p className="font-mono font-bold">
-                        {rating.propertyCareScore}/5
-                      </p>
-                    </div>
-                    <div>
-                      <p className="text-xs text-muted-foreground">
-                        Communication
-                      </p>
-                      <p className="font-mono font-bold">
-                        {rating.communicationScore}/5
-                      </p>
-                    </div>
-                  </div>
-
-                  {rating.comment && (
-                    <p className="text-sm text-muted-foreground italic">
-                      &quot;{rating.comment}&quot;
-                    </p>
-                  )}
-                </div>
-              ))}
-            </div>
+                    </li>
+                  );
+                })}
+              </ol>
+            ) : (
+              <Empty className="border-0 py-8">
+                <EmptyHeader>
+                  <EmptyMedia variant="icon">
+                    <Star aria-hidden="true" />
+                  </EmptyMedia>
+                  <EmptyTitle>No ratings yet</EmptyTitle>
+                  <EmptyDescription>
+                    This tenant hasn&apos;t received any landlord ratings yet.
+                    Their overall score will appear once a landlord submits a
+                    review.
+                  </EmptyDescription>
+                </EmptyHeader>
+              </Empty>
+            )}
           </Card>
 
-          {/* Footer */}
           <div className="mt-8 text-center text-sm text-muted-foreground">
             <p>
               Powered by{" "}
-              <Link href="/" className="font-bold text-primary underline">
+              <Link href="/" className="font-bold text-primary underline underline-offset-4">
                 Shelterflex
               </Link>
             </p>
@@ -218,4 +289,40 @@ export default function SharedRatingCardPage() {
       </section>
     </main>
   );
+}
+
+export default function SharedRatingCardPage() {
+  const params = useParams();
+  const token = params.token as string;
+  const [state, setState] = useState<PageState>({ status: "loading" });
+
+  useEffect(() => {
+    if (!token) {
+      setState({ status: "expired" });
+      return;
+    }
+
+    getSharedRatingCard(token)
+      .then((res) => {
+        setState({ status: "success", card: res.data });
+      })
+      .catch((err: unknown) => {
+        if (err instanceof ApiError) {
+          if (err.status === 429) {
+            setState({ status: "rate-limited" });
+            return;
+          }
+          if (err.status === 404 || err.status === 410) {
+            setState({ status: "expired" });
+            return;
+          }
+        }
+        setState({ status: "expired" });
+      });
+  }, [token]);
+
+  if (state.status === "loading") return <LoadingSkeleton />;
+  if (state.status === "rate-limited") return <ExpiredState rateLimited />;
+  if (state.status === "expired") return <ExpiredState />;
+  return <SuccessPage card={state.card} />;
 }


### PR DESCRIPTION

  feat: robust public states for tenant rating card (#1087)
  
  The public rating card page (/rating-card/[token]) is often a landlord's first impression of
  the platform. Previously it showed a blank screen or raw error on invalid/expired tokens —
  exactly the wrong experience for a trust-building surface.
  
  Changes
  
  - Loading — skeleton shimmer matching the page layout, aria-busy="true" while fetching
  - Success — existing card view, refactored with semantic headings (h1/h2)
  - Empty — Empty primitive inside "Rating History" when ratings.length === 0, with an
  explanatory message
  - Expired / Invalid — friendly copy for 404/410: "ask the tenant to generate a new link";
  Shield icon
  - Rate-limited — distinct state for 429: Clock icon + Alert with "wait a minute and try again";
  never shown as a raw error
  
  Accessibility
  
  - Semantic <h1>/<h2> headings (was bare <h3> with no page-level heading)
  - role="progressbar" + aria-valuenow/min/max on score bars
  - aria-label on star groups ("4 out of 5 stars") and score numbers
  - aria-hidden on decorative icons
  - <time dateTime> on rating dates
  - <blockquote> for landlord comments
  
  OpenGraph / link previews
  
  - Server layout.tsx adds og:title, og:description, and Twitter card meta — so sharing the link
  in WhatsApp/Slack/email renders a proper preview instead of a bare URL
  
  Out of scope — rating aggregation logic, authenticated management views.
closes #1171
