### PR TITLE
Add accessible names to property cards

### DIFF
--- a/frontend/components/__tests__/property-card.test.tsx
+++ b/frontend/components/__tests__/property-card.test.tsx
@@ -99,6 +99,73 @@ describe("PropertyCard", () => {
     expect(screen.getByText("Verified inspection")).toBeInTheDocument();
   });
 
+  it("gives icon-only favorite controls stateful accessible names", () => {
+    const { rerender } = render(
+      <PropertyCard
+        property={{
+          listingId: "listing-1",
+          address: "Modern Flat",
+          city: "Lagos",
+          area: "Yaba",
+          bedrooms: 2,
+          bathrooms: 2,
+          annualRentNgn: 2_000_000,
+        }}
+        isFavorited={false}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", {
+        name: "Save property: Modern Flat, Yaba, Lagos",
+      }),
+    ).toHaveAttribute("aria-pressed", "false");
+
+    rerender(
+      <PropertyCard
+        property={{
+          listingId: "listing-1",
+          address: "Modern Flat",
+          city: "Lagos",
+          area: "Yaba",
+          bedrooms: 2,
+          bathrooms: 2,
+          annualRentNgn: 2_000_000,
+        }}
+        isFavorited
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", {
+        name: "Saved: Modern Flat, Yaba, Lagos",
+      }),
+    ).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("uses a property-specific accessible name for the details link", () => {
+    render(
+      <PropertyCard
+        property={{
+          listingId: "listing-1",
+          address: "Modern Flat",
+          city: "Lagos",
+          area: "Yaba",
+          bedrooms: 2,
+          bathrooms: 2,
+          annualRentNgn: 2_000_000,
+        }}
+        showFavorite={false}
+      />,
+    );
+
+    expect(
+      screen.getByRole("link", {
+        name: "View details for Modern Flat, Yaba, Lagos",
+      }),
+    ).toHaveAttribute("href", "/properties/listing-1");
+  });
+
   it("renders the landlord verification badge when available", () => {
     render(
       <PropertyCard

--- a/frontend/components/property-card.tsx
+++ b/frontend/components/property-card.tsx
@@ -74,6 +74,10 @@ function formatLocation(property: PropertyCardData) {
   return parts.length > 0 ? parts.join(", ") : "Nigeria";
 }
 
+function propertyAccessibleName(property: PropertyCardData) {
+  return `${property.address}, ${formatLocation(property)}`;
+}
+
 function resolvePaymentType(property: PropertyCardData): PropertyCardPaymentType {
   if (property.paymentType) {
     return property.paymentType;
@@ -92,11 +96,11 @@ function getCarouselImages(property: PropertyCardData): string[] {
 }
 
 function imageAltText(property: PropertyCardData, index: number, total: number) {
-  const location = formatLocation(property);
+  const name = propertyAccessibleName(property);
   if (total <= 1) {
-    return `Photo of ${property.address}, ${location}`;
+    return `Photo of ${name}`;
   }
-  return `Photo ${index + 1} of ${total} for ${property.address}, ${location}`;
+  return `Photo ${index + 1} of ${total} for ${name}`;
 }
 
 interface PropertyImageCarouselProps {
@@ -112,6 +116,7 @@ export function PropertyImageCarousel({
 }: PropertyImageCarouselProps) {
   const images = getCarouselImages(property);
   const slideCount = Math.max(images.length, 1);
+  const propertyName = propertyAccessibleName(property);
   const scrollRef = useRef<HTMLDivElement>(null);
   const [activeIndex, setActiveIndex] = useState(0);
   const carouselId = useId();
@@ -156,7 +161,7 @@ export function PropertyImageCarousel({
         ref={scrollRef}
         role="region"
         aria-roledescription="carousel"
-        aria-label={`Photos for ${property.address}`}
+        aria-label={`Photos for ${propertyName}`}
         tabIndex={showControls ? 0 : -1}
         onKeyDown={handleKeyDown}
         onScroll={handleScroll}
@@ -173,7 +178,7 @@ export function PropertyImageCarousel({
               className="relative h-full w-full shrink-0 snap-center snap-always"
               role="group"
               aria-roledescription="slide"
-              aria-label={`${index + 1} of ${slideCount}`}
+              aria-label={`Photo ${index + 1} of ${slideCount}`}
             >
               <Image
                 src={src}
@@ -188,7 +193,7 @@ export function PropertyImageCarousel({
           <div
             className="flex h-full w-full shrink-0 snap-center items-center justify-center text-muted-foreground"
             role="img"
-            aria-label={`No photos available for ${property.address}`}
+            aria-label={`No photos available for ${propertyName}`}
           >
             <Home className="h-12 w-12" aria-hidden />
           </div>
@@ -201,7 +206,7 @@ export function PropertyImageCarousel({
         <>
           <button
             type="button"
-            aria-label="Previous photo"
+            aria-label={`Previous photo of ${propertyName}`}
             onClick={(e) => {
               e.preventDefault();
               e.stopPropagation();
@@ -214,7 +219,7 @@ export function PropertyImageCarousel({
           </button>
           <button
             type="button"
-            aria-label="Next photo"
+            aria-label={`Next photo of ${propertyName}`}
             onClick={(e) => {
               e.preventDefault();
               e.stopPropagation();
@@ -233,7 +238,7 @@ export function PropertyImageCarousel({
               <button
                 key={index}
                 type="button"
-                aria-label={`Go to photo ${index + 1}`}
+                aria-label={`Go to photo ${index + 1} of ${propertyName}`}
                 aria-current={index === activeIndex ? "true" : undefined}
                 onClick={(e) => {
                   e.preventDefault();
@@ -277,6 +282,7 @@ export function PropertyCard({
   const paymentType = resolvePaymentType(property);
   const planMonths = property.installmentPlanMonths ?? DEFAULT_PLAN_MONTHS;
   const locationLabel = formatLocation(property);
+  const propertyName = propertyAccessibleName(property);
   const detailHref = href ?? `/properties/${property.listingId}`;
 
   const showBothPrices =
@@ -343,7 +349,9 @@ export function PropertyCard({
   const favoriteButton = showFavorite ? (
     <button
       type="button"
-      aria-label={favorited ? "Remove from saved" : "Save property"}
+      aria-label={
+        favorited ? `Saved: ${propertyName}` : `Save property: ${propertyName}`
+      }
       aria-pressed={favorited}
       disabled={favoritePending}
       onClick={handleFavoriteClick}
@@ -411,7 +419,10 @@ export function PropertyCard({
         <div className="flex items-end justify-between gap-2">
           <div>{priceBlock}</div>
           {variant === "grid" && (
-            <Link href={detailHref}>
+            <Link
+              href={detailHref}
+              aria-label={`View details for ${propertyName}`}
+            >
               <Button className="border-2 border-foreground bg-primary px-4 py-2 text-sm font-bold shadow-[2px_2px_0px_0px_rgba(26,26,26,1)] transition-all hover:translate-x-px hover:translate-y-px hover:shadow-[1px_1px_0px_0px_rgba(26,26,26,1)]">
                 View
               </Button>

--- a/frontend/components/virtualized-property-list.tsx
+++ b/frontend/components/virtualized-property-list.tsx
@@ -106,11 +106,15 @@ export function VirtualizedPropertyList({
             }}
           >
             {virtualizedItems.map((property) => (
-              <div key={property.id} role="listitem" style={{ height: ITEM_HEIGHT }}>
+              <div
+                key={property.listingId}
+                role="listitem"
+                style={{ height: ITEM_HEIGHT }}
+              >
                 <PropertyCard
-                  {...propertyListingToCard(property)}
-                  isSaved={savedListingIds.includes(property.id)}
-                  onSaveToggle={() => handleSaveToggle(property.id)}
+                  property={propertyListingToCard(property)}
+                  isFavorited={savedListingIds.includes(property.listingId)}
+                  onFavoriteChange={() => handleSaveToggle(property.listingId)}
                 />
               </div>
             ))}


### PR DESCRIPTION
## Summary
- Add property-specific alt text and carousel labels for property card images
- Add stateful accessible names and `aria-pressed` to the save/favorite control
- Give repeated card detail links property-specific accessible names
- Fix virtualized property list wiring so saved state reaches `PropertyCard`

## Testing
- `git diff --check`
- Attempted `pnpm vitest run components/__tests__/property-card.test.tsx --environment jsdom`, but dependency fetching from the npm registry timed out with `EACCES` in this environment

closes #1176 