### PR TITLE
Centralize frontend currency formatting

### DIFF
--- a/frontend/app/dashboard/tenant/payments/page.tsx
+++ b/frontend/app/dashboard/tenant/payments/page.tsx
@@ -23,6 +23,7 @@ import { showErrorToast, showSuccessToast } from "@/lib/toast"
 import { usePaymentHistory } from "@/hooks/usePaymentHistory"
 import { PaymentTimeline } from "@/components/payment/PaymentTimeline"
 import { UpcomingScheduleTable } from "@/components/payment/UpcomingScheduleTable"
+import { formatNgn } from "@/lib/currency"
 
 type ActiveTab = "schedule" | "history"
 
@@ -47,13 +48,6 @@ export default function TenantPaymentsPage() {
     dealId: selectedDeal,
     limit: 10,
   })
-
-  const formatCurrency = (amount: number) =>
-    new Intl.NumberFormat("en-NG", {
-      style: "currency",
-      currency: "NGN",
-      minimumFractionDigits: 0,
-    }).format(amount)
 
   const loadData = async () => {
     setIsLoading(true)
@@ -189,7 +183,7 @@ export default function TenantPaymentsPage() {
                 </div>
                 <div>
                   <p className="text-sm text-muted-foreground">Wallet Balance</p>
-                  <p className="text-xl font-bold">{formatCurrency(walletBalance)}</p>
+                  <p className="text-xl font-bold">{formatNgn(walletBalance)}</p>
                 </div>
               </div>
             </Card>
@@ -204,7 +198,7 @@ export default function TenantPaymentsPage() {
                 <div>
                   <p className="text-sm text-muted-foreground">Next Payment</p>
                   <p className="text-xl font-bold">
-                    {nextPayment ? formatCurrency(nextPayment.amount) : "N/A"}
+                    {nextPayment ? formatNgn(nextPayment.amount) : "N/A"}
                   </p>
                 </div>
               </div>
@@ -299,7 +293,7 @@ export default function TenantPaymentsPage() {
                 {nextPayment ? (
                   <div className="rounded-3xl border-2 border-foreground/20 bg-muted p-4">
                     <p className="text-sm text-muted-foreground">Next due installment</p>
-                    <p className="text-2xl font-bold">{formatCurrency(nextPayment.amount)}</p>
+                    <p className="text-2xl font-bold">{formatNgn(nextPayment.amount)}</p>
                     <p className="text-sm text-muted-foreground">Due {nextPayment.dueDate}</p>
                   </div>
                 ) : null}

--- a/frontend/components/calculator/EquityProgressChart.tsx
+++ b/frontend/components/calculator/EquityProgressChart.tsx
@@ -11,6 +11,7 @@ import {
   Legend,
 } from "recharts";
 import type { MonthlyEquityPoint } from "@/lib/rentToOwnCalc";
+import { formatCompactNgn, formatNgn } from "@/lib/currency";
 
 interface Props {
   data: MonthlyEquityPoint[];
@@ -18,18 +19,7 @@ interface Props {
 }
 
 function formatShort(val: number): string {
-  if (val >= 1_000_000) return `₦${(val / 1_000_000).toFixed(1)}M`;
-  if (val >= 1_000) return `₦${(val / 1_000).toFixed(0)}K`;
-  return `₦${val}`;
-}
-
-function formatFull(val: number): string {
-  return new Intl.NumberFormat("en-NG", {
-    style: "currency",
-    currency: "NGN",
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 0,
-  }).format(val);
+  return formatCompactNgn(val);
 }
 
 const CustomTooltip = ({ active, payload, label }: any) => {
@@ -48,14 +38,14 @@ const CustomTooltip = ({ active, payload, label }: any) => {
           <span className="w-2.5 h-2.5 bg-primary border border-foreground inline-block" />
           Equity owned:
         </span>
-        <span className="font-bold text-primary">{formatFull(equity)}</span>
+        <span className="font-bold text-primary">{formatNgn(equity)}</span>
       </p>
       <p className="flex justify-between gap-4">
         <span className="flex items-center gap-1.5">
           <span className="w-2.5 h-2.5 bg-destructive border border-foreground inline-block" />
           Rent cost (no equity):
         </span>
-        <span className="font-bold">{formatFull(rentEquivalent)}</span>
+        <span className="font-bold">{formatNgn(rentEquivalent)}</span>
       </p>
     </div>
   );
@@ -146,7 +136,7 @@ export default function EquityProgressChart({ data, propertyPrice }: Props) {
 
       {/* Property value reference line label */}
       <p className="mt-2 text-right font-mono text-[10px] text-muted-foreground">
-        Property value: {formatFull(propertyPrice)}
+        Property value: {formatNgn(propertyPrice)}
       </p>
     </div>
   );

--- a/frontend/components/calculator/RentToOwnCalculator.tsx
+++ b/frontend/components/calculator/RentToOwnCalculator.tsx
@@ -8,6 +8,7 @@ import {
   ANNUAL_INTEREST_RATE,
   ESTIMATED_RENTAL_YIELD,
 } from "@/lib/rentToOwnCalc";
+import { formatCompactNgn, formatNgn } from "@/lib/currency";
 import dynamic from "next/dynamic";
 
 const EquityProgressChart = dynamic(() => import("./EquityProgressChart"), {
@@ -21,15 +22,6 @@ const EquityProgressChart = dynamic(() => import("./EquityProgressChart"), {
   ),
 });
 import RentToOwnPlanCard from "./RentToOwnPlanCard";
-
-function formatFull(val: number): string {
-  return new Intl.NumberFormat("en-NG", {
-    style: "currency",
-    currency: "NGN",
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 0,
-  }).format(val);
-}
 
 export default function RentToOwnCalculator() {
   const [propertyPrice, setPropertyPrice] = useState(15_000_000);
@@ -79,7 +71,7 @@ export default function RentToOwnCalculator() {
                   Property Price
                 </p>
                 <span className="border-2 border-foreground bg-muted px-2 py-1 font-mono text-base font-black sm:px-3 sm:text-lg">
-                  {formatFull(propertyPrice)}
+                  {formatNgn(propertyPrice)}
                 </span>
               </div>
               <Slider
@@ -91,8 +83,8 @@ export default function RentToOwnCalculator() {
                 className="py-4"
               />
               <div className="flex justify-between text-xs text-muted-foreground">
-                <span>₦2M</span>
-                <span>₦200M</span>
+                <span>{formatCompactNgn(2_000_000)}</span>
+                <span>{formatCompactNgn(200_000_000)}</span>
               </div>
             </div>
 
@@ -103,7 +95,7 @@ export default function RentToOwnCalculator() {
                   Deposit Percentage
                 </p>
                 <span className="border-2 border-foreground bg-muted px-2 py-1 font-mono text-base font-black sm:px-3 sm:text-lg">
-                  {depositPct}% — {formatFull(propertyPrice * depositPct / 100)}
+                  {depositPct}% - {formatNgn(propertyPrice * depositPct / 100)}
                 </span>
               </div>
               <Slider
@@ -127,7 +119,7 @@ export default function RentToOwnCalculator() {
                   Monthly Budget
                 </p>
                 <span className="border-2 border-foreground bg-muted px-2 py-1 font-mono text-base font-black sm:px-3 sm:text-lg">
-                  {formatFull(monthlyBudget)}
+                  {formatNgn(monthlyBudget)}
                 </span>
               </div>
               <Slider
@@ -139,8 +131,8 @@ export default function RentToOwnCalculator() {
                 className="py-4"
               />
               <div className="flex justify-between text-xs text-muted-foreground">
-                <span>₦50K</span>
-                <span>₦5M</span>
+                <span>{formatCompactNgn(50_000)}</span>
+                <span>{formatCompactNgn(5_000_000)}</span>
               </div>
             </div>
 
@@ -196,11 +188,11 @@ export default function RentToOwnCalculator() {
               <AlertCircle className="h-5 w-5 shrink-0 text-destructive mt-0.5" />
               <div>
                 <p className="font-mono text-sm font-bold text-destructive">
-                  Minimum required: {formatFull(result.requiredMonthlyPayment)}/mo
+                  Minimum required: {formatNgn(result.requiredMonthlyPayment)}/mo
                 </p>
                 <p className="text-xs text-muted-foreground mt-1">
-                  Your ₦{(monthlyBudget / 1000).toFixed(0)}K budget is{" "}
-                  {formatFull(result.requiredMonthlyPayment - monthlyBudget)} short.
+                  Your {formatCompactNgn(monthlyBudget)} budget is{" "}
+                  {formatNgn(result.requiredMonthlyPayment - monthlyBudget)} short.
                   Try raising your budget, increasing your deposit, or extending
                   the ownership timeline.
                 </p>

--- a/frontend/components/calculator/RentToOwnPlanCard.tsx
+++ b/frontend/components/calculator/RentToOwnPlanCard.tsx
@@ -2,19 +2,11 @@
 
 import { TrendingUp, Home, CalendarClock, AlertCircle } from "lucide-react";
 import type { RentToOwnResult } from "@/lib/rentToOwnCalc";
+import { formatNgn } from "@/lib/currency";
 
 interface Props {
   result: RentToOwnResult;
   propertyPrice: number;
-}
-
-function formatFull(val: number): string {
-  return new Intl.NumberFormat("en-NG", {
-    style: "currency",
-    currency: "NGN",
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 0,
-  }).format(val);
 }
 
 export default function RentToOwnPlanCard({ result, propertyPrice }: Props) {
@@ -66,7 +58,7 @@ export default function RentToOwnPlanCard({ result, propertyPrice }: Props) {
           <div className="border-3 border-foreground bg-primary/10 p-4">
             <p className="text-xs text-muted-foreground">Total Monthly Payment</p>
             <p className="font-mono text-3xl md:text-4xl font-black text-primary">
-              {formatFull(requiredMonthlyPayment)}
+              {formatNgn(requiredMonthlyPayment)}
             </p>
             <p className="text-xs text-muted-foreground mt-1">
               for {totalMonths} months ({totalMonths / 12} years)
@@ -79,7 +71,7 @@ export default function RentToOwnPlanCard({ result, propertyPrice }: Props) {
                 Estimated rent component
               </span>
               <span className="font-mono font-bold">
-                {formatFull(monthlyRentEquivalent)}
+                {formatNgn(monthlyRentEquivalent)}
               </span>
             </div>
             <div className="flex justify-between items-center border-b border-dashed border-foreground/20 pb-2">
@@ -92,21 +84,21 @@ export default function RentToOwnPlanCard({ result, propertyPrice }: Props) {
                 }`}
               >
                 {isEquityPositive ? "+" : ""}
-                {formatFull(equityPortion)}
+                {formatNgn(equityPortion)}
               </span>
             </div>
             <div className="flex justify-between items-center border-b border-dashed border-foreground/20 pb-2">
               <span className="text-sm text-muted-foreground">
                 Initial deposit (upfront)
               </span>
-              <span className="font-mono font-bold">{formatFull(deposit)}</span>
+              <span className="font-mono font-bold">{formatNgn(deposit)}</span>
             </div>
             <div className="flex justify-between items-center border-b border-dashed border-foreground/20 pb-2">
               <span className="text-sm text-muted-foreground">
                 Total interest paid
               </span>
               <span className="font-mono font-bold text-muted-foreground">
-                {formatFull(totalInterest)}
+                {formatNgn(totalInterest)}
               </span>
             </div>
           </div>
@@ -123,7 +115,7 @@ export default function RentToOwnPlanCard({ result, propertyPrice }: Props) {
               <p className="text-xs text-muted-foreground mb-1">
                 Rent-to-Own total cost
               </p>
-              <p className="font-mono text-base font-black">{formatFull(totalCostRTO)}</p>
+              <p className="font-mono text-base font-black">{formatNgn(totalCostRTO)}</p>
               <p className="text-xs text-secondary font-bold mt-0.5">
                 You own the property
               </p>
@@ -132,7 +124,7 @@ export default function RentToOwnPlanCard({ result, propertyPrice }: Props) {
               <p className="text-xs text-muted-foreground mb-1">
                 Standard rent total cost
               </p>
-              <p className="font-mono text-base font-black">{formatFull(totalCostRent)}</p>
+              <p className="font-mono text-base font-black">{formatNgn(totalCostRent)}</p>
               <p className="text-xs text-destructive font-bold mt-0.5">
                 Nothing to show for it
               </p>
@@ -142,7 +134,7 @@ export default function RentToOwnPlanCard({ result, propertyPrice }: Props) {
             <span className="font-mono text-xs font-bold">Net advantage (incl. property value)</span>
             <span className="font-mono font-black text-secondary text-sm">
               {netAdvantage > 0 ? "+" : ""}
-              {formatFull(netAdvantage)}
+              {formatNgn(netAdvantage)}
             </span>
           </div>
         </div>
@@ -168,7 +160,7 @@ export default function RentToOwnPlanCard({ result, propertyPrice }: Props) {
               </p>
               <p className="text-xs text-muted-foreground mt-0.5">
                 Your monthly budget is below the required payment of{" "}
-                <strong>{formatFull(requiredMonthlyPayment)}</strong> to reach
+                <strong>{formatNgn(requiredMonthlyPayment)}</strong> to reach
                 ownership in {totalMonths / 12} years. Increase your budget or
                 extend the ownership timeline.
               </p>

--- a/frontend/components/payment/PaymentTimelineNode.tsx
+++ b/frontend/components/payment/PaymentTimelineNode.tsx
@@ -2,6 +2,7 @@
 
 import { ArrowRight, Download, CircleDot } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { formatNgn } from "@/lib/currency";
 
 export interface PaymentTimelineNodeProps {
   date: string;
@@ -38,7 +39,7 @@ export function PaymentTimelineNode({
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div>
             <p className="text-sm uppercase tracking-[0.2em] text-muted-foreground">{date}</p>
-            <p className="mt-1 text-xl font-bold">₦{amount.toLocaleString("en-NG")}</p>
+            <p className="mt-1 text-xl font-bold">{formatNgn(amount)}</p>
           </div>
           <span className={`rounded-full border px-3 py-1 text-xs font-bold ${statusStyles[status]}`}>
             {status}

--- a/frontend/components/payment/PayoutBreakdown.test.tsx
+++ b/frontend/components/payment/PayoutBreakdown.test.tsx
@@ -5,6 +5,7 @@ import type { PayoutBreakdown as PayoutBreakdownType } from "@/lib/paymentApi";
 
 // Mock next-intl
 vi.mock("next-intl", () => ({
+  useLocale: () => "en-NG",
   useTranslations: (namespace: string) => {
     // Simple mock that returns the key or a mapped value
     const messages: Record<string, Record<string, string>> = {

--- a/frontend/components/payment/PayoutBreakdown.tsx
+++ b/frontend/components/payment/PayoutBreakdown.tsx
@@ -4,32 +4,28 @@ import { CheckCircle2 } from "lucide-react";
 import { Separator } from "@/components/ui/separator";
 import { cn } from "@/lib/utils";
 import type { PayoutBreakdown as PayoutBreakdownType } from "@/lib/paymentApi";
-import { useTranslations } from "next-intl";
-
-function formatNgn(amount: number) {
-  return new Intl.NumberFormat("en-NG", {
-    style: "currency",
-    currency: "NGN",
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  }).format(amount);
-}
+import { formatMoney, type SupportedCurrency } from "@/lib/currency";
+import { useLocale, useTranslations } from "next-intl";
 
 interface LineItemProps {
   label: string;
   amount: number;
   sublabel?: string;
   bold?: boolean;
+  currency: SupportedCurrency;
+  locale: string;
 }
 
-function LineItem({ label, amount, sublabel, bold }: LineItemProps) {
+function LineItem({ label, amount, sublabel, bold, currency, locale }: LineItemProps) {
   return (
     <div className={cn("flex items-start justify-between gap-4 py-2", bold && "font-bold")}>
       <div>
         <p className={cn("text-sm", bold ? "font-bold" : "text-muted-foreground")}>{label}</p>
         {sublabel && <p className="text-xs text-muted-foreground">{sublabel}</p>}
       </div>
-      <span className={cn("font-mono text-sm shrink-0", bold && "text-base")}>{formatNgn(amount)}</span>
+      <span className={cn("font-mono text-sm shrink-0", bold && "text-base")}>
+        {formatMoney(amount, currency, { locale })}
+      </span>
     </div>
   );
 }
@@ -47,7 +43,9 @@ interface PayoutBreakdownProps {
  */
 export function PayoutBreakdown({ breakdown, confirmed, className }: PayoutBreakdownProps) {
   const t = useTranslations("payment");
+  const locale = useLocale();
   const { totalAmount, platformShare, reporterShare, landlordAmount } = breakdown;
+  const currency: SupportedCurrency = breakdown.currency === "USDC" ? "USDC" : "NGN";
 
   return (
     <div
@@ -71,6 +69,8 @@ export function PayoutBreakdown({ breakdown, confirmed, className }: PayoutBreak
         label={t("platformFee")}
         sublabel={t("platformFeeSubLabel")}
         amount={platformShare}
+        currency={currency}
+        locale={locale}
       />
 
       {reporterShare !== null ? (
@@ -78,6 +78,8 @@ export function PayoutBreakdown({ breakdown, confirmed, className }: PayoutBreak
           label={t("reporterReward")}
           sublabel={t("reporterRewardSubLabel")}
           amount={reporterShare}
+          currency={currency}
+          locale={locale}
         />
       ) : (
         <div className="flex items-start justify-between gap-4 py-2">
@@ -89,11 +91,11 @@ export function PayoutBreakdown({ breakdown, confirmed, className }: PayoutBreak
         </div>
       )}
 
-      <LineItem label={t("landlordPayout")} amount={landlordAmount} />
+      <LineItem label={t("landlordPayout")} amount={landlordAmount} currency={currency} locale={locale} />
 
       <Separator className="my-3 border-foreground/20" />
 
-      <LineItem label={t("totalCharged")} amount={totalAmount} bold />
+      <LineItem label={t("totalCharged")} amount={totalAmount} bold currency={currency} locale={locale} />
     </div>
   );
 }

--- a/frontend/components/payment/UpcomingScheduleTable.a11y.test.tsx
+++ b/frontend/components/payment/UpcomingScheduleTable.a11y.test.tsx
@@ -2,6 +2,10 @@ import { render, screen } from "@testing-library/react"
 import { describe, it, expect, vi } from "vitest"
 import { UpcomingScheduleTable } from "./UpcomingScheduleTable"
 
+vi.mock("next-intl", () => ({
+  useLocale: () => "en-NG",
+}))
+
 const mockSchedule = [
   {
     period: 1,

--- a/frontend/components/payment/UpcomingScheduleTable.tsx
+++ b/frontend/components/payment/UpcomingScheduleTable.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
+import { formatNgn } from "@/lib/currency";
 import { AlertCircle, CheckCircle2, Loader2, XCircle } from "lucide-react";
+import { useLocale } from "next-intl";
 
 export interface ScheduleRow {
   period: number;
@@ -39,6 +41,8 @@ export function UpcomingScheduleTable({
   onPayNow,
   optimisticStatuses = {},
 }: UpcomingScheduleTableProps) {
+  const locale = useLocale();
+
   return (
     <div className="overflow-hidden rounded-3xl border-2 border-foreground/20 bg-card shadow-[4px_4px_0_rgba(26,26,26,0.05)]">
       <table
@@ -60,6 +64,8 @@ export function UpcomingScheduleTable({
             const effectiveStatus = optimistic ?? row.status;
             const isProcessing = optimistic === "pending";
             const isFailed = optimistic === "failed";
+            const formattedAmount = formatNgn(row.amount, locale);
+
             return (
               <tr
                 key={`${row.period}-${row.month}`}
@@ -73,7 +79,7 @@ export function UpcomingScheduleTable({
                 </td>
                 <td className="px-6 py-4">{row.dueDate}</td>
                 <td className="px-6 py-4 font-mono font-bold">
-                  ₦{row.amount.toLocaleString("en-NG")}
+                  {formattedAmount}
                 </td>
                 <td className="px-6 py-4">
                   <span
@@ -98,7 +104,7 @@ export function UpcomingScheduleTable({
                   {row.isNextDue && !optimistic ? (
                     <Button
                       onClick={onPayNow}
-                      aria-label={`Pay installment ${row.period} — ₦${row.amount.toLocaleString("en-NG")}`}
+                      aria-label={`Pay installment ${row.period} - ${formattedAmount}`}
                       className="border-2 border-foreground bg-primary font-bold shadow-[4px_4px_0_rgba(26,26,26,1)]"
                     >
                       Pay Now

--- a/frontend/components/properties/PropertyPriceBreakdown.tsx
+++ b/frontend/components/properties/PropertyPriceBreakdown.tsx
@@ -7,6 +7,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { formatNgn } from "@/lib/currency";
 
 interface PriceBreakdownProps {
   outrightPriceNgn?: number | null;
@@ -14,14 +15,6 @@ interface PriceBreakdownProps {
   annualRentNgn: number;
   depositPercentage?: number;
   paymentMonths?: number;
-}
-
-function formatNgn(amount: number) {
-  return new Intl.NumberFormat("en-NG", {
-    style: "currency",
-    currency: "NGN",
-    minimumFractionDigits: 0,
-  }).format(amount);
 }
 
 export default function PropertyPriceBreakdown({

--- a/frontend/components/property-card.tsx
+++ b/frontend/components/property-card.tsx
@@ -28,6 +28,7 @@ import { cn } from "@/lib/utils";
 import { LandlordVerificationBadge } from "@/components/LandlordVerificationBadge";
 import { setListingSaved } from "@/lib/savedPropertiesApi";
 import { showErrorToast } from "@/lib/toast";
+import { formatNgn } from "@/lib/currency";
 
 export type PropertyCardPaymentType = "outright" | "installment";
 
@@ -67,14 +68,6 @@ export interface PropertyCardProps {
 }
 
 const DEFAULT_PLAN_MONTHS = 12;
-
-function formatNgn(amount: number) {
-  return new Intl.NumberFormat("en-NG", {
-    style: "currency",
-    currency: "NGN",
-    minimumFractionDigits: 0,
-  }).format(amount);
-}
 
 function formatLocation(property: PropertyCardData) {
   const parts = [property.area, property.city].filter(Boolean);

--- a/frontend/contexts/CurrencyContext.tsx
+++ b/frontend/contexts/CurrencyContext.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react'
+import { useLocale } from 'next-intl'
 import usePreferencesStore from '@/store/usePreferencesStore'
 import { formatByPreference, formatDual, type DisplayCurrency } from '@/lib/currency'
 
@@ -28,6 +29,7 @@ async function persistDisplayCurrency(currency: DisplayCurrency): Promise<void> 
 }
 
 export function CurrencyProvider({ children }: { children: React.ReactNode }) {
+  const locale = useLocale()
   const currency = usePreferencesStore((s) => s.currency) as DisplayCurrency
   const setPreference = usePreferencesStore((s) => s.setPreference)
   const [, setTick] = useState(0)
@@ -65,10 +67,10 @@ export function CurrencyProvider({ children }: { children: React.ReactNode }) {
     () => ({
       displayCurrency: currency === 'USDC' ? 'USDC' : 'NGN',
       setDisplayCurrency,
-      formatAmount: (ngn, usdc) => formatByPreference(ngn, usdc, currency === 'USDC' ? 'USDC' : 'NGN'),
-      formatDual,
+      formatAmount: (ngn, usdc) => formatByPreference(ngn, usdc, currency === 'USDC' ? 'USDC' : 'NGN', locale),
+      formatDual: (ngn, usdc) => formatDual(ngn, usdc, locale),
     }),
-    [currency, setDisplayCurrency],
+    [currency, locale, setDisplayCurrency],
   )
 
   return <CurrencyContext.Provider value={value}>{children}</CurrencyContext.Provider>

--- a/frontend/lib/__tests__/currency.test.ts
+++ b/frontend/lib/__tests__/currency.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { formatMoney, formatNgn, formatUsdc, roundCurrencyAmount } from "@/lib/currency";
+
+describe("currency formatting", () => {
+  it("rounds NGN half-up to two decimals at positive boundaries", () => {
+    expect(roundCurrencyAmount(156_799.504, "NGN")).toBe(156_799.5);
+    expect(roundCurrencyAmount(156_799.505, "NGN")).toBe(156_799.51);
+    expect(formatNgn(156_799.505, "en-NG")).toBe("₦156,799.51");
+  });
+
+  it("rounds negative ties away from zero", () => {
+    expect(roundCurrencyAmount(-1.005, "NGN")).toBe(-1.01);
+    expect(formatNgn(-1.005, "en-NG")).toBe("-₦1.01");
+  });
+
+  it("formats zero and invalid amounts as zero", () => {
+    expect(formatNgn(0, "en-NG")).toBe("₦0.00");
+    expect(formatUsdc("not-a-number", "en-US")).toBe("0.00 USDC");
+  });
+
+  it("formats large values with locale-aware grouping", () => {
+    expect(formatNgn(1_234_567_890.125, "en-NG")).toBe("₦1,234,567,890.13");
+  });
+
+  it("keeps USDC precision consistent", () => {
+    expect(formatMoney(42.345, "USDC", { locale: "en-US" })).toBe("42.35 USDC");
+  });
+
+  it("uses locale-specific symbol placement through Intl", () => {
+    expect(formatNgn(1234.5, "fr-FR")).toMatch(/1[\s\u202f]234,50/);
+    expect(formatNgn(1234.5, "fr-FR")).toContain("NGN");
+  });
+});

--- a/frontend/lib/currency.ts
+++ b/frontend/lib/currency.ts
@@ -1,25 +1,113 @@
-export type DisplayCurrency = 'NGN' | 'USDC'
+export type DisplayCurrency = "NGN" | "USDC";
 
-export function formatNgn(amount: number | string): string {
-  const n = typeof amount === 'string' ? Number.parseFloat(amount) : amount
-  if (!Number.isFinite(n)) return '₦0.00'
-  return `₦${n.toLocaleString('en-NG', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+export type SupportedCurrency = DisplayCurrency;
+
+interface CurrencyPolicy {
+  locale: string;
+  fractionDigits: number;
+  style: "currency" | "decimal";
+  currencyDisplay?: Intl.NumberFormatOptions["currencyDisplay"];
 }
 
-export function formatUsdc(amount: number | string): string {
-  const n = typeof amount === 'string' ? Number.parseFloat(amount) : amount
-  if (!Number.isFinite(n)) return '0.00 USDC'
-  return `${n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })} USDC`
+interface FormatMoneyOptions {
+  locale?: string;
 }
 
-export function formatDual(ngn: number | string, usdc: number | string): string {
-  return `${formatNgn(ngn)} · ${formatUsdc(usdc)}`
+const DEFAULT_LOCALE = "en-NG";
+
+export const CURRENCY_POLICIES: Record<SupportedCurrency, CurrencyPolicy> = {
+  NGN: {
+    locale: DEFAULT_LOCALE,
+    fractionDigits: 2,
+    style: "currency",
+    currencyDisplay: "symbol",
+  },
+  USDC: {
+    locale: "en-US",
+    fractionDigits: 2,
+    style: "decimal",
+  },
+};
+
+function toFiniteNumber(amount: number | string): number {
+  const value = typeof amount === "string" ? Number.parseFloat(amount) : amount;
+  return Number.isFinite(value) ? value : 0;
+}
+
+/**
+ * Shelterflex displays monetary values with commercial half-up rounding:
+ * ties at the currency precision round away from zero (1.005 -> 1.01,
+ * -1.005 -> -1.01). Keep transaction and receipt displays on this path.
+ */
+export function roundCurrencyAmount(
+  amount: number | string,
+  currency: SupportedCurrency,
+): number {
+  const value = toFiniteNumber(amount);
+  const digits = CURRENCY_POLICIES[currency].fractionDigits;
+  const factor = 10 ** digits;
+  const roundedMagnitude = Math.round((Math.abs(value) + Number.EPSILON) * factor);
+
+  return Math.sign(value) * (roundedMagnitude / factor);
+}
+
+export function formatMoney(
+  amount: number | string,
+  currency: SupportedCurrency,
+  options: FormatMoneyOptions = {},
+): string {
+  const policy = CURRENCY_POLICIES[currency];
+  const locale = options.locale ?? policy.locale;
+  const rounded = roundCurrencyAmount(amount, currency);
+  const formatterOptions: Intl.NumberFormatOptions = {
+    minimumFractionDigits: policy.fractionDigits,
+    maximumFractionDigits: policy.fractionDigits,
+  };
+
+  if (policy.style === "currency") {
+    formatterOptions.style = "currency";
+    formatterOptions.currency = currency;
+    formatterOptions.currencyDisplay = policy.currencyDisplay;
+  }
+
+  const formatted = new Intl.NumberFormat(locale, formatterOptions).format(rounded);
+
+  return currency === "USDC" ? `${formatted} USDC` : formatted;
+}
+
+export function formatNgn(amount: number | string, locale?: string): string {
+  return formatMoney(amount, "NGN", { locale });
+}
+
+export function formatCompactNgn(amount: number | string, locale = DEFAULT_LOCALE): string {
+  const rounded = roundCurrencyAmount(amount, "NGN");
+
+  return new Intl.NumberFormat(locale, {
+    style: "currency",
+    currency: "NGN",
+    currencyDisplay: "symbol",
+    notation: "compact",
+    maximumFractionDigits: 1,
+  }).format(rounded);
+}
+
+export function formatUsdc(amount: number | string, locale?: string): string {
+  return formatMoney(amount, "USDC", { locale });
+}
+
+export function formatDual(
+  ngn: number | string,
+  usdc: number | string,
+  locale?: string,
+): string {
+  return `${formatNgn(ngn, locale)} · ${formatUsdc(usdc, locale)}`;
 }
 
 export function formatByPreference(
   amountNgn: number | string,
   amountUsdc: number | string,
   preference: DisplayCurrency,
+  locale?: string,
 ): string {
-  return preference === 'USDC' ? formatUsdc(amountUsdc) : formatNgn(amountNgn)
+  return preference === "USDC" ? formatUsdc(amountUsdc, locale) : formatNgn(amountNgn, locale);
 }


### PR DESCRIPTION
Centralize frontend currency formatting and rounding
Description
This PR centralizes frontend money display through frontend/lib/currency.ts and migrates audited payment, calculator, and property-price surfaces away from ad-hoc Intl.NumberFormat, manual ₦ concatenation, and local formatter helpers.
What Changed
Added a shared currency formatter in frontend/lib/currency.ts
Supports NGN and USDC
Uses Intl.NumberFormat under the hood
Enforces currency precision in one place
Documents commercial half-up rounding, including negative tie behavior
Adds compact NGN formatting for chart/slider labels

Updated CurrencyContext to pass the active next-intl locale into formatter helpers.

Migrated audited dynamic money displays:
Tenant payments page
Upcoming payment schedule table
Payment timeline node
Full payment payout breakdown / receipt display
Rent-to-own calculator
Rent-to-own plan card
Equity progress chart
Property price breakdown
Property card price rows

Added formatter unit coverage:
Positive half-up rounding boundaries
Negative half-up rounding boundaries
Large values
Zero and invalid values
USDC precision
Locale-aware NGN placement

Transaction Reconciliation
The tenant payment flow now formats displayed schedule amounts, next-payment cards, payment timeline entries, and payout preview/receipt totals through the same shared formatter. The displayed amount remains derived from the same numeric value submitted to initiateQuickPay, avoiding UI rounding drift from local formatter differences.
Tests
npm.cmd test -- --run lib/__tests__/currency.test.ts components/payment/PayoutBreakdown.test.tsx components/payment/UpcomingScheduleTable.a11y.test.tsx
Result:
3 test files passed
18 tests passed
Notes
npm install was needed locally because node_modules was missing.
npm reported existing audit issues: 23 vulnerabilities. No audit fixes are included in this PR.

closes #1170 