### PR TITLE
Stellar Wave: referral anti-fraud, bond fail-safe, RTL layout, idempotent offline queue

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1556,7 +1556,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -1606,7 +1605,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.1.tgz",
       "integrity": "sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -2430,7 +2428,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.6.1.tgz",
       "integrity": "sha512-r86ut4T1e8vNwB35CqCcKd45yzqH6/6Wzvpk2/cZB8PsPLlZFTvrh8yfOS3CYZYcUmAx4hHTZJ8AO8Dj8nrdhw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.6.1",
         "@opentelemetry/resources": "2.6.1",
@@ -2525,7 +2522,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
       "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -2699,7 +2695,6 @@
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -4007,7 +4002,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
       "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -4174,7 +4168,6 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -4476,7 +4469,6 @@
       "integrity": "sha512-CGJ25bc8fRi8Lod/3GHSvXRKi7nBo3kxh0ApW4yCjmrWmRmlT53B5E08XRSZRliygG0aVNxLrBEqPYdz/KcCtQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.0.18",
         "fflate": "^0.8.2",
@@ -4538,7 +4530,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4600,7 +4591,6 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -5293,7 +5283,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
@@ -5733,7 +5722,6 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6097,7 +6085,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
       "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -7238,7 +7225,6 @@
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -7581,7 +7567,6 @@
       "integrity": "sha512-UczzB+0nnwGotYSgllfARAqWCJ5e/skuV2K/l+Zyck/H6pJIhLXuBnz+6vn2i211o7DtbE78HQtsYEKICHGI+g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mobx"
@@ -8252,7 +8237,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -8433,7 +8417,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8825,7 +8808,6 @@
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8836,7 +8818,6 @@
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -9668,7 +9649,6 @@
       "integrity": "sha512-ADu2dF53esUzzM4I0ewxhxFtsDd6v4V6dNkg3vG0iFKhnt06sJneTZnRvujAosZwW0XD58IKgGMQoqri4wHRqg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emotion/is-prop-valid": "1.4.0",
         "css-to-react-native": "3.2.0",
@@ -10050,7 +10030,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -10117,7 +10096,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10267,7 +10245,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -10343,7 +10320,6 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",

--- a/backend/src/repositories/ReferralRepository.ts
+++ b/backend/src/repositories/ReferralRepository.ts
@@ -92,6 +92,32 @@ export class ReferralRepository {
     }
   }
 
+  async getConversionById(conversionId: string): Promise<ReferralConversion | null> {
+    const pool = await getPool()
+    if (!pool) throw new Error('Database not configured')
+
+    const { rows } = await pool.query(
+      `SELECT id, referral_code_id, referrer_tenant_id, referred_tenant_id, deal_id, reward_amount_ngn, status, created_at, updated_at
+       FROM referral_conversions WHERE id = $1`,
+      [conversionId],
+    )
+
+    if (rows.length === 0) return null
+
+    const row = rows[0]
+    return {
+      id: row.id,
+      referralCodeId: row.referral_code_id,
+      referrerTenantId: row.referrer_tenant_id,
+      referredTenantId: row.referred_tenant_id,
+      dealId: row.deal_id,
+      rewardAmountNgn: row.reward_amount_ngn,
+      status: row.status,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    }
+  }
+
   async getConversionsByReferrer(
     referrerTenantId: string,
   ): Promise<ReferralConversion[]> {

--- a/backend/src/routes/inspectorJobs.test.ts
+++ b/backend/src/routes/inspectorJobs.test.ts
@@ -209,7 +209,7 @@ describe('Inspector Jobs API', () => {
 
       await request(app)
         .post('/api/v1/inspector/bond/stake')
-        .send({ amount: '500' })
+        .send({ amount: '100000000' })
         .expect(200)
 
       const res = await request(app)
@@ -253,7 +253,7 @@ describe('Inspector Jobs API', () => {
       // Inspector 1 stakes and claims
       await request(app1)
         .post('/api/v1/inspector/bond/stake')
-        .send({ amount: '500' })
+        .send({ amount: '100000000' })
         .expect(200)
 
       await request(app1)
@@ -263,7 +263,7 @@ describe('Inspector Jobs API', () => {
       // Inspector 2 stakes and tries to claim same job
       await request(app2)
         .post('/api/v1/inspector/bond/stake')
-        .send({ amount: '500' })
+        .send({ amount: '100000000' })
         .expect(200)
 
       await request(app2)
@@ -464,7 +464,7 @@ describe('Inspector Jobs API', () => {
       // Inspector stakes and claims
       await request(inspectorApp)
         .post('/api/v1/inspector/bond/stake')
-        .send({ amount: '500' })
+        .send({ amount: '100000000' })
         .expect(200)
 
       await request(inspectorApp)

--- a/backend/src/services/inspectorBondService.test.ts
+++ b/backend/src/services/inspectorBondService.test.ts
@@ -1,0 +1,243 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { InspectorBondService, BondStatus } from "./inspectorBondService.js";
+import { SorobanAdapter } from "../soroban/adapter.js";
+import { AppError } from "../errors/AppError.js";
+import { ErrorCode } from "../errors/errorCodes.js";
+
+function createMockAdapter(
+  overrides: Partial<SorobanAdapter> = {},
+): SorobanAdapter {
+  return {
+    getBalance: vi.fn(),
+    credit: vi.fn(),
+    debit: vi.fn(),
+    getStakedBalance: vi.fn(),
+    getClaimableRewards: vi.fn(),
+    recordReceipt: vi.fn(),
+    getConfig: vi.fn() as any,
+    getReceiptEvents: vi.fn() as any,
+    getTimelockEvents: vi.fn() as any,
+    executeTimelock: vi.fn() as any,
+    cancelTimelock: vi.fn() as any,
+    stakeBond: vi.fn(),
+    unstakeBond: vi.fn(),
+    isBonded: vi.fn(),
+    getBond: vi.fn(),
+    syncDealStatus: vi.fn() as any,
+    ...overrides,
+  } as SorobanAdapter;
+}
+
+describe("InspectorBondService", () => {
+  let service: InspectorBondService;
+  let mockAdapter: SorobanAdapter;
+
+  beforeEach(() => {
+    mockAdapter = createMockAdapter();
+    service = new InspectorBondService(mockAdapter);
+  });
+
+  describe("assertBonded", () => {
+    it("allows a bonded inspector with sufficient bond", async () => {
+      vi.mocked(mockAdapter.isBonded).mockResolvedValue(true);
+      vi.mocked(mockAdapter.getBond).mockResolvedValue({
+        isBonded: true,
+        amount: 100_000_000n,
+      });
+
+      await expect(service.assertBonded("inspector-ok")).resolves.toBeUndefined();
+      expect(mockAdapter.isBonded).toHaveBeenCalledWith("inspector-ok");
+    });
+
+    it("denies an unbonded inspector", async () => {
+      vi.mocked(mockAdapter.isBonded).mockResolvedValue(false);
+
+      await expect(service.assertBonded("inspector-unbonded")).rejects.toMatchObject({
+        name: "AppError",
+        code: ErrorCode.INSPECTOR_NOT_BONDED,
+        status: 403,
+      });
+    });
+
+    it("denies an inspector with bond below minimum threshold", async () => {
+      vi.mocked(mockAdapter.isBonded).mockResolvedValue(true);
+      vi.mocked(mockAdapter.getBond).mockResolvedValue({
+        isBonded: true,
+        amount: 1n,
+      });
+
+      await expect(service.assertBonded("inspector-low-bond")).rejects.toMatchObject({
+        name: "AppError",
+        code: ErrorCode.INSPECTOR_NOT_BONDED,
+        status: 403,
+      });
+    });
+
+    it("fails safe (denies) when Soroban RPC is unavailable", async () => {
+      const rpcError = new Error("RPC timeout: request timed out");
+      vi.mocked(mockAdapter.isBonded).mockRejectedValue(rpcError);
+
+      await expect(service.assertBonded("inspector-rpc-fail")).rejects.toMatchObject({
+        name: "AppError",
+        code: ErrorCode.CHAIN_UNAVAILABLE,
+        status: 503,
+      });
+    });
+
+    it("fails safe (denies) on transient RPC errors", async () => {
+      const networkError = new Error("econnreset: connection reset");
+      vi.mocked(mockAdapter.isBonded).mockRejectedValue(networkError);
+
+      await expect(
+        service.assertBonded("inspector-network-fail"),
+      ).rejects.toMatchObject({
+        name: "AppError",
+        code: ErrorCode.CHAIN_UNAVAILABLE,
+        status: 503,
+      });
+    });
+
+    it("denies (INSPECTOR_NOT_BONDED) on non-transient adapter errors", async () => {
+      const contractError = new Error("Contract not found");
+      vi.mocked(mockAdapter.isBonded).mockRejectedValue(contractError);
+
+      await expect(
+        service.assertBonded("inspector-contract-error"),
+      ).rejects.toMatchObject({
+        name: "AppError",
+        code: ErrorCode.INSPECTOR_NOT_BONDED,
+        status: 403,
+      });
+    });
+
+    it("uses cached bond status within TTL", async () => {
+      vi.mocked(mockAdapter.isBonded).mockResolvedValue(true);
+      vi.mocked(mockAdapter.getBond).mockResolvedValue({
+        isBonded: true,
+        amount: 100_000_000n,
+      });
+
+      await service.assertBonded("inspector-cached");
+      await service.assertBonded("inspector-cached");
+
+      expect(mockAdapter.isBonded).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("getStatus", () => {
+    it("returns bond status for a bonded inspector", async () => {
+      vi.mocked(mockAdapter.getBond).mockResolvedValue({
+        isBonded: true,
+        amount: 200_000_000n,
+      });
+
+      const status = await service.getStatus("inspector-status-ok");
+      expect(status.isBonded).toBe(true);
+      expect(status.amount).toBe("200000000");
+    });
+
+    it("returns bond status for an unbonded inspector", async () => {
+      vi.mocked(mockAdapter.getBond).mockResolvedValue({
+        isBonded: false,
+        amount: 0n,
+      });
+
+      const status = await service.getStatus("inspector-status-unbonded");
+      expect(status.isBonded).toBe(false);
+      expect(status.amount).toBe("0");
+    });
+
+    it("returns cached status when available", async () => {
+      vi.mocked(mockAdapter.getBond).mockResolvedValue({
+        isBonded: true,
+        amount: 100_000_000n,
+      });
+
+      await service.getStatus("inspector-cached-status");
+      await service.getStatus("inspector-cached-status");
+
+      expect(mockAdapter.getBond).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("stake", () => {
+    it("stakes a bond for the inspector", async () => {
+      vi.mocked(mockAdapter.stakeBond).mockResolvedValue(undefined);
+
+      await service.stake("inspector-stake", 500_000_000n);
+      expect(mockAdapter.stakeBond).toHaveBeenCalledWith("inspector-stake", 500_000_000n);
+    });
+
+    it("rejects zero or negative amounts", async () => {
+      await expect(service.stake("inspector-stake", 0n)).rejects.toMatchObject({
+        name: "AppError",
+        code: ErrorCode.VALIDATION_ERROR,
+        status: 400,
+      });
+      await expect(service.stake("inspector-stake", -1n)).rejects.toMatchObject({
+        name: "AppError",
+        code: ErrorCode.VALIDATION_ERROR,
+        status: 400,
+      });
+    });
+  });
+
+  describe("unstake", () => {
+    it("unstakes a bonded inspector", async () => {
+      vi.mocked(mockAdapter.isBonded).mockResolvedValue(true);
+      vi.mocked(mockAdapter.unstakeBond).mockResolvedValue(undefined);
+
+      await service.unstake("inspector-unstake");
+      expect(mockAdapter.unstakeBond).toHaveBeenCalledWith("inspector-unstake");
+    });
+
+    it("rejects unstaking when inspector has no bond", async () => {
+      vi.mocked(mockAdapter.isBonded).mockResolvedValue(false);
+      vi.mocked(mockAdapter.unstakeBond).mockResolvedValue(undefined);
+
+      await expect(service.unstake("inspector-no-bond")).rejects.toMatchObject({
+        name: "AppError",
+        code: ErrorCode.INSPECTOR_NOT_BONDED,
+        status: 400,
+      });
+      expect(mockAdapter.unstakeBond).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("getMinBondAmount", () => {
+    it("returns the configured minimum bond amount", () => {
+      const minBond = service.getMinBondAmount();
+      expect(minBond).toBeGreaterThan(0n);
+    });
+  });
+
+  describe("clearCache", () => {
+    it("clears cache for a specific inspector", async () => {
+      vi.mocked(mockAdapter.isBonded).mockResolvedValue(true);
+      vi.mocked(mockAdapter.getBond).mockResolvedValue({
+        isBonded: true,
+        amount: 100_000_000n,
+      });
+
+      await service.assertBonded("inspector-clear");
+      service.clearCache("inspector-clear");
+      await service.assertBonded("inspector-clear");
+
+      expect(mockAdapter.isBonded).toHaveBeenCalledTimes(2);
+    });
+
+    it("clears entire cache", async () => {
+      vi.mocked(mockAdapter.isBonded).mockResolvedValue(true);
+      vi.mocked(mockAdapter.getBond).mockResolvedValue({
+        isBonded: true,
+        amount: 100_000_000n,
+      });
+
+      await service.assertBonded("inspector-clear-all");
+      service.clearCache();
+      await service.assertBonded("inspector-clear-all");
+
+      expect(mockAdapter.isBonded).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/backend/src/services/inspectorBondService.ts
+++ b/backend/src/services/inspectorBondService.ts
@@ -2,14 +2,51 @@ import { SorobanAdapter } from '../soroban/adapter.js'
 import { AppError } from '../errors/AppError.js'
 import { ErrorCode } from '../errors/errorCodes.js'
 import { logger } from '../utils/logger.js'
+import { isTransientRpcError } from '../soroban/errors.js'
 
 export interface BondStatus {
   isBonded: boolean
   amount: string
 }
 
+const MIN_BOND_AMOUNT = BigInt(process.env.INSPECTOR_MIN_BOND_AMOUNT ?? '100000000')
+const CACHE_TTL_MS = parseInt(process.env.INSPECTOR_BOND_CACHE_TTL_MS ?? '30000', 10)
+
+interface CacheEntry {
+  isBonded: boolean
+  amount: bigint
+  expiresAt: number
+}
+
 export class InspectorBondService {
+  private cache = new Map<string, CacheEntry>()
+
   constructor(private adapter: SorobanAdapter) {}
+
+  private getCached(inspectorId: string): CacheEntry | undefined {
+    const entry = this.cache.get(inspectorId)
+    if (entry && Date.now() < entry.expiresAt) {
+      return entry
+    }
+    this.cache.delete(inspectorId)
+    return undefined
+  }
+
+  private setCached(inspectorId: string, isBonded: boolean, amount: bigint): void {
+    this.cache.set(inspectorId, {
+      isBonded,
+      amount,
+      expiresAt: Date.now() + CACHE_TTL_MS,
+    })
+  }
+
+  clearCache(inspectorId?: string): void {
+    if (inspectorId) {
+      this.cache.delete(inspectorId)
+    } else {
+      this.cache.clear()
+    }
+  }
 
   async stake(inspectorId: string, amount: bigint): Promise<void> {
     if (amount <= 0n) {
@@ -17,6 +54,7 @@ export class InspectorBondService {
     }
     logger.info('Inspector staking bond', { inspectorId, amount: amount.toString() })
     await this.adapter.stakeBond(inspectorId, amount)
+    this.clearCache(inspectorId)
   }
 
   async unstake(inspectorId: string): Promise<void> {
@@ -26,16 +64,70 @@ export class InspectorBondService {
     }
     logger.info('Inspector unstaking bond', { inspectorId })
     await this.adapter.unstakeBond(inspectorId)
+    this.clearCache(inspectorId)
   }
 
   async getStatus(inspectorId: string): Promise<BondStatus> {
+    const cached = this.getCached(inspectorId)
+    if (cached) {
+      return { isBonded: cached.isBonded, amount: cached.amount.toString() }
+    }
     const { isBonded, amount } = await this.adapter.getBond(inspectorId)
+    this.setCached(inspectorId, isBonded, amount)
     return { isBonded, amount: amount.toString() }
   }
 
+  getMinBondAmount(): bigint {
+    return MIN_BOND_AMOUNT
+  }
+
   async assertBonded(inspectorId: string): Promise<void> {
-    const bonded = await this.adapter.isBonded(inspectorId)
-    if (!bonded) {
+    const cached = this.getCached(inspectorId)
+    if (cached) {
+      if (!cached.isBonded || cached.amount < MIN_BOND_AMOUNT) {
+        throw new AppError(
+          ErrorCode.INSPECTOR_NOT_BONDED,
+          403,
+          'Inspector must post a bond before claiming jobs',
+        )
+      }
+      return
+    }
+
+    try {
+      const bonded = await this.adapter.isBonded(inspectorId)
+      let amount = 0n
+      if (bonded) {
+        const bond = await this.adapter.getBond(inspectorId)
+        amount = bond.amount
+      }
+      this.setCached(inspectorId, bonded, amount)
+
+      if (!bonded || amount < MIN_BOND_AMOUNT) {
+        throw new AppError(
+          ErrorCode.INSPECTOR_NOT_BONDED,
+          403,
+          'Inspector must post a bond before claiming jobs',
+        )
+      }
+    } catch (error) {
+      if (error instanceof AppError) {
+        throw error
+      }
+
+      logger.warn('Bond check failed — denying access (fail-safe)', {
+        inspectorId,
+        errorMessage: error instanceof Error ? error.message : String(error),
+      })
+
+      if (isTransientRpcError(error)) {
+        throw new AppError(
+          ErrorCode.CHAIN_UNAVAILABLE,
+          503,
+          'Unable to verify bond status at this time. Please try again later.',
+        )
+      }
+
       throw new AppError(
         ErrorCode.INSPECTOR_NOT_BONDED,
         403,

--- a/backend/src/services/referralService.test.ts
+++ b/backend/src/services/referralService.test.ts
@@ -1,0 +1,316 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { ReferralService } from "./referralService.js";
+import { referralRepository } from "../repositories/ReferralRepository.js";
+import type { ReferralCode, ReferralConversion } from "../schemas/referral.js";
+import { AppError } from "../errors/AppError.js";
+import { ErrorCode } from "../errors/errorCodes.js";
+
+const mockQuery = vi.fn();
+vi.mock("../db.js", () => ({
+  getPool: vi.fn().mockResolvedValue({
+    query: mockQuery,
+    connect: vi.fn(),
+  }),
+}));
+
+vi.mock("../repositories/ReferralRepository.js", () => ({
+  referralRepository: {
+    getReferralCodeByTenantId: vi.fn(),
+    getReferralCodeByCode: vi.fn(),
+    createReferralCode: vi.fn(),
+    createConversion: vi.fn(),
+    getConversionsByReferrer: vi.fn(),
+    getConversionByReferredTenant: vi.fn(),
+    getConversionById: vi.fn(),
+    updateConversionStatus: vi.fn(),
+    getAllConversions: vi.fn(),
+  },
+}));
+
+function makeReferralCode(
+  overrides: Partial<ReferralCode> = {},
+): ReferralCode {
+  return {
+    id: overrides.id ?? "rc-1",
+    tenantId: overrides.tenantId ?? "tenant-referrer",
+    code: overrides.code ?? "ABC12345",
+    createdAt: overrides.createdAt ?? new Date().toISOString(),
+  };
+}
+
+function makeConversion(
+  overrides: Partial<ReferralConversion> = {},
+): ReferralConversion {
+  return {
+    id: overrides.id ?? "conv-1",
+    referralCodeId: overrides.referralCodeId ?? "rc-1",
+    referrerTenantId: overrides.referrerTenantId ?? "tenant-referrer",
+    referredTenantId: overrides.referredTenantId ?? "tenant-referred",
+    dealId: overrides.dealId ?? null,
+    rewardAmountNgn: overrides.rewardAmountNgn ?? 5000,
+    status: overrides.status ?? "pending",
+    createdAt: overrides.createdAt ?? new Date().toISOString(),
+    updatedAt: overrides.updatedAt ?? new Date().toISOString(),
+  };
+}
+
+describe("ReferralService", () => {
+  let service: ReferralService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockQuery.mockReset();
+    service = new ReferralService();
+  });
+
+  describe("applyReferralCode", () => {
+    it("rejects self-referral", async () => {
+      const code = makeReferralCode({ tenantId: "tenant-self" });
+      vi.mocked(referralRepository.getReferralCodeByCode).mockResolvedValue(code);
+
+      await expect(
+        service.applyReferralCode("ABC12345", "tenant-self"),
+      ).rejects.toMatchObject({
+        name: "AppError",
+        code: ErrorCode.VALIDATION_ERROR,
+        status: 400,
+        message: "You cannot use your own referral code",
+      });
+    });
+
+    it("rejects duplicate attribution for the same referred tenant", async () => {
+      const code = makeReferralCode();
+      const existing = makeConversion();
+      vi.mocked(referralRepository.getReferralCodeByCode).mockResolvedValue(code);
+      vi.mocked(referralRepository.getConversionByReferredTenant).mockResolvedValue(
+        existing,
+      );
+
+      await expect(
+        service.applyReferralCode("ABC12345", "tenant-referred"),
+      ).rejects.toMatchObject({
+        name: "AppError",
+        code: ErrorCode.VALIDATION_ERROR,
+        status: 400,
+        message: "This tenant has already been referred",
+      });
+    });
+
+    it("rejects referral code that does not exist", async () => {
+      vi.mocked(referralRepository.getReferralCodeByCode).mockResolvedValue(null);
+
+      await expect(
+        service.applyReferralCode("INVALID", "tenant-new"),
+      ).rejects.toMatchObject({
+        name: "AppError",
+        code: ErrorCode.NOT_FOUND,
+        status: 404,
+      });
+    });
+
+    it("creates a conversion when all checks pass", async () => {
+      const code = makeReferralCode();
+      const created = makeConversion();
+      vi.mocked(referralRepository.getReferralCodeByCode).mockResolvedValue(code);
+      vi.mocked(referralRepository.getConversionByReferredTenant).mockResolvedValue(
+        null,
+      );
+      vi.mocked(referralRepository.getConversionsByReferrer).mockResolvedValue([]);
+      vi.mocked(referralRepository.createConversion).mockResolvedValue(created);
+
+      const result = await service.applyReferralCode("ABC12345", "tenant-new");
+      expect(result).toEqual(created);
+      expect(referralRepository.createConversion).toHaveBeenCalled();
+    });
+
+    it("rejects when velocity cap is exceeded", async () => {
+      const code = makeReferralCode();
+      const now = Date.now();
+      const recentConversions = Array.from({ length: 20 }, (_, i) =>
+        makeConversion({
+          id: `conv-${i}`,
+          createdAt: new Date(now - 1000).toISOString(),
+        }),
+      );
+      vi.mocked(referralRepository.getReferralCodeByCode).mockResolvedValue(code);
+      vi.mocked(referralRepository.getConversionByReferredTenant).mockResolvedValue(
+        null,
+      );
+      vi.mocked(referralRepository.getConversionsByReferrer).mockResolvedValue(
+        recentConversions,
+      );
+
+      await expect(
+        service.applyReferralCode("ABC12345", "tenant-over-cap"),
+      ).rejects.toMatchObject({
+        name: "AppError",
+        code: ErrorCode.VALIDATION_ERROR,
+        status: 429,
+      });
+      expect(referralRepository.createConversion).not.toHaveBeenCalled();
+    });
+
+    it("allows referrals when velocity is below cap", async () => {
+      const code = makeReferralCode();
+      const createdConversion = makeConversion({
+        id: "conv-below",
+        referredTenantId: "tenant-new-below",
+      });
+      const belowCapConversions = Array.from({ length: 5 }, (_, i) =>
+        makeConversion({
+          id: `conv-existing-${i}`,
+          createdAt: new Date(Date.now() - 1000).toISOString(),
+        }),
+      );
+      vi.mocked(referralRepository.getReferralCodeByCode).mockResolvedValue(code);
+      vi.mocked(referralRepository.getConversionByReferredTenant).mockResolvedValue(
+        null,
+      );
+      vi.mocked(referralRepository.getConversionsByReferrer).mockResolvedValue(
+        belowCapConversions,
+      );
+      vi.mocked(referralRepository.createConversion).mockResolvedValue(
+        createdConversion,
+      );
+
+      const result = await service.applyReferralCode(
+        "ABC12345",
+        "tenant-new-below",
+      );
+      expect(result).toEqual(createdConversion);
+      expect(referralRepository.createConversion).toHaveBeenCalled();
+    });
+  });
+
+  describe("creditRewardForDealActivation (reward gating)", () => {
+    it("skips when no conversion exists for the referred tenant", async () => {
+      vi.mocked(referralRepository.getConversionByReferredTenant).mockResolvedValue(
+        null,
+      );
+
+      await expect(
+        service.creditRewardForDealActivation("tenant-noref", "deal-1"),
+      ).resolves.toBeUndefined();
+    });
+
+    it("credits reward when referred tenant activates their first deal", async () => {
+      const conversion = makeConversion({ status: "pending" });
+      vi.mocked(referralRepository.getConversionByReferredTenant).mockResolvedValue(
+        conversion,
+      );
+      mockQuery.mockResolvedValue({ rows: [] });
+
+      await service.creditRewardForDealActivation("tenant-referred", "deal-1");
+      expect(mockQuery).toHaveBeenCalled();
+    });
+
+    it("is idempotent — does not re-credit an already credited conversion", async () => {
+      const conversion = makeConversion({ status: "credited" });
+      vi.mocked(referralRepository.getConversionByReferredTenant).mockResolvedValue(
+        conversion,
+      );
+
+      await service.creditRewardForDealActivation("tenant-referred", "deal-1");
+      // The early return on non-pending status prevents double-crediting
+    });
+  });
+
+  describe("applyRewardCredit (idempotent issuance)", () => {
+    it("throws not-found for unknown conversion", async () => {
+      vi.mocked(referralRepository.getConversionById).mockResolvedValue(null);
+
+      await expect(
+        service.applyRewardCredit("conv-unknown"),
+      ).rejects.toMatchObject({
+        name: "AppError",
+        code: ErrorCode.NOT_FOUND,
+        status: 404,
+      });
+    });
+
+    it("applies a pending conversion", async () => {
+      const conversion = makeConversion({ status: "credited" });
+      const updated = makeConversion({ status: "applied" });
+      vi.mocked(referralRepository.getConversionById).mockResolvedValue(conversion);
+      vi.mocked(referralRepository.updateConversionStatus).mockResolvedValue(
+        updated,
+      );
+
+      await service.applyRewardCredit("conv-1");
+      expect(referralRepository.updateConversionStatus).toHaveBeenCalledWith(
+        "conv-1",
+        "applied",
+      );
+    });
+
+    it("is idempotent — does not re-apply an already applied conversion", async () => {
+      const conversion = makeConversion({ status: "applied" });
+      vi.mocked(referralRepository.getConversionById).mockResolvedValue(conversion);
+
+      await service.applyRewardCredit("conv-1");
+      expect(referralRepository.updateConversionStatus).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("generateReferralCode", () => {
+    it("returns existing code if tenant already has one", async () => {
+      const existing = makeReferralCode();
+      vi.mocked(referralRepository.getReferralCodeByTenantId).mockResolvedValue(
+        existing,
+      );
+
+      const result = await service.generateReferralCode("tenant-existing");
+      expect(result).toEqual(existing);
+      expect(referralRepository.createReferralCode).not.toHaveBeenCalled();
+    });
+
+    it("generates a new code when tenant has none", async () => {
+      const created = makeReferralCode();
+      vi.mocked(referralRepository.getReferralCodeByTenantId).mockResolvedValue(
+        null,
+      );
+      vi.mocked(referralRepository.getReferralCodeByCode).mockResolvedValue(null);
+      vi.mocked(referralRepository.createReferralCode).mockResolvedValue(created);
+
+      const result = await service.generateReferralCode("tenant-new");
+      expect(result).toEqual(created);
+      expect(referralRepository.createReferralCode).toHaveBeenCalled();
+    });
+  });
+
+  describe("getReferralStats", () => {
+    it("returns stats for a referrer with conversions", async () => {
+      const code = makeReferralCode();
+      const conversions = [
+        makeConversion({ status: "applied", rewardAmountNgn: 5000 }),
+        makeConversion({ status: "pending", rewardAmountNgn: 5000 }),
+      ];
+      vi.mocked(referralRepository.getReferralCodeByTenantId).mockResolvedValue(
+        code,
+      );
+      vi.mocked(referralRepository.getConversionsByReferrer).mockResolvedValue(
+        conversions,
+      );
+
+      const stats = await service.getReferralStats("tenant-referrer");
+      expect(stats.totalReferred).toBe(2);
+      expect(stats.pendingRewards).toBe(1);
+      expect(stats.appliedRewards).toBe(1);
+      expect(stats.totalRewardAmountNgn).toBe(10000);
+    });
+
+    it("throws not-found for tenant without a referral code", async () => {
+      vi.mocked(referralRepository.getReferralCodeByTenantId).mockResolvedValue(
+        null,
+      );
+
+      await expect(
+        service.getReferralStats("tenant-no-code"),
+      ).rejects.toMatchObject({
+        name: "AppError",
+        code: ErrorCode.NOT_FOUND,
+        status: 404,
+      });
+    });
+  });
+});

--- a/backend/src/services/referralService.ts
+++ b/backend/src/services/referralService.ts
@@ -10,6 +10,12 @@ const generateCode = customAlphabet(alphabet, 8)
 
 const REFERRAL_REWARD_NGN = parseInt(process.env.REFERRAL_REWARD_NGN ?? '5000', 10)
 
+const REFERRAL_VELOCITY_MAX = parseInt(process.env.REFERRAL_VELOCITY_MAX ?? '20', 10)
+const REFERRAL_VELOCITY_WINDOW_MS = parseInt(
+  process.env.REFERRAL_VELOCITY_WINDOW_MS ?? '86400000',
+  10,
+)
+
 export class ReferralService {
   /**
    * Generate a unique referral code for a tenant
@@ -81,6 +87,20 @@ export class ReferralService {
       )
     }
 
+    // Velocity cap: limit conversions per referrer in a time window
+    const conversions = await referralRepository.getConversionsByReferrer(refCode.tenantId)
+    const windowStart = Date.now() - REFERRAL_VELOCITY_WINDOW_MS
+    const recentConversions = conversions.filter(
+      (c) => new Date(c.createdAt).getTime() >= windowStart,
+    )
+    if (recentConversions.length >= REFERRAL_VELOCITY_MAX) {
+      throw new AppError(
+        ErrorCode.VALIDATION_ERROR,
+        429,
+        'This referral code has reached its usage limit. Please try again later.',
+      )
+    }
+
     // Create conversion record
     return referralRepository.createConversion(
       refCode.id,
@@ -127,30 +147,36 @@ export class ReferralService {
     referredTenantId: string,
     dealId: string,
   ): Promise<void> {
-    // Get the conversion for this referred tenant
     const conversion = await referralRepository.getConversionByReferredTenant(referredTenantId)
     if (!conversion) {
-      // No referral conversion for this tenant, nothing to do
       return
     }
 
-    // Update conversion status to credited and set deal ID
+    // Idempotent: skip if already credited or beyond
+    if (conversion.status !== 'pending') {
+      return
+    }
+
     const pool = await (await import('../db.js')).getPool()
     if (!pool) throw new Error('Database not configured')
 
     await pool.query(
-      `UPDATE referral_conversions SET status = 'credited', deal_id = $1, updated_at = NOW() WHERE id = $2`,
+      `UPDATE referral_conversions SET status = 'credited', deal_id = $1, updated_at = NOW() WHERE id = $2 AND status = 'pending'`,
       [dealId, conversion.id],
     )
   }
 
-  /**
-   * Apply credit to referrer's account
-   * This should be called when the referrer is next billed
-   */
   async applyRewardCredit(conversionId: string): Promise<void> {
-    // This method will be called from the payment flow to apply the credit
-    // For now, just update the status
+    const conversion = await referralRepository.getConversionById(conversionId)
+    if (!conversion) {
+      throw new AppError(ErrorCode.NOT_FOUND, 404, 'Referral conversion not found')
+    }
+
+    // Idempotent: skip if already applied
+    if (conversion.status === 'applied') {
+      return
+    }
+
     await referralRepository.updateConversionStatus(conversionId, 'applied')
   }
 }

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -268,3 +268,39 @@
     }
   }
 }
+
+/* =============================================
+   RTL (Right-to-Left) Support
+   ============================================= */
+[dir="rtl"] .flip-rtl {
+  transform: scaleX(-1);
+}
+
+[dir="rtl"] .ml-auto {
+  margin-left: 0 !important;
+  margin-right: auto !important;
+}
+
+[dir="rtl"] .space-x-2 > :not([hidden]) ~ :not([hidden]),
+[dir="rtl"] .space-x-3 > :not([hidden]) ~ :not([hidden]),
+[dir="rtl"] .space-x-4 > :not([hidden]) ~ :not([hidden]),
+[dir="rtl"] .space-x-6 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 1;
+}
+
+[dir="rtl"] .ml-64 {
+  margin-left: 0 !important;
+  margin-right: 16rem !important;
+}
+
+/* Auto-flip directional icons in RTL */
+[dir="rtl"] .lucide-arrow-right,
+[dir="rtl"] .lucide-arrow-left,
+[dir="rtl"] .lucide-chevron-right,
+[dir="rtl"] .lucide-chevron-left,
+[dir="rtl"] .lucide-chevron-first,
+[dir="rtl"] .lucide-chevron-last,
+[dir="rtl"] .lucide-move-right,
+[dir="rtl"] .lucide-move-left {
+  transform: scaleX(-1);
+}

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -47,7 +47,7 @@ export default function RootLayout({
   children: React.ReactNode
 }>) {
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html suppressHydrationWarning>
       <head>
         <meta name="theme-color" content="#ff6b35" />
       </head>

--- a/frontend/components/dashboard/DashboardSidebar.tsx
+++ b/frontend/components/dashboard/DashboardSidebar.tsx
@@ -231,7 +231,7 @@ export function DashboardSidebar({ role, userInfo }: DashboardSidebarProps) {
         id="dashboard-sidebar"
         ref={sidebarRef}
         aria-label={`${userInfo.roleLabel} dashboard navigation`}
-        className={`fixed left-0 top-0 z-40 h-screen w-64 border-r-3 border-foreground bg-card pt-20 transition-transform lg:translate-x-0 ${open ? "translate-x-0" : "-translate-x-full"}`}
+        className={`fixed left-0 rtl:right-0 rtl:left-auto top-0 z-40 h-screen w-64 border-r-3 rtl:border-r-0 rtl:border-l-3 border-foreground bg-card pt-20 transition-transform lg:translate-x-0 ${open ? "translate-x-0" : "-translate-x-full rtl:translate-x-full"}`}
       >
         <div className="flex h-full flex-col px-4 py-6">
           {/* User card */}

--- a/frontend/components/dashboard/SettingsPageSkeleton.tsx
+++ b/frontend/components/dashboard/SettingsPageSkeleton.tsx
@@ -6,7 +6,7 @@ export function SettingsPageSkeleton() {
     <div className="min-h-screen bg-background">
       <DashboardHeader />
 
-      <aside className="fixed left-0 top-0 z-40 h-screen w-64 border-r-3 border-foreground bg-card pt-20">
+      <aside className="fixed left-0 rtl:right-0 rtl:left-auto top-0 z-40 h-screen w-64 border-r-3 rtl:border-r-0 rtl:border-l-3 border-foreground bg-card pt-20">
         <div className="flex h-full flex-col px-4 py-6">
           <div className="mb-8 border-3 border-foreground p-4">
             <Skeleton className="h-4 w-24" />

--- a/frontend/components/header.tsx
+++ b/frontend/components/header.tsx
@@ -68,13 +68,13 @@ export function Header() {
             <Link href="/login">
               <Button
                 variant="outline"
-                className="border-3 border-foreground font-bold shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] hover:shadow-[2px_2px_0px_0px_rgba(26,26,26,1)] hover:translate-x-0.5 hover:translate-y-0.5 transition-all bg-background text-foreground min-h-[44px] px-4 sm:px-6"
+                className="border-3 border-foreground font-bold shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] hover:shadow-[2px_2px_0px_0px_rgba(26,26,26,1)] hover:translate-x-0.5 rtl:hover:-translate-x-0.5 hover:translate-y-0.5 transition-all bg-background text-foreground min-h-[44px] px-4 sm:px-6"
               >
                 Log In
               </Button>
             </Link>
             <Link href="/signup">
-              <Button className="border-3 border-foreground bg-primary font-bold shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] hover:shadow-[2px_2px_0px_0px_rgba(26,26,26,1)] hover:translate-x-0.5 hover:translate-y-0.5 transition-all text-foreground min-h-[44px] px-4 sm:px-6">
+              <Button className="border-3 border-foreground bg-primary font-bold shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] hover:shadow-[2px_2px_0px_0px_rgba(26,26,26,1)] hover:translate-x-0.5 rtl:hover:-translate-x-0.5 hover:translate-y-0.5 transition-all text-foreground min-h-[44px] px-4 sm:px-6">
                 Get Started
               </Button>
             </Link>

--- a/frontend/components/landlord/LandlordSidebar.tsx
+++ b/frontend/components/landlord/LandlordSidebar.tsx
@@ -111,7 +111,7 @@ export function LandlordSidebar() {
         id="landlord-dashboard-sidebar"
         ref={sidebarRef}
         aria-label="Landlord dashboard navigation"
-        className={`fixed left-0 top-0 z-40 h-screen w-64 border-r-3 border-foreground bg-card pt-20 transition-transform lg:translate-x-0 ${isOpen ? "translate-x-0" : "-translate-x-full"}`}
+        className={`fixed left-0 rtl:right-0 rtl:left-auto top-0 z-40 h-screen w-64 border-r-3 rtl:border-r-0 rtl:border-l-3 border-foreground bg-card pt-20 transition-transform lg:translate-x-0 ${isOpen ? "translate-x-0" : "-translate-x-full rtl:translate-x-full"}`}
       >
         <div className="flex h-full flex-col px-4 py-6">
           <div className="mb-8 border-3 border-foreground bg-accent p-4 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">

--- a/frontend/lib/offline-queue.ts
+++ b/frontend/lib/offline-queue.ts
@@ -7,15 +7,28 @@ export interface OfflineQueueEntry {
   body: string | null
   headers: Record<string, string>
   createdAt: string
+  retryCount: number
+}
+
+export type FlushStatus = 'idle' | 'replaying' | 'completed' | 'partial' | 'failed'
+
+export interface FlushProgress {
+  status: FlushStatus
+  processed: number
+  total: number
+  failedCount: number
 }
 
 const STORAGE_KEY = 'shelterflex-offline-queue'
+
+const MAX_RETRIES_PER_ITEM = 3
+const BASE_BACKOFF_MS = 500
+const MAX_BACKOFF_MS = 10_000
 
 function getStorage() {
   if (typeof window === 'undefined') {
     return null
   }
-
   return window.localStorage
 }
 
@@ -47,8 +60,26 @@ function writeQueue(entries: OfflineQueueEntry[]) {
   storage.setItem(STORAGE_KEY, JSON.stringify(entries))
   window.dispatchEvent(
     new CustomEvent('offline-queue-updated', {
-      detail: entries.length,
+      detail: { count: entries.length },
     }),
+  )
+}
+
+function isNonRetryable(status: number): boolean {
+  if (status >= 400 && status < 500) {
+    return status !== 409 && status !== 429
+  }
+  return false
+}
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function emitFlushEvent(progress: FlushProgress) {
+  if (typeof window === 'undefined') return
+  window.dispatchEvent(
+    new CustomEvent('offline-flush-progress', { detail: progress }),
   )
 }
 
@@ -57,15 +88,24 @@ export function getOfflineQueueCount() {
 }
 
 export function enqueueOfflineRequest(
-  entry: Omit<OfflineQueueEntry, 'id' | 'createdAt'>,
+  entry: Omit<OfflineQueueEntry, 'id' | 'createdAt' | 'retryCount'>,
 ) {
+  const idempotencyKey = `idem_${Date.now().toString(36)}_${Math.random()
+    .toString(36)
+    .slice(2, 10)}`
+
   const entries = readQueue()
   entries.push({
     ...entry,
     id: `offline_${Date.now().toString(36)}_${Math.random()
       .toString(36)
       .slice(2, 8)}`,
+    headers: {
+      ...entry.headers,
+      'Idempotency-Key': idempotencyKey,
+    },
     createdAt: new Date().toISOString(),
+    retryCount: 0,
   })
   writeQueue(entries)
 }
@@ -74,16 +114,36 @@ export function clearOfflineQueue() {
   writeQueue([])
 }
 
-export async function flushOfflineQueue(baseUrl: string) {
+export type ReconciliationCallback = (processed: number) => Promise<void>
+
+export async function flushOfflineQueue(
+  baseUrl: string,
+  onReconcile?: ReconciliationCallback,
+): Promise<number> {
   const entries = readQueue()
   if (!entries.length) {
+    emitFlushEvent({ status: 'completed', processed: 0, total: 0, failedCount: 0 })
     return 0
   }
 
+  emitFlushEvent({
+    status: 'replaying',
+    processed: 0,
+    total: entries.length,
+    failedCount: 0,
+  })
+
   const remaining: OfflineQueueEntry[] = []
   let processed = 0
+  let failedCount = 0
 
   for (const entry of entries) {
+    if (entry.retryCount >= MAX_RETRIES_PER_ITEM) {
+      remaining.push(entry)
+      failedCount += 1
+      continue
+    }
+
     try {
       const response = await fetch(`${baseUrl}${entry.path}`, {
         method: entry.method,
@@ -91,17 +151,73 @@ export async function flushOfflineQueue(baseUrl: string) {
         body: entry.body,
       })
 
+      if (isNonRetryable(response.status)) {
+        failedCount += 1
+        continue
+      }
+
       if (!response.ok) {
+        entry.retryCount += 1
         remaining.push(entry)
+        failedCount += 1
+
+        const delay = Math.min(
+          BASE_BACKOFF_MS * Math.pow(2, entry.retryCount - 1) +
+            Math.random() * BASE_BACKOFF_MS,
+          MAX_BACKOFF_MS,
+        )
+        emitFlushEvent({
+          status: 'replaying',
+          processed,
+          total: entries.length,
+          failedCount,
+        })
+        await sleep(delay)
         continue
       }
 
       processed += 1
+      emitFlushEvent({
+        status: 'replaying',
+        processed,
+        total: entries.length,
+        failedCount,
+      })
     } catch {
+      entry.retryCount += 1
       remaining.push(entry)
+      failedCount += 1
+
+      const delay = Math.min(
+        BASE_BACKOFF_MS * Math.pow(2, entry.retryCount - 1) +
+          Math.random() * BASE_BACKOFF_MS,
+        MAX_BACKOFF_MS,
+      )
+      emitFlushEvent({
+        status: 'replaying',
+        processed,
+        total: entries.length,
+        failedCount,
+      })
+      await sleep(delay)
     }
   }
 
   writeQueue(remaining)
+
+  const status: FlushStatus =
+    processed === 0 ? 'failed' : failedCount > 0 ? 'partial' : 'completed'
+
+  emitFlushEvent({
+    status,
+    processed,
+    total: entries.length,
+    failedCount,
+  })
+
+  if (processed > 0 && onReconcile) {
+    await onReconcile(processed)
+  }
+
   return processed
 }


### PR DESCRIPTION
## Summary

- **#1159 — Backend: Referral anti-fraud guards** — self-referral rejection, unique attribution enforcement, reward gating on deal activation, velocity cap (env-configurable, default 20/24h), idempotent reward issuance, and a full `referralService.test.ts` covering all paths.
- **#1160 — Backend: Fail-safe inspector bond gating** — `assertBonded` now enforces a configurable min-bond amount, fails safe (deny) on transient Soroban RPC errors (→ 503) and non-transient errors (→ 403), adds a short-TTL in-memory cache to reduce chain calls, and ships `inspectorBondService.test.ts` with 17 tests covering bonded, unbonded, below-min, RPC failure, cache hit, and cache eviction paths.
- **#1161 — Frontend: RTL layout support for Arabic locale** — removes hardcoded `lang="en"` from the root `<html>` element so locale layouts can inject the correct `lang`/`dir` attributes, adds RTL CSS utilities to `globals.css` (icon flips, spacing mirrors, sidebar overrides), and updates `DashboardSidebar`, `LandlordSidebar`, `SettingsPageSkeleton`, and `Header` with Tailwind RTL variants.
- **#1162 — Frontend: Idempotent offline queue** — attaches stable idempotency keys to every queued request, adds per-item retry counting with jittered exponential backoff, drops permanent 4xx failures (non-retryable), emits `offline-flush-progress` CustomEvents (`FlushStatus`/`FlushProgress`) for UI feedback, and exposes an `onReconcile` callback post-flush.

## Test plan

- [ ] `cd backend && npx vitest run src/services/referralService.test.ts` — 16 tests pass
- [ ] `cd backend && npx vitest run src/services/inspectorBondService.test.ts` — 17 tests pass
- [ ] Switch locale to `ar` and verify sidebars, header, and icons render RTL correctly
- [ ] Simulate offline → online transition and confirm queue flushes exactly once with idempotency keys visible in network tab
- [ ] Confirm duplicate deal-activation events do not re-credit a referral reward
- [ ] Confirm an inspector with `amount < MIN_BOND_AMOUNT` is denied with 403; RPC timeout yields 503

closes #1159
closes #1160 
closes #1161 
closes #1162