### PR TITLE
test(backend): add coverage for credit bureau, background check, and KYC provider services

### DIFF
--- a/backend/src/models/creditBureauReportStore.ts
+++ b/backend/src/models/creditBureauReportStore.ts
@@ -114,4 +114,78 @@ class PostgresCreditBureauReportStore implements ICreditBureauReportStore {
   }
 }
 
-export const creditBureauReportStore = new PostgresCreditBureauReportStore();
+/**
+ * In-memory implementation for testing
+ */
+export class InMemoryCreditBureauReportStore implements ICreditBureauReportStore {
+  private reports: Map<string, CreditBureauReportRecord> = new Map();
+  private counter = 1;
+
+  async create(
+    input: CreateCreditBureauReportInput,
+  ): Promise<CreditBureauReportRecord> {
+    const id = `CBR-${Date.now()}-${this.counter++}`;
+    const now = new Date();
+    const expiresAt = new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000); // 30 days TTL
+
+    const record: CreditBureauReportRecord = {
+      id,
+      tenantId: input.tenantId,
+      bvn: input.bvn,
+      nin: input.nin,
+      report: input.report,
+      cachedAt: now,
+      expiresAt,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    this.reports.set(id, record);
+    return record;
+  }
+
+  async findLatestByTenantId(
+    tenantId: string,
+  ): Promise<CreditBureauReportRecord | null> {
+    const matches = Array.from(this.reports.values()).filter(
+      (r) => r.tenantId === tenantId,
+    );
+    if (matches.length === 0) return null;
+    return matches.sort(
+      (a, b) => b.cachedAt.getTime() - a.cachedAt.getTime(),
+    )[0];
+  }
+
+  async findById(id: string): Promise<CreditBureauReportRecord | null> {
+    return this.reports.get(id) || null;
+  }
+
+  async deleteExpired(): Promise<number> {
+    const now = new Date();
+    let count = 0;
+    for (const [id, record] of this.reports.entries()) {
+      if (record.expiresAt < now) {
+        this.reports.delete(id);
+        count++;
+      }
+    }
+    return count;
+  }
+
+  // Test helper
+  async clear(): Promise<void> {
+    this.reports.clear();
+    this.counter = 1;
+  }
+}
+
+let creditBureauReportStore: ICreditBureauReportStore =
+  new PostgresCreditBureauReportStore();
+
+export function initCreditBureauReportStore(
+  store: ICreditBureauReportStore,
+): void {
+  creditBureauReportStore = store;
+}
+
+export { creditBureauReportStore };

--- a/backend/src/services/backgroundCheckService.test.ts
+++ b/backend/src/services/backgroundCheckService.test.ts
@@ -1,0 +1,286 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { BackgroundCheckService } from "./backgroundCheckService.js";
+import {
+  initBackgroundCheckResultStore,
+  InMemoryBackgroundCheckResultStore,
+} from "../models/backgroundCheckResultStore.js";
+import { getBackgroundCheckProvider } from "./backgroundCheck/BackgroundCheckFactory.js";
+import { logger } from "../utils/logger.js";
+import { AppError } from "../errors/AppError.js";
+
+vi.mock("./backgroundCheck/BackgroundCheckFactory.js");
+
+const TENANT_ID = "tenant-1";
+const OTHER_TENANT_ID = "tenant-2";
+const EMPLOYER_NAME = "Acme Corp";
+const BANK_ACCOUNT_REF = "0123456789";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function makeEmploymentResult(overrides: Partial<any> = {}) {
+  return {
+    verified: true,
+    employerName: EMPLOYER_NAME,
+    jobTitle: "Engineer",
+    startDate: new Date("2020-01-01").toISOString(),
+    employmentType: "full_time",
+    monthlyIncome: 500000,
+    verificationDate: new Date("2024-01-01").toISOString(),
+    ...overrides,
+  };
+}
+
+describe("BackgroundCheckService", () => {
+  let store: InMemoryBackgroundCheckResultStore;
+  let provider: {
+    verifyEmployment: ReturnType<typeof vi.fn>;
+    verifyIncome: ReturnType<typeof vi.fn>;
+    verifyBankStatement: ReturnType<typeof vi.fn>;
+  };
+
+  function buildService(): BackgroundCheckService {
+    return new BackgroundCheckService();
+  }
+
+  beforeEach(() => {
+    store = new InMemoryBackgroundCheckResultStore();
+    initBackgroundCheckResultStore(store);
+
+    provider = {
+      verifyEmployment: vi.fn(),
+      verifyIncome: vi.fn(),
+      verifyBankStatement: vi.fn(),
+    };
+    vi.mocked(getBackgroundCheckProvider).mockReturnValue(provider as any);
+
+    vi.spyOn(logger, "info").mockImplementation(() => {});
+    vi.spyOn(logger, "warn").mockImplementation(() => {});
+    vi.spyOn(logger, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  describe("lifecycle", () => {
+    it("moves a check from pending to a persisted, tenant-attributed result", async () => {
+      const gate = deferred<ReturnType<typeof makeEmploymentResult>>();
+      provider.verifyEmployment.mockReturnValue(gate.promise);
+
+      const service = buildService();
+      const runPromise = service.runFullCheck({
+        tenantId: TENANT_ID,
+        employerName: EMPLOYER_NAME,
+      });
+
+      // Allow the initial pending record to be persisted before resolving.
+      await new Promise((r) => setTimeout(r, 0));
+      const midFlight = await store.findLatestByTenantId(TENANT_ID);
+      expect(midFlight?.overallStatus).toBe("pending");
+      expect(midFlight?.tenantId).toBe(TENANT_ID);
+
+      gate.resolve(makeEmploymentResult());
+      const output = await runPromise;
+
+      expect(output.overallStatus).toBe("completed");
+      expect(output.tenantId).toBe(TENANT_ID);
+
+      const persisted = await store.findById(output.id);
+      expect(persisted?.overallStatus).toBe("completed");
+      expect(persisted?.tenantId).toBe(TENANT_ID);
+    });
+  });
+
+  describe("adverse-action gating", () => {
+    it("allows the application to proceed when verification passes", async () => {
+      provider.verifyEmployment.mockResolvedValue(
+        makeEmploymentResult({ verified: true }),
+      );
+
+      const service = buildService();
+      const output = await service.runFullCheck({
+        tenantId: TENANT_ID,
+        employerName: EMPLOYER_NAME,
+      });
+
+      expect(output.eligible).toBe(true);
+      expect(output.adverseReasons).toEqual([]);
+    });
+
+    it("gates the application with a recorded reason on an adverse employment result", async () => {
+      provider.verifyEmployment.mockResolvedValue(
+        makeEmploymentResult({ verified: false, monthlyIncome: undefined }),
+      );
+
+      const service = buildService();
+      const output = await service.runFullCheck({
+        tenantId: TENANT_ID,
+        employerName: EMPLOYER_NAME,
+      });
+
+      expect(output.eligible).toBe(false);
+      expect(output.adverseReasons).toContain(
+        "Employment could not be verified",
+      );
+
+      const persisted = await store.findById(output.id);
+      expect(persisted?.verificationMetadata?.adverseReasons).toContain(
+        "Employment could not be verified",
+      );
+    });
+
+    it("gates the application on unstable income", async () => {
+      provider.verifyIncome.mockResolvedValue({
+        averageMonthlyIncome: 200000,
+        incomeStability: "unstable",
+        lastSalaryDate: new Date().toISOString(),
+        transactionCount3m: 10,
+        verificationDate: new Date().toISOString(),
+      });
+
+      const service = buildService();
+      const output = await service.runFullCheck({
+        tenantId: TENANT_ID,
+        bankAccountRef: BANK_ACCOUNT_REF,
+      });
+
+      expect(output.eligible).toBe(false);
+      expect(output.adverseReasons).toContain(
+        "Income stability does not meet requirements",
+      );
+    });
+  });
+
+  describe("pending and timeout safety", () => {
+    it("never falsely resolves as completed when the provider times out", async () => {
+      vi.useFakeTimers();
+      provider.verifyEmployment.mockReturnValue(new Promise(() => {})); // hangs
+
+      const service = buildService();
+      const runPromise = service.runFullCheck({
+        tenantId: TENANT_ID,
+        employerName: EMPLOYER_NAME,
+      });
+      const assertion = expect(runPromise).rejects.toThrow(AppError);
+
+      await vi.advanceTimersByTimeAsync(15_001);
+      await assertion;
+
+      const persisted = await store.findLatestByTenantId(TENANT_ID);
+      expect(persisted?.overallStatus).toBe("failed");
+      expect(persisted?.overallStatus).not.toBe("completed");
+    });
+
+    it("marks the result failed (not falsely passing) on a provider error", async () => {
+      provider.verifyEmployment.mockRejectedValue(
+        new Error("provider unavailable"),
+      );
+
+      const service = buildService();
+
+      await expect(
+        service.runFullCheck({
+          tenantId: TENANT_ID,
+          employerName: EMPLOYER_NAME,
+        }),
+      ).rejects.toThrow(AppError);
+
+      const persisted = await store.findLatestByTenantId(TENANT_ID);
+      expect(persisted?.overallStatus).toBe("failed");
+    });
+  });
+
+  describe("idempotency on re-run", () => {
+    it("updates the existing result instead of creating a duplicate", async () => {
+      provider.verifyEmployment.mockResolvedValue(
+        makeEmploymentResult({ verified: false }),
+      );
+
+      const service = buildService();
+      const first = await service.runFullCheck({
+        tenantId: TENANT_ID,
+        employerName: EMPLOYER_NAME,
+      });
+      expect(first.eligible).toBe(false);
+
+      provider.verifyEmployment.mockResolvedValue(
+        makeEmploymentResult({ verified: true }),
+      );
+
+      const second = await service.runFullCheck({
+        tenantId: TENANT_ID,
+        employerName: EMPLOYER_NAME,
+        existingCheckId: first.id,
+      });
+
+      expect(second.id).toBe(first.id);
+      expect(second.eligible).toBe(true);
+
+      const allForTenant = await store.findByTenantId(TENANT_ID);
+      expect(allForTenant).toHaveLength(1);
+    });
+
+    it("does not update a result owned by a different tenant", async () => {
+      provider.verifyEmployment.mockResolvedValue(makeEmploymentResult());
+
+      const service = buildService();
+      const ownerCheck = await service.runFullCheck({
+        tenantId: TENANT_ID,
+        employerName: EMPLOYER_NAME,
+      });
+
+      const attempted = await service.runFullCheck({
+        tenantId: OTHER_TENANT_ID,
+        employerName: EMPLOYER_NAME,
+        existingCheckId: ownerCheck.id,
+      });
+
+      expect(attempted.id).not.toBe(ownerCheck.id);
+      expect(attempted.tenantId).toBe(OTHER_TENANT_ID);
+
+      const allResults = await store.findByTenantId(TENANT_ID);
+      expect(allResults).toHaveLength(1);
+    });
+  });
+
+  describe("PII handling", () => {
+    it("never logs raw employer name or bank account reference", async () => {
+      provider.verifyEmployment.mockResolvedValue(makeEmploymentResult());
+      provider.verifyIncome.mockResolvedValue({
+        averageMonthlyIncome: 400000,
+        incomeStability: "stable",
+        lastSalaryDate: new Date().toISOString(),
+        transactionCount3m: 20,
+        verificationDate: new Date().toISOString(),
+      });
+
+      const service = buildService();
+      await service.runFullCheck({
+        tenantId: TENANT_ID,
+        employerName: EMPLOYER_NAME,
+        bankAccountRef: BANK_ACCOUNT_REF,
+      });
+
+      const allLogCalls = [
+        ...vi.mocked(logger.info).mock.calls,
+        ...vi.mocked(logger.warn).mock.calls,
+        ...vi.mocked(logger.error).mock.calls,
+      ];
+
+      for (const call of allLogCalls) {
+        const serialized = JSON.stringify(call);
+        expect(serialized).not.toContain(EMPLOYER_NAME);
+        expect(serialized).not.toContain(BANK_ACCOUNT_REF);
+      }
+    });
+  });
+});

--- a/backend/src/services/backgroundCheckService.ts
+++ b/backend/src/services/backgroundCheckService.ts
@@ -19,6 +19,11 @@ export interface BackgroundCheckInput {
   skipEmployment?: boolean;
   skipIncome?: boolean;
   skipBankStatement?: boolean;
+  /**
+   * If provided and it matches an existing result owned by the same tenant,
+   * the run updates that result in place instead of creating a duplicate.
+   */
+  existingCheckId?: string;
 }
 
 export interface BackgroundCheckOutput {
@@ -48,6 +53,10 @@ export interface BackgroundCheckOutput {
   overallStatus: string;
   provider: string;
   createdAt: string;
+  /** Whether the application can proceed based on the verification results. */
+  eligible: boolean;
+  /** Recorded reasons for an adverse (gating) decision, empty when eligible. */
+  adverseReasons: string[];
 }
 
 export class BackgroundCheckService {
@@ -59,13 +68,29 @@ export class BackgroundCheckService {
   async runFullCheck(input: BackgroundCheckInput): Promise<BackgroundCheckOutput> {
     logger.info(`Starting full background check for tenant ${input.tenantId}`);
 
-    // Create initial record with pending status
-    const result = await backgroundCheckResultStore.create({
-      tenantId: input.tenantId,
-      applicationId: input.applicationId,
-      overallStatus: "pending",
-      provider: "mock",
-    });
+    // Re-running against an existing check id updates that result in place
+    // rather than creating a duplicate record.
+    let result = null;
+    if (input.existingCheckId) {
+      const existing = await backgroundCheckResultStore.findById(
+        input.existingCheckId,
+      );
+      if (existing && existing.tenantId === input.tenantId) {
+        result = await backgroundCheckResultStore.update(existing.id, {
+          overallStatus: "pending",
+        });
+      }
+    }
+
+    if (!result) {
+      // Create initial record with pending status
+      result = await backgroundCheckResultStore.create({
+        tenantId: input.tenantId,
+        applicationId: input.applicationId,
+        overallStatus: "pending",
+        provider: "mock",
+      });
+    }
 
     let employmentData;
     let incomeData;
@@ -145,6 +170,12 @@ export class BackgroundCheckService {
         }
       }
 
+      const adverseReasons = this.computeAdverseReasons(
+        employmentData,
+        incomeData,
+        bankData,
+      );
+
       // Update result with completed status
       const updated = await backgroundCheckResultStore.update(result.id, {
         employmentVerified: employmentData?.verified,
@@ -167,6 +198,7 @@ export class BackgroundCheckService {
         bankStatementEndDate: bankData?.statementPeriod?.endDate,
         bankVerificationDate: bankData?.verificationDate,
         overallStatus: "completed",
+        verificationMetadata: { adverseReasons },
       });
 
       logger.info(
@@ -213,6 +245,30 @@ export class BackgroundCheckService {
   }
 
   /**
+   * Derive adverse-action reasons from verification results. An empty list
+   * means the application is eligible to proceed.
+   */
+  private computeAdverseReasons(
+    employmentData?: { verified: boolean },
+    incomeData?: { incomeStability: string },
+    bankData?: { overdraftCount: number },
+  ): string[] {
+    const reasons: string[] = [];
+
+    if (employmentData && !employmentData.verified) {
+      reasons.push("Employment could not be verified");
+    }
+    if (incomeData && incomeData.incomeStability === "unstable") {
+      reasons.push("Income stability does not meet requirements");
+    }
+    if (bankData && bankData.overdraftCount > 2) {
+      reasons.push("Excessive overdraft history");
+    }
+
+    return reasons;
+  }
+
+  /**
    * Utility: Promise with timeout
    */
   private async withTimeout<T>(
@@ -231,6 +287,7 @@ export class BackgroundCheckService {
    * Map database result to output format
    */
   private mapToOutput(result: any): BackgroundCheckOutput {
+    const adverseReasons: string[] = result.verificationMetadata?.adverseReasons || [];
     const output: BackgroundCheckOutput = {
       id: result.id,
       tenantId: result.tenantId,
@@ -238,6 +295,8 @@ export class BackgroundCheckService {
       overallStatus: result.overallStatus,
       provider: result.provider,
       createdAt: result.createdAt,
+      eligible: result.overallStatus === "completed" && adverseReasons.length === 0,
+      adverseReasons,
     };
 
     if (result.employmentVerified !== undefined) {

--- a/backend/src/services/creditBureauService.test.ts
+++ b/backend/src/services/creditBureauService.test.ts
@@ -1,0 +1,261 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { CreditBureauService } from "./creditBureauService.js";
+import {
+  initCreditBureauReportStore,
+  InMemoryCreditBureauReportStore,
+} from "../models/creditBureauReportStore.js";
+import { getCreditBureauProvider } from "./creditBureau/CreditBureauFactory.js";
+import { logger } from "../utils/logger.js";
+import { AppError } from "../errors/AppError.js";
+import { ErrorCode } from "../errors/errorCodes.js";
+import type { CreditReport } from "./creditBureau/CreditBureauProvider.js";
+
+vi.mock("./creditBureau/CreditBureauFactory.js");
+
+const TENANT_ID = "tenant-1";
+const BVN = "22123456789";
+const NIN = "98765432109";
+
+function makeReport(overrides: Partial<CreditReport> = {}): CreditReport {
+  return {
+    score: 720,
+    derogatoryMarks: [],
+    outstandingLoans: [],
+    repaymentHistory: {
+      onTimePaymentRate: 0.95,
+      missedPayments: 0,
+      defaultedLoans: 0,
+    },
+    reportDate: new Date("2024-01-01T00:00:00Z").toISOString(),
+    expiresAt: new Date("2024-01-31T00:00:00Z").toISOString(),
+    ...overrides,
+  };
+}
+
+describe("CreditBureauService", () => {
+  let store: InMemoryCreditBureauReportStore;
+  let pullReportMock: ReturnType<typeof vi.fn>;
+  function buildService(): CreditBureauService {
+    return new CreditBureauService();
+  }
+
+  beforeEach(() => {
+    store = new InMemoryCreditBureauReportStore();
+    initCreditBureauReportStore(store);
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-01T00:00:00Z"));
+
+    pullReportMock = vi.fn();
+    vi.mocked(getCreditBureauProvider).mockReturnValue({
+      pullReport: pullReportMock,
+    } as any);
+
+    vi.spyOn(logger, "info").mockImplementation(() => {});
+    vi.spyOn(logger, "warn").mockImplementation(() => {});
+    vi.spyOn(logger, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  describe("pullReport - success path", () => {
+    it("parses a successful pull into the credit report shape and caches/snapshots it", async () => {
+      const report = makeReport({ score: 805 });
+      pullReportMock.mockResolvedValue(report);
+
+      const service = buildService();
+      const result = await service.pullReport(TENANT_ID, BVN, NIN);
+
+      expect(result).toEqual(report);
+      expect(pullReportMock).toHaveBeenCalledWith(TENANT_ID, BVN, NIN);
+
+      const cached = await store.findLatestByTenantId(TENANT_ID);
+      expect(cached).not.toBeNull();
+      expect(cached?.report).toEqual(report);
+      expect(cached?.tenantId).toBe(TENANT_ID);
+    });
+  });
+
+  describe("pullReport - freshness window", () => {
+    it("reuses the cached report within the freshness window without re-pulling", async () => {
+      const report = makeReport();
+      pullReportMock.mockResolvedValue(report);
+
+      const service = buildService();
+      const first = await service.pullReport(TENANT_ID, BVN, NIN);
+      expect(pullReportMock).toHaveBeenCalledTimes(1);
+
+      // Advance the injected clock, but stay within the cached report's TTL.
+      vi.setSystemTime(new Date("2024-01-15T00:00:00Z"));
+
+      const second = await service.pullReport(TENANT_ID, BVN, NIN);
+
+      expect(second).toEqual(first);
+      expect(pullReportMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("re-pulls from the bureau once the cached report has expired", async () => {
+      const firstReport = makeReport({ score: 700 });
+      const secondReport = makeReport({ score: 750 });
+      pullReportMock
+        .mockResolvedValueOnce(firstReport)
+        .mockResolvedValueOnce(secondReport);
+
+      const service = buildService();
+      await service.pullReport(TENANT_ID, BVN, NIN);
+
+      // Advance the injected clock past the cached report's expiresAt.
+      vi.setSystemTime(new Date("2024-02-15T00:00:00Z"));
+
+      const result = await service.pullReport(TENANT_ID, BVN, NIN);
+
+      expect(result).toEqual(secondReport);
+      expect(pullReportMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("getCachedReport reflects the same freshness window as pullReport", async () => {
+      const report = makeReport();
+      pullReportMock.mockResolvedValue(report);
+
+      const service = buildService();
+      await service.pullReport(TENANT_ID, BVN, NIN);
+
+      vi.setSystemTime(new Date("2024-01-15T00:00:00Z"));
+      expect(await service.getCachedReport(TENANT_ID)).toEqual(report);
+
+      vi.setSystemTime(new Date("2024-02-15T00:00:00Z"));
+      expect(await service.getCachedReport(TENANT_ID)).toBeNull();
+    });
+  });
+
+  describe("pullReport - bureau outage / timeout", () => {
+    it("degrades gracefully to a controlled error when the bureau call fails, without caching a false clean report", async () => {
+      pullReportMock.mockRejectedValue(new Error("bureau connection refused"));
+
+      const service = buildService();
+
+      await expect(service.pullReport(TENANT_ID, BVN, NIN)).rejects.toThrow(
+        AppError,
+      );
+
+      try {
+        await service.pullReport(TENANT_ID, BVN, NIN);
+      } catch (error) {
+        expect(error).toBeInstanceOf(AppError);
+        expect((error as AppError).code).toBe(ErrorCode.EXTERNAL_SERVICE_ERROR);
+        expect((error as AppError).status).toBe(503);
+      }
+
+      const cached = await store.findLatestByTenantId(TENANT_ID);
+      expect(cached).toBeNull();
+    });
+
+    it("degrades gracefully when the bureau call times out", async () => {
+      pullReportMock.mockImplementation(() => new Promise(() => {})); // never resolves
+
+      const service = buildService();
+      const pending = service.pullReport(TENANT_ID, BVN, NIN);
+      const assertion = expect(pending).rejects.toThrow(AppError);
+
+      await vi.advanceTimersByTimeAsync(10_001);
+      await assertion;
+
+      const cached = await store.findLatestByTenantId(TENANT_ID);
+      expect(cached).toBeNull();
+    });
+
+    it("does not throw uncaught errors and surfaces a controlled AppError instead of a crash", async () => {
+      pullReportMock.mockRejectedValue(new Error("ECONNRESET"));
+      const service = buildService();
+
+      let caught: unknown;
+      try {
+        await service.pullReport(TENANT_ID, BVN, NIN);
+      } catch (error) {
+        caught = error;
+      }
+
+      expect(caught).toBeInstanceOf(AppError);
+    });
+  });
+
+  describe("pullReport - malformed/partial bureau responses", () => {
+    it("does not throw on a partial report missing optional collections", async () => {
+      const partialReport = {
+        score: 650,
+        repaymentHistory: {
+          onTimePaymentRate: 0.5,
+          missedPayments: 2,
+          defaultedLoans: 0,
+        },
+        reportDate: new Date("2024-01-01T00:00:00Z").toISOString(),
+        expiresAt: new Date("2024-01-31T00:00:00Z").toISOString(),
+      } as unknown as CreditReport;
+
+      pullReportMock.mockResolvedValue(partialReport);
+      const service = buildService();
+
+      const result = await service.pullReport(TENANT_ID, BVN, NIN);
+
+      expect(result).toEqual(partialReport);
+      const cached = await store.findLatestByTenantId(TENANT_ID);
+      expect(cached?.report).toEqual(partialReport);
+    });
+
+    it("does not throw when the bureau returns a null/empty payload", async () => {
+      pullReportMock.mockResolvedValue(null as unknown as CreditReport);
+      const service = buildService();
+
+      const result = await service.pullReport(TENANT_ID, BVN, NIN);
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("PII handling", () => {
+    it("never logs raw bvn/nin values on the cache-hit path", async () => {
+      const report = makeReport();
+      pullReportMock.mockResolvedValue(report);
+      const service = buildService();
+
+      await service.pullReport(TENANT_ID, BVN, NIN);
+      vi.setSystemTime(new Date("2024-01-10T00:00:00Z"));
+      await service.pullReport(TENANT_ID, BVN, NIN);
+
+      const allLogCalls = [
+        ...vi.mocked(logger.info).mock.calls,
+        ...vi.mocked(logger.warn).mock.calls,
+        ...vi.mocked(logger.error).mock.calls,
+      ];
+
+      for (const call of allLogCalls) {
+        const serialized = JSON.stringify(call);
+        expect(serialized).not.toContain(BVN);
+        expect(serialized).not.toContain(NIN);
+      }
+    });
+
+    it("never logs raw bvn/nin values on the bureau failure path", async () => {
+      pullReportMock.mockRejectedValue(new Error("bureau down"));
+      const service = buildService();
+
+      await expect(
+        service.pullReport(TENANT_ID, BVN, NIN),
+      ).rejects.toThrow(AppError);
+
+      const allLogCalls = [
+        ...vi.mocked(logger.info).mock.calls,
+        ...vi.mocked(logger.warn).mock.calls,
+        ...vi.mocked(logger.error).mock.calls,
+      ];
+
+      for (const call of allLogCalls) {
+        const serialized = JSON.stringify(call);
+        expect(serialized).not.toContain(BVN);
+        expect(serialized).not.toContain(NIN);
+      }
+    });
+  });
+});

--- a/backend/src/services/kycProvider.test.ts
+++ b/backend/src/services/kycProvider.test.ts
@@ -1,0 +1,277 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import crypto from "node:crypto";
+import {
+  StubKycProvider,
+  RealKycProvider,
+  createKycProvider,
+} from "./kycProvider.js";
+import { logger } from "../utils/logger.js";
+import type { KycSubmission } from "../schemas/kyc.js";
+
+function mockFetch(body: unknown, status = 200) {
+  return vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+    new Response(typeof body === "string" ? body : JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    }),
+  );
+}
+
+const SUBMISSION: KycSubmission = {
+  documentType: "passport",
+  frontImageKey: "s3://docs/front-secret-key.jpg",
+  backImageKey: "s3://docs/back-secret-key.jpg",
+  livenessSignal: "liveness-token-xyz",
+};
+
+describe("kycProvider", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    vi.spyOn(logger, "info").mockImplementation(() => {});
+    vi.spyOn(logger, "warn").mockImplementation(() => {});
+    vi.spyOn(logger, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.env = { ...originalEnv };
+  });
+
+  describe("StubKycProvider", () => {
+    const provider = new StubKycProvider();
+
+    it("submits and returns an approved state with a fresh external id", async () => {
+      const result = await provider.submit(SUBMISSION);
+
+      expect(result.success).toBe(true);
+      expect(result.status).toBe("approved");
+      expect(result.externalId).toBeTruthy();
+    });
+
+    it("generates a unique external id per submission session (no collisions)", async () => {
+      const first = await provider.submit(SUBMISSION);
+      const second = await provider.submit(SUBMISSION);
+
+      expect(first.externalId).not.toBe(second.externalId);
+    });
+
+    it("checkStatus reports approved for any external id", async () => {
+      const status = await provider.checkStatus("session-123");
+      expect(status).toBe("approved");
+    });
+
+    it("webhookAuthenticate only accepts the expected signature", () => {
+      expect(
+        provider.webhookAuthenticate({ signature: "stub_valid_signature" }),
+      ).toBe(true);
+      expect(provider.webhookAuthenticate({ signature: "wrong" })).toBe(
+        false,
+      );
+      expect(provider.webhookAuthenticate({})).toBe(false);
+    });
+
+    it("never logs raw identity document keys or liveness signal", async () => {
+      await provider.submit(SUBMISSION);
+      await provider.checkStatus("session-123");
+
+      const allLogCalls = [
+        ...vi.mocked(logger.info).mock.calls,
+        ...vi.mocked(logger.warn).mock.calls,
+        ...vi.mocked(logger.error).mock.calls,
+      ];
+
+      for (const call of allLogCalls) {
+        const serialized = JSON.stringify(call);
+        expect(serialized).not.toContain(SUBMISSION.frontImageKey);
+        expect(serialized).not.toContain(SUBMISSION.backImageKey);
+        expect(serialized).not.toContain(SUBMISSION.livenessSignal);
+      }
+    });
+  });
+
+  describe("RealKycProvider", () => {
+    function withRealProviderEnv() {
+      process.env.KYC_PROVIDER_API_KEY = "test-api-key";
+      process.env.KYC_PROVIDER_BASE_URL = "https://kyc.example.com";
+    }
+
+    it("refuses to construct without the required configuration", () => {
+      delete process.env.KYC_PROVIDER_API_KEY;
+      delete process.env.KYC_PROVIDER_BASE_URL;
+
+      expect(() => new RealKycProvider()).toThrow();
+    });
+
+    describe("submit", () => {
+      it("maps a successful response into the verification state", async () => {
+        withRealProviderEnv();
+        const provider = new RealKycProvider();
+        mockFetch({ id: "ext-1", status: "approved" });
+
+        const result = await provider.submit(SUBMISSION);
+
+        expect(result).toEqual({
+          success: true,
+          externalId: "ext-1",
+          status: "approved",
+        });
+      });
+
+      it.each([
+        ["pending", "pending"],
+        ["in_progress", "in_review"],
+        ["approved", "approved"],
+        ["rejected", "rejected"],
+        ["expired", "expired"],
+        ["some_unknown_provider_status", "pending"],
+      ])(
+        "maps provider status %s to platform status %s",
+        async (providerStatus, expectedStatus) => {
+          withRealProviderEnv();
+          const provider = new RealKycProvider();
+          mockFetch({ id: "ext-1", status: providerStatus });
+
+          const result = await provider.submit(SUBMISSION);
+
+          expect(result.status).toBe(expectedStatus);
+        },
+      );
+
+      it("fails safe (does not throw, does not report verified) when the provider rejects the submission", async () => {
+        withRealProviderEnv();
+        const provider = new RealKycProvider();
+        mockFetch({ message: "invalid document" }, 422);
+
+        const result = await provider.submit(SUBMISSION);
+
+        expect(result.success).toBe(false);
+        expect(result.status).toBeUndefined();
+      });
+
+      it("does not log raw document keys or liveness signal on success or failure", async () => {
+        withRealProviderEnv();
+        const provider = new RealKycProvider();
+        mockFetch({ id: "ext-1", status: "approved" });
+        await provider.submit(SUBMISSION);
+
+        mockFetch({ message: "invalid document" }, 422);
+        await provider.submit(SUBMISSION);
+
+        const allLogCalls = [
+          ...vi.mocked(logger.info).mock.calls,
+          ...vi.mocked(logger.warn).mock.calls,
+          ...vi.mocked(logger.error).mock.calls,
+        ];
+
+        for (const call of allLogCalls) {
+          const serialized = JSON.stringify(call);
+          expect(serialized).not.toContain(SUBMISSION.frontImageKey);
+          expect(serialized).not.toContain(SUBMISSION.backImageKey);
+          expect(serialized).not.toContain(SUBMISSION.livenessSignal);
+        }
+      });
+    });
+
+    describe("checkStatus / expiry and re-verification", () => {
+      it("fails safe to null (not falsely verified) when the provider call fails", async () => {
+        withRealProviderEnv();
+        const provider = new RealKycProvider();
+        mockFetch({ message: "not found" }, 404);
+
+        const status = await provider.checkStatus("ext-1");
+
+        expect(status).toBeNull();
+      });
+
+      it("always reflects the provider's current state rather than a cached prior result", async () => {
+        withRealProviderEnv();
+        const provider = new RealKycProvider();
+
+        mockFetch({ status: "approved" });
+        const first = await provider.checkStatus("ext-1");
+        expect(first).toBe("approved");
+
+        // Same external id, but the provider now reports the verification has expired.
+        mockFetch({ status: "expired" });
+        const second = await provider.checkStatus("ext-1");
+        expect(second).toBe("expired");
+      });
+
+      it("does not throw on a malformed status payload and falls back to pending", async () => {
+        withRealProviderEnv();
+        const provider = new RealKycProvider();
+        mockFetch({ status: "totally-unrecognized" });
+
+        const status = await provider.checkStatus("ext-1");
+
+        expect(status).toBe("pending");
+      });
+    });
+
+    describe("webhookAuthenticate", () => {
+      it("accepts a correctly signed payload and is deterministic (idempotent) for the same payload", () => {
+        withRealProviderEnv();
+        const provider = new RealKycProvider();
+        const payload = { id: "session-1", status: "approved" };
+        const signature = crypto
+          .createHmac("sha256", "test-api-key")
+          .update(JSON.stringify(payload))
+          .digest("hex");
+
+        const signedPayload = { ...payload, signature };
+
+        expect(provider.webhookAuthenticate(signedPayload)).toBe(true);
+        // Re-checking the same signed payload yields the same result.
+        expect(provider.webhookAuthenticate(signedPayload)).toBe(true);
+      });
+
+      it("rejects a tampered or missing signature", () => {
+        withRealProviderEnv();
+        const provider = new RealKycProvider();
+
+        expect(
+          provider.webhookAuthenticate({
+            id: "session-1",
+            status: "approved",
+            signature: "not-the-right-signature",
+          }),
+        ).toBe(false);
+        expect(
+          provider.webhookAuthenticate({ id: "session-1", status: "approved" }),
+        ).toBe(false);
+      });
+    });
+  });
+
+  describe("createKycProvider", () => {
+    it("defaults to the stub provider when no provider type is configured", () => {
+      delete process.env.KYC_PROVIDER_TYPE;
+      const provider = createKycProvider();
+      expect(provider.name).toBe("stub");
+    });
+
+    it("uses the stub provider for unrecognized provider types", () => {
+      process.env.KYC_PROVIDER_TYPE = "something-else";
+      const provider = createKycProvider();
+      expect(provider.name).toBe("stub");
+    });
+
+    it("constructs the real provider when explicitly configured with credentials", () => {
+      process.env.KYC_PROVIDER_TYPE = "real";
+      process.env.KYC_PROVIDER_API_KEY = "test-api-key";
+      process.env.KYC_PROVIDER_BASE_URL = "https://kyc.example.com";
+
+      const provider = createKycProvider();
+      expect(provider.name).toBe("real");
+    });
+
+    it("throws rather than silently falling back when real is requested without credentials", () => {
+      process.env.KYC_PROVIDER_TYPE = "real";
+      delete process.env.KYC_PROVIDER_API_KEY;
+      delete process.env.KYC_PROVIDER_BASE_URL;
+
+      expect(() => createKycProvider()).toThrow();
+    });
+  });
+});

--- a/backend/src/services/kycProvider.ts
+++ b/backend/src/services/kycProvider.ts
@@ -1,3 +1,4 @@
+import { createHmac } from 'node:crypto'
 import type { KycSubmission, KycStatus, KycDocumentType } from '../schemas/kyc.js'
 import { logger } from '../utils/logger.js'
 
@@ -99,10 +100,9 @@ export class RealKycProvider implements KycProvider {
   }
 
   webhookAuthenticate(payload: Record<string, unknown>): boolean {
-    const signature = payload.signature as string | undefined
-    const expected = require('crypto')
-      .createHmac('sha256', this.apiKey)
-      .update(JSON.stringify(payload))
+    const { signature, ...rest } = payload as { signature?: string } & Record<string, unknown>
+    const expected = createHmac('sha256', this.apiKey)
+      .update(JSON.stringify(rest))
       .digest('hex')
     return signature === expected
   }


### PR DESCRIPTION
## Summary

Adds the missing test files for three external-dependency services that gate underwriting and onboarding decisions (#1205, #1206, #1207), plus the minimal seams needed to make each one testable.

### #1205 — creditBureauService
- `creditBureauReportStore.ts`: added an `InMemoryCreditBureauReportStore` + `initCreditBureauReportStore()` fake (the store was Postgres-only before, with no testable seam).
- `creditBureauService.test.ts`: successful pull parses/caches into the report shape, freshness-window reuse vs. re-pull after expiry (controlled via `vi.useFakeTimers`), bureau outage/timeout degrades to a controlled `AppError` (never a crash, never cached as a false clean report), malformed/null bureau responses don't throw uncaught, and bvn/nin are never logged.

### #1206 — backgroundCheckService
- `backgroundCheckService.ts`: added `existingCheckId` support for idempotent re-runs (updates the existing result instead of duplicating, guarded by tenant ownership), and adverse-action gating (`eligible` / `adverseReasons`, persisted via the already-existing but previously unused `verificationMetadata` field).
- `backgroundCheckService.test.ts`: pending → completed lifecycle with tenant attribution, pass vs. adverse gating with recorded reasons, provider timeouts/errors always land on `failed` (never falsely pass), idempotent re-run, cross-tenant re-run rejection, and PII (employer name, bank account ref) never logged.

### #1207 — kycProvider
- `kycProvider.ts`: fixed a real bug in `RealKycProvider.webhookAuthenticate` — it called `require('crypto')` inside this ESM (`"type": "module"`) package, which throws `ReferenceError: require is not defined` at runtime, and it hashed the `signature` field into the payload being signed, making a valid signature mathematically impossible to produce. Fixed by importing `createHmac` and excluding `signature` from the hashed payload.
- `kycProvider.test.ts`: state mapping coverage for all `mapProviderStatus` branches (including unknown → pending fallback), submit/checkStatus fail safely (never falsely "verified" on provider failure), `checkStatus` always reflects fresh provider state rather than a stale cached "approved" (covers expiry/re-verification), webhook signature accept/reject + determinism, `createKycProvider` factory branches, and no document keys/liveness signal ever logged.

## Test plan
- [x] `npx vitest run src/services/creditBureauService.test.ts src/services/backgroundCheckService.test.ts src/services/kycProvider.test.ts` — 44/44 passing
- [x] Full backend suite (`npx vitest run`) — only pre-existing, unrelated failures in `session.test.ts` remain (verified identical failures on `main` before this branch's changes)

Closes #1205
Closes #1206
Closes #1207

🤖 Generated with [Claude Code](https://claude.com/claude-code)