### PR TITLE
Feat/accessible payment status and a11y fixes

### DIFF
--- a/frontend/app/report/loading.tsx
+++ b/frontend/app/report/loading.tsx
@@ -1,0 +1,52 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function ReportLoading() {
+  return (
+    <div
+      role="status"
+      aria-busy="true"
+      className="min-h-screen bg-background px-4 pb-16 pt-24 sm:px-6 lg:px-8"
+    >
+      <span className="sr-only">Loading the anonymous report form…</span>
+
+      <div className="mx-auto max-w-2xl space-y-6" aria-hidden="true">
+        {/* Heading + trust badge */}
+        <div className="space-y-3 text-center">
+          <Skeleton className="mx-auto h-8 w-64" />
+          <Skeleton className="mx-auto h-4 w-80" />
+          <Skeleton className="mx-auto h-7 w-44" />
+        </div>
+
+        {/* Form card */}
+        <div className="space-y-6 border-3 border-foreground bg-card p-6 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
+          {/* Report type select */}
+          <div className="space-y-2">
+            <Skeleton className="h-4 w-28" />
+            <Skeleton className="h-12 w-full" />
+          </div>
+
+          {/* Description textarea */}
+          <div className="space-y-2">
+            <Skeleton className="h-4 w-32" />
+            <Skeleton className="h-32 w-full" />
+          </div>
+
+          {/* Evidence URL */}
+          <div className="space-y-2">
+            <Skeleton className="h-4 w-36" />
+            <Skeleton className="h-12 w-full" />
+          </div>
+
+          {/* Optional contact email */}
+          <div className="space-y-2">
+            <Skeleton className="h-4 w-40" />
+            <Skeleton className="h-12 w-full" />
+          </div>
+
+          {/* Submit */}
+          <Skeleton className="h-12 w-full" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/staking/loading.tsx
+++ b/frontend/app/staking/loading.tsx
@@ -1,0 +1,61 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function StakingLoading() {
+  return (
+    <div
+      role="status"
+      aria-busy="true"
+      className="min-h-screen bg-background px-4 pb-16 pt-24 sm:px-6 lg:px-8"
+    >
+      <span className="sr-only">Loading staking…</span>
+
+      <div className="mx-auto max-w-4xl space-y-6" aria-hidden="true">
+        {/* Heading */}
+        <div className="space-y-2">
+          <Skeleton className="h-8 w-48" />
+          <Skeleton className="h-4 w-72" />
+        </div>
+
+        {/* Position summary cards */}
+        <div className="grid gap-4 sm:grid-cols-2">
+          {Array.from({ length: 2 }).map((_, i) => (
+            <div
+              key={i}
+              className="space-y-3 border-3 border-foreground bg-card p-6 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]"
+            >
+              <Skeleton className="h-4 w-28" />
+              <Skeleton className="h-9 w-40" />
+              <Skeleton className="h-4 w-32" />
+            </div>
+          ))}
+        </div>
+
+        {/* Stake form */}
+        <div className="space-y-4 border-3 border-foreground bg-card p-6 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
+          <Skeleton className="h-6 w-32" />
+          <div className="flex gap-2">
+            <Skeleton className="h-10 w-28" />
+            <Skeleton className="h-10 w-28" />
+            <Skeleton className="h-10 w-28" />
+          </div>
+          <Skeleton className="h-12 w-full" />
+          <Skeleton className="h-12 w-full" />
+        </div>
+
+        {/* History table */}
+        <div className="space-y-3 border-3 border-foreground bg-card p-6 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
+          <Skeleton className="h-6 w-36" />
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div
+              key={i}
+              className="flex items-center justify-between border-b-2 border-dashed border-foreground/10 pb-3"
+            >
+              <Skeleton className="h-4 w-40" />
+              <Skeleton className="h-5 w-20" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/wallet/loading.tsx
+++ b/frontend/app/wallet/loading.tsx
@@ -1,0 +1,62 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function WalletLoading() {
+  return (
+    <div
+      role="status"
+      aria-busy="true"
+      className="min-h-screen bg-background px-4 pb-16 pt-24 sm:px-6 lg:px-8"
+    >
+      <span className="sr-only">Loading your wallet…</span>
+
+      <div className="mx-auto max-w-5xl space-y-6" aria-hidden="true">
+        {/* Page heading + currency toggle */}
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div className="space-y-2">
+            <Skeleton className="h-8 w-40" />
+            <Skeleton className="h-4 w-56" />
+          </div>
+          <Skeleton className="h-10 w-48 border-3 border-foreground" />
+        </div>
+
+        {/* Balance + action cards */}
+        <div className="grid gap-4 md:grid-cols-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div
+              key={i}
+              className="space-y-4 border-3 border-foreground bg-card p-6 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]"
+            >
+              <Skeleton className="h-4 w-24" />
+              <Skeleton className="h-9 w-36" />
+              <Skeleton className="h-10 w-full" />
+            </div>
+          ))}
+        </div>
+
+        {/* Ledger filters */}
+        <div className="flex flex-wrap items-center gap-3">
+          <Skeleton className="h-9 w-28" />
+          <Skeleton className="h-9 w-28" />
+          <Skeleton className="h-9 w-28" />
+        </div>
+
+        {/* Ledger table */}
+        <div className="space-y-3 border-3 border-foreground bg-card p-6 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
+          <Skeleton className="h-6 w-40" />
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div
+              key={i}
+              className="flex items-center justify-between border-b-2 border-dashed border-foreground/10 pb-3"
+            >
+              <div className="space-y-2">
+                <Skeleton className="h-4 w-44" />
+                <Skeleton className="h-3 w-28" />
+              </div>
+              <Skeleton className="h-5 w-24" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/dashboard-header.tsx
+++ b/frontend/components/dashboard-header.tsx
@@ -28,7 +28,11 @@ export function DashboardHeader() {
               type="button"
               variant="outline"
               className="border-2 border-foreground bg-transparent font-bold shadow-[2px_2px_0px_0px_rgba(26,26,26,1)]"
-              aria-label="Notifications"
+              aria-label={
+                unread > 0
+                  ? `Notifications, ${unread} unread`
+                  : "Notifications"
+              }
             >
               <Bell className="h-4 w-4" />
               {unread > 0 && (
@@ -69,7 +73,11 @@ export function DashboardHeader() {
 
         {/* Mobile Menu Button */}
         <button
-          className="md:hidden border-2 border-foreground p-2"
+          type="button"
+          aria-label={mobileMenuOpen ? "Close menu" : "Open menu"}
+          aria-expanded={mobileMenuOpen}
+          aria-controls="dashboard-header-mobile-menu"
+          className="md:hidden border-2 border-foreground p-2 outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
           onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
         >
           {mobileMenuOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
@@ -78,7 +86,10 @@ export function DashboardHeader() {
 
       {/* Mobile Menu */}
       {mobileMenuOpen && (
-        <div className="md:hidden border-t-2 border-foreground bg-card p-4 space-y-2">
+        <div
+          id="dashboard-header-mobile-menu"
+          className="md:hidden border-t-2 border-foreground bg-card p-4 space-y-2"
+        >
           <Link href="/" className="block">
             <Button variant="outline" className="w-full border-2 border-foreground justify-start bg-transparent">
               <Home className="mr-2 h-4 w-4" />

--- a/frontend/components/payment/PaymentTimeline.tsx
+++ b/frontend/components/payment/PaymentTimeline.tsx
@@ -19,20 +19,35 @@ export function PaymentTimeline({
   hasMore,
   isLoading,
 }: PaymentTimelineProps) {
+  // Announce the most recent payment's status to assistive tech so live updates
+  // (e.g. a payment moving to "Processing"/"Paid") are conveyed without sight.
+  const latest = payments[0];
+
   return (
     <div className="space-y-6">
-      {payments.map((payment) => (
-        <PaymentTimelineNode
-          key={payment.id}
-          date={payment.transactionDate}
-          amount={payment.amount}
-          status={payment.status}
-          reference={payment.reference}
-          isOverdue={payment.isOverdue}
-          daysOverdue={payment.daysOverdue}
-          onDownloadReceipt={() => onDownloadReceipt(payment.reference)}
-        />
-      ))}
+      <p role="status" aria-live="polite" aria-atomic="true" className="sr-only">
+        {latest
+          ? `Showing ${payments.length} payment${payments.length === 1 ? "" : "s"}. Most recent payment is ${latest.status}.`
+          : ""}
+      </p>
+
+      {payments.length > 0 && (
+        <ol className="space-y-6" aria-label="Payment history timeline">
+          {payments.map((payment) => (
+            <li key={payment.id}>
+              <PaymentTimelineNode
+                date={payment.transactionDate}
+                amount={payment.amount}
+                status={payment.status}
+                reference={payment.reference}
+                isOverdue={payment.isOverdue}
+                daysOverdue={payment.daysOverdue}
+                onDownloadReceipt={() => onDownloadReceipt(payment.reference)}
+              />
+            </li>
+          ))}
+        </ol>
+      )}
 
       {payments.length === 0 && (
         <div className="rounded-3xl border-2 border-dashed border-foreground/20 bg-muted p-10 text-center text-muted-foreground">

--- a/frontend/components/payment/PaymentTimelineNode.tsx
+++ b/frontend/components/payment/PaymentTimelineNode.tsx
@@ -1,24 +1,37 @@
 "use client";
 
-import { ArrowRight, Download, CircleDot } from "lucide-react";
+import {
+  ArrowRight,
+  Download,
+  CircleDot,
+  CheckCircle2,
+  AlertTriangle,
+  Clock,
+  Loader2,
+  type LucideIcon,
+} from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { formatNgn } from "@/lib/currency";
+
+type PaymentStatus = "Paid" | "Overdue" | "Upcoming" | "Processing";
 
 export interface PaymentTimelineNodeProps {
   date: string;
   amount: number;
-  status: "Paid" | "Overdue" | "Upcoming" | "Processing";
+  status: PaymentStatus;
   reference: string;
   isOverdue?: boolean;
   daysOverdue?: number;
   onDownloadReceipt?: () => void;
 }
 
-const statusStyles: Record<string, string> = {
-  Paid: "bg-emerald-100 text-emerald-900 border-emerald-200",
-  Overdue: "bg-red-100 text-red-900 border-red-200",
-  Upcoming: "bg-primary/10 text-primary border-primary/20",
-  Processing: "bg-amber-100 text-amber-900 border-amber-200",
+// Each status pairs a label with a distinct icon so it is never conveyed by
+// colour alone (WCAG 1.4.1). Colours chosen to meet AA contrast on the badge.
+const statusConfig: Record<PaymentStatus, { className: string; icon: LucideIcon; spin?: boolean }> = {
+  Paid: { className: "bg-emerald-100 text-emerald-900 border-emerald-300", icon: CheckCircle2 },
+  Overdue: { className: "bg-red-100 text-red-900 border-red-300", icon: AlertTriangle },
+  Upcoming: { className: "bg-primary/10 text-primary border-primary/30", icon: Clock },
+  Processing: { className: "bg-amber-100 text-amber-900 border-amber-300", icon: Loader2, spin: true },
 };
 
 export function PaymentTimelineNode({
@@ -30,10 +43,11 @@ export function PaymentTimelineNode({
   daysOverdue,
   onDownloadReceipt,
 }: PaymentTimelineNodeProps) {
+  const { className: statusClassName, icon: StatusIcon, spin } = statusConfig[status];
   return (
     <div className="group relative flex gap-4 rounded-3xl border-2 border-foreground/10 bg-card p-5 shadow-[4px_4px_0_rgba(26,26,26,0.1)] transition hover:-translate-y-0.5 hover:shadow-[6px_6px_0_rgba(26,26,26,0.1)]">
       <div className="flex h-12 w-12 flex-none items-center justify-center rounded-full border-2 border-foreground/20 bg-muted text-foreground">
-        <CircleDot className="h-5 w-5" />
+        <CircleDot className="h-5 w-5" aria-hidden="true" />
       </div>
       <div className="flex-1 space-y-3">
         <div className="flex flex-wrap items-center justify-between gap-3">
@@ -41,7 +55,14 @@ export function PaymentTimelineNode({
             <p className="text-sm uppercase tracking-[0.2em] text-muted-foreground">{date}</p>
             <p className="mt-1 text-xl font-bold">{formatNgn(amount)}</p>
           </div>
-          <span className={`rounded-full border px-3 py-1 text-xs font-bold ${statusStyles[status]}`}>
+          <span
+            className={`inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-bold ${statusClassName}`}
+          >
+            <StatusIcon
+              className={`h-3.5 w-3.5 ${spin ? "motion-safe:animate-spin" : ""}`}
+              aria-hidden="true"
+            />
+            <span className="sr-only">Status: </span>
             {status}
           </span>
         </div>

--- a/frontend/components/properties/ApartmentReviews.tsx
+++ b/frontend/components/properties/ApartmentReviews.tsx
@@ -10,6 +10,7 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
 import { useTranslations } from "next-intl";
 import { mockReviews, type Review } from "@/lib/mockData/reviews";
+import { sanitizeText } from "@/lib/sanitize";
 import { cn } from "@/lib/utils";
 
 interface ApartmentReviewsProps {
@@ -182,16 +183,21 @@ export function ApartmentReviews({ propertyId }: ApartmentReviewsProps) {
         </div>
       ) : (
         <div className="grid gap-4">
-          {filteredAndSortedReviews.map((review) => (
+          {filteredAndSortedReviews.map((review) => {
+            // Reviews are free-text authored by other users — sanitize before
+            // rendering to prevent stored-XSS (see lib/sanitize.ts).
+            const safeUserName = sanitizeText(review.userName);
+            const safeComment = sanitizeText(review.comment);
+            return (
             <Card key={review.id} className="border-3 border-foreground shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] overflow-hidden">
               <CardContent className="p-6">
                 <div className="flex justify-between items-start mb-4">
                   <div className="flex items-center gap-3">
                     <div className="h-10 w-10 border-2 border-foreground bg-secondary flex items-center justify-center font-bold">
-                      {review.userName.charAt(0)}
+                      {safeUserName.charAt(0)}
                     </div>
                     <div>
-                      <p className="font-bold">{review.userName}</p>
+                      <p className="font-bold">{safeUserName}</p>
                       <p className="text-xs text-muted-foreground">{new Date(review.date).toLocaleDateString("en-NG", { dateStyle: 'medium' })}</p>
                     </div>
                   </div>
@@ -209,7 +215,7 @@ export function ApartmentReviews({ propertyId }: ApartmentReviewsProps) {
                     </div>
                   )}
                   <p className="text-sm leading-relaxed text-foreground">
-                    {review.comment}
+                    {safeComment}
                   </p>
                 </div>
 
@@ -223,7 +229,8 @@ export function ApartmentReviews({ propertyId }: ApartmentReviewsProps) {
                 </div>
               </CardContent>
             </Card>
-          ))}
+            );
+          })}
         </div>
       )}
     </div>

--- a/frontend/components/transaction/TransactionStatusPanel.test.tsx
+++ b/frontend/components/transaction/TransactionStatusPanel.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { TransactionStatusPanel } from "./TransactionStatusPanel";
+
+// next/link renders a plain anchor in tests.
+vi.mock("next/link", () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+describe("TransactionStatusPanel accessibility", () => {
+  it("renders the status as text inside a live region", () => {
+    render(<TransactionStatusPanel status="pending" />);
+    const live = screen.getByRole("status");
+    expect(live).toHaveAttribute("aria-live", "polite");
+    expect(screen.getAllByText(/processing/i).length).toBeGreaterThan(0);
+  });
+
+  it("renders an ordered, navigable progress timeline with a current step", () => {
+    render(<TransactionStatusPanel status="pending" />);
+    const list = screen.getByRole("list", { name: /transaction progress/i });
+    const items = within(list).getAllByRole("listitem");
+    expect(items).toHaveLength(3);
+    // pending => second step ("Settling") is current
+    expect(items[1]).toHaveAttribute("aria-current", "step");
+  });
+
+  it("conveys each step state with text, not colour alone", () => {
+    render(<TransactionStatusPanel status="confirmed" />);
+    // All three steps complete => "Done" appears for each.
+    expect(screen.getAllByText("Done")).toHaveLength(3);
+  });
+
+  it("shows failure guidance, a retry action and a support link", () => {
+    render(<TransactionStatusPanel status="failed" allowRetry onRetry={vi.fn()} />);
+    expect(screen.getByText(/didn't go through/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /retry transaction/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /get help/i })).toHaveAttribute("href", "/contact");
+  });
+
+  it("shows the loading state while a status is being fetched", () => {
+    render(<TransactionStatusPanel status="pending" loading />);
+    expect(screen.getAllByText(/checking status/i).length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/components/transaction/TransactionStatusPanel.tsx
+++ b/frontend/components/transaction/TransactionStatusPanel.tsx
@@ -1,21 +1,53 @@
 "use client";
 
-import React, { useState } from "react";
-import { Loader2, CheckCircle2, AlertCircle, Clock, RefreshCw, XCircle } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { AlertCircle, Loader2, RefreshCw, LifeBuoy } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { apiPost } from "@/lib/api";
+import { usePolling, type PollingConfig } from "@/hooks/use-polling";
+import {
+  getStatusMeta,
+  getTimelineStepStates,
+  normalizeTransactionStatus,
+  TIMELINE_STEP_STATE_META,
+  TRANSACTION_TIMELINE_STEPS,
+  type DisplayStatus,
+} from "@/lib/transactionStatus";
 
-export type TransactionStatus = "pending" | "queued" | "confirmed" | "failed";
+// Re-exported for backwards compatibility with existing imports
+// (e.g. hooks/use-realtime-transactions.ts).
+export type { TransactionStatus } from "@/lib/transactionStatus";
 
 export interface TransactionStatusPanelProps {
-  status: TransactionStatus;
+  /** Current (or initial) transaction status. */
+  status: DisplayStatus;
   txId?: string | null;
   outboxId?: string | null;
   message?: string | null;
   allowRetry?: boolean;
-  onRetry?: () => void;
+  onRetry?: () => void | Promise<void>;
   className?: string;
+  /** Show the loading/unknown state while the first status is being fetched. */
+  loading?: boolean;
+  /** Externally-detected stall (overrides the internal timer). */
+  isStalled?: boolean;
+  /** Mark a non-terminal transaction as stalled after this many ms (0 disables). */
+  stalledAfterMs?: number;
+  /** Where the "contact support" link points. */
+  supportHref?: string;
+  /**
+   * Optional live status source. When provided, the panel polls it and advances
+   * automatically to the terminal state. Reuses the shared {@link usePolling} hook.
+   */
+  poll?: () => Promise<{
+    status: string;
+    txId?: string | null;
+    outboxId?: string | null;
+    message?: string | null;
+  }>;
+  pollConfig?: PollingConfig;
 }
 
 interface RetryResponse {
@@ -28,6 +60,8 @@ interface RetryResponse {
   message: string;
 }
 
+const DEFAULT_STALL_MS = 45_000;
+
 export function TransactionStatusPanel({
   status,
   txId,
@@ -36,37 +70,76 @@ export function TransactionStatusPanel({
   allowRetry = false,
   onRetry,
   className = "",
+  loading = false,
+  isStalled,
+  stalledAfterMs = DEFAULT_STALL_MS,
+  supportHref = "/contact",
+  poll,
+  pollConfig,
 }: TransactionStatusPanelProps) {
   const [isRetrying, setIsRetrying] = useState(false);
   const [retryError, setRetryError] = useState<string | null>(null);
-  const [currentStatus, setCurrentStatus] = useState<TransactionStatus>(status);
+  // Local override used after a retry when there is no live poll source.
+  const [localStatus, setLocalStatus] = useState<DisplayStatus | null>(null);
+  const [internalStalled, setInternalStalled] = useState(false);
+
+  // Adapt the consumer-supplied poll callback to the usePolling `{ data, status }`
+  // contract, normalising the backend status so polling stops on terminal states.
+  const polling = usePolling(
+    poll
+      ? async () => {
+          const result = await poll();
+          return { data: result, status: normalizeTransactionStatus(result.status) };
+        }
+      : async () => ({ data: null, status: "" }),
+    {
+      enabled: Boolean(poll),
+      stopOnStatuses: ["confirmed", "failed"],
+      ...pollConfig,
+    },
+  );
+
+  const polled = poll ? polling.data : null;
+
+  // Resolve the effective raw status: live poll > local override (post-retry) > prop.
+  const rawStatus = polled?.status ?? localStatus ?? status;
+  const display: DisplayStatus = loading ? "loading" : normalizeTransactionStatus(String(rawStatus));
+  const meta = getStatusMeta(display);
+  const StatusIcon = meta.icon;
+
+  const effectiveTxId = polled?.txId || txId || null;
+  const effectiveMessage = polled?.message || message || meta.description;
+
+  // Stall detection: arm a timer whenever we enter a non-terminal, known state.
+  useEffect(() => {
+    setInternalStalled(false);
+    if (meta.isTerminal || display === "loading" || display === "unknown") return;
+    if (!stalledAfterMs || stalledAfterMs <= 0) return;
+    const timer = setTimeout(() => setInternalStalled(true), stalledAfterMs);
+    return () => clearTimeout(timer);
+  }, [display, meta.isTerminal, stalledAfterMs]);
+
+  const stalled = (isStalled ?? false) || internalStalled;
 
   const handleRetry = async () => {
-    if (!outboxId || (!allowRetry && !onRetry)) return;
+    if (!onRetry && !outboxId) return;
 
     setIsRetrying(true);
     setRetryError(null);
 
     try {
       if (onRetry) {
-        // Use custom retry handler if provided
         await onRetry();
       } else if (outboxId) {
-        // Use admin retry endpoint
         const response = await apiPost<RetryResponse>(`/api/admin/outbox/${outboxId}/retry`, {});
-        
         if (response.success) {
-          // Update status based on response
-          const newStatus = response.item?.status?.toLowerCase();
-          if (newStatus === "confirmed" || newStatus === "completed") {
-            setCurrentStatus("confirmed");
-          } else if (newStatus === "pending" || newStatus === "queued") {
-            setCurrentStatus("queued");
-          }
+          setLocalStatus(normalizeTransactionStatus(response.item?.status) === "confirmed" ? "confirmed" : "queued");
         } else {
           setRetryError(response.message || "Retry failed");
         }
       }
+      // If we have a live poll source, restart it to pick up the new state.
+      if (poll) polling.restart();
     } catch (err) {
       setRetryError(err instanceof Error ? err.message : "Retry failed");
     } finally {
@@ -74,93 +147,87 @@ export function TransactionStatusPanel({
     }
   };
 
-  const getStatusConfig = (status: TransactionStatus) => {
-    switch (status) {
-      case "pending":
-        return {
-          icon: Clock,
-          title: "Processing",
-          description: message || "Transaction is being processed...",
-          variant: "default" as const,
-          iconClass: "text-blue-500",
-          bgClass: "bg-blue-50",
-          borderClass: "border-blue-200",
-        };
-      case "queued":
-        return {
-          icon: Loader2,
-          title: "Queued for Retry",
-          description: message || "Transaction is queued and will be retried automatically",
-          variant: "default" as const,
-          iconClass: "text-amber-500 animate-spin",
-          bgClass: "bg-amber-50",
-          borderClass: "border-amber-200",
-        };
-      case "confirmed":
-        return {
-          icon: CheckCircle2,
-          title: "Confirmed",
-          description: message || "Transaction has been confirmed successfully",
-          variant: "default" as const,
-          iconClass: "text-green-500",
-          bgClass: "bg-green-50",
-          borderClass: "border-green-200",
-        };
-      case "failed":
-        return {
-          icon: XCircle,
-          title: "Failed",
-          description: message || "Transaction failed. You can retry or contact support.",
-          variant: "destructive" as const,
-          iconClass: "text-destructive",
-          bgClass: "bg-destructive/10",
-          borderClass: "border-destructive/20",
-        };
-      default:
-        return {
-          icon: Clock,
-          title: "Processing",
-          description: message || "Transaction is being processed...",
-          variant: "default" as const,
-          iconClass: "text-blue-500",
-          bgClass: "bg-blue-50",
-          borderClass: "border-blue-200",
-        };
-    }
-  };
+  const stepStates = useMemo(() => getTimelineStepStates(display), [display]);
+  const showTimeline = display !== "unknown";
+  const showRetry =
+    (display === "failed" || stalled) && (allowRetry || Boolean(onRetry) || Boolean(outboxId) || Boolean(poll));
 
-  const config = getStatusConfig(currentStatus);
-  const StatusIcon = config.icon;
-  const showRetry = currentStatus === "failed" && (allowRetry || onRetry || outboxId);
+  // Build the announcement read by screen readers when the status changes.
+  const announcement = `${meta.label}. ${effectiveMessage}`;
 
   return (
     <Card className={`border-3 border-foreground shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] ${className}`}>
-      <CardHeader className={`${config.bgClass} border-b ${config.borderClass}`}>
+      <CardHeader className={`${meta.bgClass} border-b ${meta.borderClass}`}>
         <div className="flex items-center gap-3">
-          <StatusIcon className={`h-6 w-6 ${config.iconClass}`} />
+          <StatusIcon className={`h-6 w-6 shrink-0 ${meta.iconClass}`} aria-hidden="true" />
           <div>
-            <CardTitle className="font-mono text-lg">{config.title}</CardTitle>
-            {txId && (
+            {/* Status conveyed as text + icon, never colour alone. */}
+            <CardTitle className="font-mono text-lg">{meta.label}</CardTitle>
+            {effectiveTxId && (
               <CardDescription className="font-mono text-xs mt-1">
-                Tx: {txId.slice(0, 16)}...{txId.slice(-8)}
+                Tx: {effectiveTxId.slice(0, 16)}...{effectiveTxId.slice(-8)}
               </CardDescription>
             )}
           </div>
         </div>
       </CardHeader>
-      <CardContent className="pt-4 space-y-4">
-        <p className="text-sm text-muted-foreground">{config.description}</p>
 
-        {(txId || outboxId) && (
+      <CardContent className="pt-4 space-y-4">
+        {/* Live region: announces status transitions to assistive tech. */}
+        <p
+          role="status"
+          aria-live="polite"
+          aria-atomic="true"
+          className="text-sm text-muted-foreground"
+        >
+          {announcement}
+        </p>
+
+        {/* Ordered, screen-reader-navigable progress timeline. */}
+        {showTimeline && (
+          <ol aria-label="Transaction progress" className="space-y-3">
+            {TRANSACTION_TIMELINE_STEPS.map((step, index) => {
+              const state = stepStates[index];
+              const stateMeta = TIMELINE_STEP_STATE_META[state];
+              const StepIcon = stateMeta.icon;
+              return (
+                <li
+                  key={step.key}
+                  aria-current={state === "current" ? "step" : undefined}
+                  className="flex items-start gap-3"
+                >
+                  <StepIcon
+                    className={`mt-0.5 h-5 w-5 shrink-0 ${stateMeta.iconClass} ${
+                      stateMeta.spin ? "motion-safe:animate-spin" : ""
+                    }`}
+                    aria-hidden="true"
+                  />
+                  <div className="min-w-0">
+                    <p className="text-sm font-bold text-foreground">
+                      {step.label}
+                      {/* Status word so the step state is not conveyed by colour/icon alone. */}
+                      <span className="ml-2 align-middle text-xs font-medium text-muted-foreground">
+                        {stateMeta.label}
+                      </span>
+                    </p>
+                    <p className="text-xs text-muted-foreground">{step.description}</p>
+                  </div>
+                </li>
+              );
+            })}
+          </ol>
+        )}
+
+        {(effectiveTxId || outboxId) && (
           <div className="space-y-2 text-xs font-mono text-muted-foreground">
-            {txId && (
-              <div className="flex justify-between">
+            {effectiveTxId && (
+              <div className="flex justify-between gap-2">
                 <span>Transaction ID:</span>
-                <span className="truncate max-w-[200px]">{txId}</span>
+                <span className="truncate max-w-[200px]">{effectiveTxId}</span>
               </div>
             )}
             {outboxId && (
-              <div className="flex justify-between">
+              <div className="flex justify-between gap-2">
                 <span>Outbox ID:</span>
                 <span className="truncate max-w-[200px]">{outboxId}</span>
               </div>
@@ -168,32 +235,69 @@ export function TransactionStatusPanel({
           </div>
         )}
 
+        {/* Stalled / failed guidance with a clear next step. */}
+        {(stalled || display === "failed" || display === "unknown") && (
+          <div className="flex items-start gap-2 rounded-md border-2 border-foreground/20 bg-muted p-3 text-sm text-foreground">
+            <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+            <div className="space-y-1">
+              <p className="font-bold">
+                {display === "failed"
+                  ? "This transaction didn't go through"
+                  : stalled
+                    ? "This is taking longer than expected"
+                    : "We can't show the latest status"}
+              </p>
+              <p className="text-muted-foreground">
+                {display === "failed"
+                  ? "No funds have moved. You can retry, or contact support if the problem continues."
+                  : "It may still complete. You can wait a moment, retry, or reach out to support."}{" "}
+                <Link href={supportHref} className="font-bold text-foreground underline underline-offset-2">
+                  Contact support
+                </Link>
+                .
+              </p>
+            </div>
+          </div>
+        )}
+
         {retryError && (
-          <div className="flex items-start gap-2 rounded-md border border-destructive/20 bg-destructive/10 p-3 text-sm text-destructive">
-            <AlertCircle className="h-4 w-4 mt-0.5 shrink-0" />
+          <div className="flex items-start gap-2 rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">
+            <AlertCircle className="h-4 w-4 mt-0.5 shrink-0" aria-hidden="true" />
             <span>{retryError}</span>
           </div>
         )}
 
         {showRetry && (
-          <Button
-            onClick={handleRetry}
-            disabled={isRetrying}
-            variant="outline"
-            className="w-full border-2 border-foreground font-bold shadow-[2px_2px_0px_0px_rgba(26,26,26,1)] transition-all hover:translate-x-0.5 hover:translate-y-0.5 hover:shadow-[1px_1px_0px_0px_rgba(26,26,26,1)]"
-          >
-            {isRetrying ? (
-              <>
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                Retrying...
-              </>
-            ) : (
-              <>
-                <RefreshCw className="mr-2 h-4 w-4" />
-                Retry Transaction
-              </>
-            )}
-          </Button>
+          <div className="flex flex-col gap-2 sm:flex-row">
+            <Button
+              onClick={handleRetry}
+              disabled={isRetrying}
+              variant="outline"
+              className="w-full border-2 border-foreground font-bold shadow-[2px_2px_0px_0px_rgba(26,26,26,1)] transition-all hover:translate-x-0.5 hover:translate-y-0.5 hover:shadow-[1px_1px_0px_0px_rgba(26,26,26,1)]"
+            >
+              {isRetrying ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 motion-safe:animate-spin" aria-hidden="true" />
+                  Retrying…
+                </>
+              ) : (
+                <>
+                  <RefreshCw className="mr-2 h-4 w-4" aria-hidden="true" />
+                  Retry transaction
+                </>
+              )}
+            </Button>
+            <Button
+              asChild
+              variant="outline"
+              className="w-full border-2 border-foreground font-bold sm:w-auto"
+            >
+              <Link href={supportHref}>
+                <LifeBuoy className="mr-2 h-4 w-4" aria-hidden="true" />
+                Get help
+              </Link>
+            </Button>
+          </div>
         )}
       </CardContent>
     </Card>

--- a/frontend/lib/sanitize.test.ts
+++ b/frontend/lib/sanitize.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { sanitizeText, escapeHtml, sanitizeUrl, sanitizeHtml } from "./sanitize";
+
+describe("sanitizeText (user-generated content)", () => {
+  it("strips script tags from a review string so it renders inert", () => {
+    const malicious = 'Nice flat<script>alert("xss")</script>';
+    const safe = sanitizeText(malicious);
+    expect(safe).not.toContain("<script");
+    expect(safe).not.toContain("</script>");
+    expect(safe).toContain("Nice flat");
+  });
+
+  it("strips inline event handlers and js: protocol from review text", () => {
+    const malicious = '<img src=x onerror="steal()"> javascript:doEvil()';
+    const safe = sanitizeText(malicious);
+    expect(safe).not.toMatch(/onerror\s*=/i);
+    expect(safe).not.toContain("<img");
+    expect(safe.toLowerCase()).not.toContain("javascript:");
+  });
+
+  it("leaves ordinary review prose untouched (apart from trimming)", () => {
+    const text = "Great location and very secure. Solid 4 stars.";
+    expect(sanitizeText(text)).toBe(text);
+  });
+
+  it("removes data: URIs that could carry encoded payloads", () => {
+    const safe = sanitizeText("data:text/html;base64,PHNjcmlwdD4=");
+    expect(safe.toLowerCase()).not.toContain("data:");
+  });
+});
+
+describe("escapeHtml", () => {
+  it("encodes HTML-significant characters", () => {
+    expect(escapeHtml('<b>"hi"</b> & \'bye\'')).toBe(
+      "&lt;b&gt;&quot;hi&quot;&lt;/b&gt; &amp; &#x27;bye&#x27;",
+    );
+  });
+});
+
+describe("sanitizeUrl", () => {
+  it("allows http/https and rejects javascript: URLs", () => {
+    expect(sanitizeUrl("https://example.com/")).toBe("https://example.com/");
+    expect(sanitizeUrl("javascript:alert(1)")).toBeNull();
+    expect(sanitizeUrl("not a url")).toBeNull();
+  });
+});
+
+describe("sanitizeHtml", () => {
+  it("removes script tags and inline handlers from HTML", () => {
+    const dirty = '<p onclick="x()">hi</p><script>evil()</script>';
+    const clean = sanitizeHtml(dirty);
+    expect(clean).not.toContain("<script");
+    expect(clean).not.toMatch(/onclick\s*=/i);
+    expect(clean).toContain("hi");
+  });
+});

--- a/frontend/lib/transactionStatus.test.ts
+++ b/frontend/lib/transactionStatus.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import {
+  normalizeTransactionStatus,
+  getStatusMeta,
+  getTimelineStepStates,
+  TRANSACTION_TIMELINE_STEPS,
+} from "./transactionStatus";
+
+describe("normalizeTransactionStatus", () => {
+  it("maps backend synonyms onto known statuses", () => {
+    expect(normalizeTransactionStatus("processing")).toBe("pending");
+    expect(normalizeTransactionStatus("retrying")).toBe("queued");
+    expect(normalizeTransactionStatus("COMPLETED")).toBe("confirmed");
+    expect(normalizeTransactionStatus("success")).toBe("confirmed");
+    expect(normalizeTransactionStatus("rejected")).toBe("failed");
+  });
+
+  it("falls back to 'unknown' for empty or unrecognised values", () => {
+    expect(normalizeTransactionStatus(null)).toBe("unknown");
+    expect(normalizeTransactionStatus(undefined)).toBe("unknown");
+    expect(normalizeTransactionStatus("weird-value")).toBe("unknown");
+  });
+});
+
+describe("getStatusMeta", () => {
+  it("marks terminal states", () => {
+    expect(getStatusMeta("confirmed").isTerminal).toBe(true);
+    expect(getStatusMeta("failed").isTerminal).toBe(true);
+    expect(getStatusMeta("pending").isTerminal).toBe(false);
+  });
+
+  it("always provides a human-readable label and icon", () => {
+    for (const status of ["pending", "queued", "confirmed", "failed", "loading", "unknown"] as const) {
+      const meta = getStatusMeta(status);
+      expect(meta.label.length).toBeGreaterThan(0);
+      expect(meta.icon).toBeTruthy();
+    }
+  });
+});
+
+describe("getTimelineStepStates", () => {
+  it("returns one state per step", () => {
+    expect(getTimelineStepStates("pending")).toHaveLength(TRANSACTION_TIMELINE_STEPS.length);
+  });
+
+  it("advances steps as the transaction progresses", () => {
+    expect(getTimelineStepStates("pending")).toEqual(["complete", "current", "upcoming"]);
+    expect(getTimelineStepStates("confirmed")).toEqual(["complete", "complete", "complete"]);
+    expect(getTimelineStepStates("failed")).toEqual(["complete", "failed", "upcoming"]);
+  });
+});

--- a/frontend/lib/transactionStatus.ts
+++ b/frontend/lib/transactionStatus.ts
@@ -1,0 +1,234 @@
+import {
+  CheckCircle2,
+  Clock,
+  Loader2,
+  XCircle,
+  HelpCircle,
+  AlertTriangle,
+  CircleDashed,
+  type LucideIcon,
+} from "lucide-react";
+
+/**
+ * Single source of truth for mapping backend transaction status enums to the
+ * user-facing labels, descriptions and (non-color-only) icons used across the
+ * payment / transaction status surfaces.
+ *
+ * Keeping this mapping in one place means every status surface stays
+ * consistent and accessible (text + icon, never color alone).
+ */
+
+export type TransactionStatus = "pending" | "queued" | "confirmed" | "failed";
+
+/** Status used while we are still fetching, or when the backend value is unrecognised. */
+export type DisplayStatus = TransactionStatus | "loading" | "unknown";
+
+export type StatusTone = "info" | "progress" | "success" | "error" | "neutral";
+
+export interface StatusMeta {
+  /** Short, user-facing label (also read by screen readers). */
+  label: string;
+  /** Default human-readable description; consumers may override with a server message. */
+  description: string;
+  /** Distinct icon shape so status is never conveyed by colour alone. */
+  icon: LucideIcon;
+  /** Whether the icon should spin (in-progress states). */
+  spin?: boolean;
+  /** Whether this is a terminal state (no further updates expected). */
+  isTerminal: boolean;
+  tone: StatusTone;
+  /** Tailwind classes — text/border tones chosen to meet WCAG AA contrast on light/dark cards. */
+  iconClass: string;
+  bgClass: string;
+  borderClass: string;
+}
+
+export const TRANSACTION_STATUS_META: Record<DisplayStatus, StatusMeta> = {
+  loading: {
+    label: "Checking status",
+    description: "Fetching the latest transaction status…",
+    icon: Loader2,
+    spin: true,
+    isTerminal: false,
+    tone: "neutral",
+    iconClass: "text-muted-foreground motion-safe:animate-spin",
+    bgClass: "bg-muted",
+    borderClass: "border-foreground/20",
+  },
+  pending: {
+    label: "Processing",
+    description: "Your transaction is being processed…",
+    icon: Clock,
+    isTerminal: false,
+    tone: "info",
+    iconClass: "text-blue-700 dark:text-blue-300",
+    bgClass: "bg-blue-50 dark:bg-blue-950/40",
+    borderClass: "border-blue-300 dark:border-blue-800",
+  },
+  queued: {
+    label: "Queued for retry",
+    description: "Your transaction is queued and will be retried automatically.",
+    icon: Loader2,
+    spin: true,
+    isTerminal: false,
+    tone: "progress",
+    iconClass: "text-amber-700 dark:text-amber-300 motion-safe:animate-spin",
+    bgClass: "bg-amber-50 dark:bg-amber-950/40",
+    borderClass: "border-amber-300 dark:border-amber-800",
+  },
+  confirmed: {
+    label: "Confirmed",
+    description: "Your transaction has been confirmed successfully.",
+    icon: CheckCircle2,
+    isTerminal: true,
+    tone: "success",
+    iconClass: "text-emerald-700 dark:text-emerald-300",
+    bgClass: "bg-emerald-50 dark:bg-emerald-950/40",
+    borderClass: "border-emerald-300 dark:border-emerald-800",
+  },
+  failed: {
+    label: "Failed",
+    description: "Your transaction failed. You can retry or contact support.",
+    icon: XCircle,
+    isTerminal: true,
+    tone: "error",
+    iconClass: "text-destructive",
+    bgClass: "bg-destructive/10",
+    borderClass: "border-destructive/40",
+  },
+  unknown: {
+    label: "Status unavailable",
+    description:
+      "We couldn't determine the current status. Refresh or contact support if this persists.",
+    icon: HelpCircle,
+    isTerminal: false,
+    tone: "neutral",
+    iconClass: "text-muted-foreground",
+    bgClass: "bg-muted",
+    borderClass: "border-foreground/20",
+  },
+};
+
+/**
+ * Normalise an arbitrary backend status string into one of our known statuses.
+ * Unrecognised values map to "unknown" so the UI degrades gracefully.
+ */
+export function normalizeTransactionStatus(
+  raw: string | null | undefined,
+): DisplayStatus {
+  if (!raw) return "unknown";
+  const value = raw.toLowerCase().trim();
+  switch (value) {
+    case "pending":
+    case "processing":
+    case "submitted":
+      return "pending";
+    case "queued":
+    case "retrying":
+      return "queued";
+    case "confirmed":
+    case "completed":
+    case "success":
+    case "succeeded":
+      return "confirmed";
+    case "failed":
+    case "error":
+    case "rejected":
+      return "failed";
+    default:
+      return "unknown";
+  }
+}
+
+export function getStatusMeta(status: DisplayStatus): StatusMeta {
+  return TRANSACTION_STATUS_META[status] ?? TRANSACTION_STATUS_META.unknown;
+}
+
+/* ------------------------------------------------------------------ */
+/* Stepped progress timeline (initiated → settling → confirmed)        */
+/* ------------------------------------------------------------------ */
+
+export type TimelineStepState =
+  | "complete"
+  | "current"
+  | "upcoming"
+  | "failed";
+
+export interface TimelineStep {
+  key: string;
+  label: string;
+  description: string;
+}
+
+export const TRANSACTION_TIMELINE_STEPS: readonly TimelineStep[] = [
+  {
+    key: "initiated",
+    label: "Initiated",
+    description: "Payment request submitted.",
+  },
+  {
+    key: "settling",
+    label: "Settling",
+    description: "Confirming the transaction on the network.",
+  },
+  {
+    key: "confirmed",
+    label: "Confirmed",
+    description: "Payment complete.",
+  },
+] as const;
+
+/**
+ * Compute the state of each timeline step from the current status, in the same
+ * order as {@link TRANSACTION_TIMELINE_STEPS}.
+ */
+export function getTimelineStepStates(
+  status: DisplayStatus,
+): TimelineStepState[] {
+  switch (status) {
+    case "confirmed":
+      return ["complete", "complete", "complete"];
+    case "failed":
+      // The network/settling step is where a transaction fails.
+      return ["complete", "failed", "upcoming"];
+    case "queued":
+    case "pending":
+      return ["complete", "current", "upcoming"];
+    case "loading":
+    case "unknown":
+    default:
+      return ["upcoming", "upcoming", "upcoming"];
+  }
+}
+
+export interface StepStateMeta {
+  /** Screen-reader status text, e.g. "Done", "In progress". */
+  label: string;
+  icon: LucideIcon;
+  spin?: boolean;
+  iconClass: string;
+}
+
+export const TIMELINE_STEP_STATE_META: Record<TimelineStepState, StepStateMeta> = {
+  complete: {
+    label: "Done",
+    icon: CheckCircle2,
+    iconClass: "text-emerald-700 dark:text-emerald-300",
+  },
+  current: {
+    label: "In progress",
+    icon: Loader2,
+    spin: true,
+    iconClass: "text-blue-700 dark:text-blue-300 motion-safe:animate-spin",
+  },
+  failed: {
+    label: "Failed",
+    icon: AlertTriangle,
+    iconClass: "text-destructive",
+  },
+  upcoming: {
+    label: "Pending",
+    icon: CircleDashed,
+    iconClass: "text-muted-foreground",
+  },
+};


### PR DESCRIPTION
## Summary

This PR bundles four scoped, frontend-only accessibility / UX fixes. Each is
isolated to its own commit so they can be reviewed (or reverted) independently.

- **#1227** — Make the payment/transaction status surfaces live and accessible:
  a single source of truth for status enums, an ordered screen-reader-navigable
  progress timeline that advances to terminal states, status conveyed by text +
  icon (never colour alone), `aria-live` announcements, and clear guidance for
  stalled/failed transactions.
- **#1278** — Add accessible names (state-reflecting) to icon-only dashboard
  header controls.
- **#1234** — Add `loading.tsx` skeletons for the `staking`, `report` and
  `wallet` routes so they no longer flash blank during data fetch.
- **#1233** — Sanitize user-generated apartment review text before render to
  close a stored-XSS gap.

All changes are confined to `frontend/`.

## Linked issue

Closes #1227
Closes #1278
Closes #1234
Closes #1233

## Changes

### #1227 — Live, accessible transaction status timeline
- New `frontend/lib/transactionStatus.ts`: single place that maps backend status
  enums (incl. synonyms like `processing`, `completed`, `rejected`) to
  user-facing labels, descriptions and distinct icons, plus the ordered timeline
  steps (`initiated → settling → confirmed`) and per-step state metadata.
  Unrecognised values degrade to an `unknown` state.
- `components/transaction/TransactionStatusPanel.tsx`:
  - Renders an ordered (`<ol>`), screen-reader-navigable progress timeline with
    `aria-current="step"` on the active step.
  - Status conveyed by **text + icon**, never colour alone; colours chosen to
    meet WCAG AA contrast on light/dark cards.
  - Status changes announced through an `aria-live="polite"` region.
  - Handles **loading** and **unknown** states.
  - Detects **stalled** transactions (timer + external override) and shows
    clear next-step guidance (retry + contact support) for stalled/failed.
  - Optional live driving via the shared `usePolling` hook (`poll` prop); stays
    fully backwards-compatible in controlled mode. `TransactionStatus` type is
    re-exported for existing importers.
- `components/payment/PaymentTimeline.tsx`: now a semantic ordered list with an
  `aria-live` region announcing the most recent payment's status.
- `components/payment/PaymentTimelineNode.tsx`: each status now shows a distinct
  icon next to its label (text + icon), with AA-contrast badge colours.
- Tests: `lib/transactionStatus.test.ts` and
  `components/transaction/TransactionStatusPanel.test.tsx`.

### #1278 — Accessible names for icon-only dashboard header controls
- `components/dashboard-header.tsx`: mobile menu toggle gets a state-reflecting
  accessible name (`aria-label` "Open menu"/"Close menu", `aria-expanded`,
  `aria-controls`) and a visible focus ring; notifications bell label now
  includes unread context (e.g. "Notifications, 3 unread").
- The existing `DashboardSidebar` / `LandlordSidebar` toggles already expose
  proper `aria-label` + `aria-expanded`, so no changes were needed there.

### #1234 — Loading skeletons for staking / report / wallet
- New `app/staking/loading.tsx`, `app/report/loading.tsx`,
  `app/wallet/loading.tsx`. Each reuses the shared `Skeleton` primitive, matches
  its page's layout/spacing to avoid CLS, and is marked `aria-busy` with an
  `sr-only` status while the skeleton itself is hidden from assistive tech.

### #1233 — Sanitize user-generated review content
- `components/properties/ApartmentReviews.tsx`: review author name and comment
  are passed through `lib/sanitize.ts` (`sanitizeText`) before render.
- New `lib/sanitize.test.ts` verifying script-laden strings render inert.

## How to test

- [ ] All automated tests pass
- [x] Manual testing completed (describe what you tested)

```bash
cd frontend
npm run lint          # passes
npm run build         # passes
npx vitest run lib/sanitize.test.ts lib/transactionStatus.test.ts \
  components/transaction/TransactionStatusPanel.test.tsx   # 18 passing
```

Manual checks:
- Status panel: cycle `pending → confirmed` and `pending → failed`; timeline
  advances, the active step is announced, and failed/stalled states show retry +
  "Contact support".
- Navigate with VoiceOver/NVDA: the dashboard header mobile toggle announces
  "Open menu, collapsed" / "Close menu, expanded"; the bell announces unread
  count.
- Hard-navigate to `/staking`, `/report`, `/wallet`: a layout-matched skeleton
  shows instantly instead of a blank screen.
- Render a review containing `<script>alert(1)</script>`: it renders as inert
  text.

## Security Considerations

- [x] No secrets or sensitive data are logged
- [x] No changes to authentication/authorization logic
- [x] No changes to admin/upgrade logic
- Closes a stored-XSS gap on public, user-controlled review content (#1233).

## Screenshots (if UI)

> Please attach before/after screenshots when opening the PR:
> - Transaction status timeline: loading / processing / confirmed / failed states.
> - Dashboard header mobile toggle focus ring.
> - Staking, report and wallet loading skeletons (before: blank → after: skeleton).

## Checklist

- [x] I linked an issue (or explained why one is not needed)
- [x] I tested locally
- [x] I did not commit secrets
- [x] I updated docs if needed
- [x] Code follows the project's style guidelines
- [x] CI checks pass
- [ ] If UI changes: I included before/after screenshots
- [x] If images added/changed: I verified they are optimized and accessible
