### PR TITLE
Add route tests for quote, conversion, properties, and publicRoutes (…

### DIFF
--- a/backend/src/routes/conversion.test.ts
+++ b/backend/src/routes/conversion.test.ts
@@ -1,0 +1,83 @@
+import express from 'express'
+import request from 'supertest'
+import { describe, it, expect, vi } from 'vitest'
+import { createConversionRouter } from './conversion.js'
+import type { ConversionRateService } from '../services/conversionRateService.js'
+
+function buildApp(rateService: Partial<ConversionRateService>) {
+  const app = express()
+  app.use('/api/conversion', createConversionRouter(rateService as ConversionRateService))
+  app.use((err: any, _req: any, res: any, _next: any) => {
+    res.status(500).json({ error: { code: 'INTERNAL_ERROR', message: err.message } })
+  })
+  return app
+}
+
+describe('GET /api/conversion/rate', () => {
+  it('returns rate, source, fetchedAt, expiresAt from the service', async () => {
+    const mockRate = {
+      rate: 1550.75,
+      source: 'stub',
+      fetchedAt: '2026-06-30T10:00:00.000Z',
+      expiresAt: '2026-06-30T10:05:00.000Z',
+    }
+    const rateService = { getRate: vi.fn().mockResolvedValue(mockRate) }
+    const app = buildApp(rateService)
+
+    const res = await request(app).get('/api/conversion/rate').expect(200)
+
+    expect(res.body.rate).toBe(1550.75)
+    expect(res.body.source).toBe('stub')
+    expect(res.body.fetchedAt).toBe('2026-06-30T10:00:00.000Z')
+    expect(res.body.expiresAt).toBe('2026-06-30T10:05:00.000Z')
+  })
+
+  it('calls getRate exactly once per request', async () => {
+    const mockRate = { rate: 1500, source: 'stub', fetchedAt: '', expiresAt: '' }
+    const rateService = { getRate: vi.fn().mockResolvedValue(mockRate) }
+    const app = buildApp(rateService)
+
+    await request(app).get('/api/conversion/rate').expect(200)
+
+    expect(rateService.getRate).toHaveBeenCalledTimes(1)
+  })
+
+  it('surfaces provider error as 500 when rate is unavailable', async () => {
+    const rateService = {
+      getRate: vi.fn().mockRejectedValue(new Error('FX provider unreachable')),
+    }
+    const app = buildApp(rateService)
+
+    const res = await request(app).get('/api/conversion/rate').expect(500)
+
+    expect(res.body.error.code).toBe('INTERNAL_ERROR')
+    expect(res.body.error.message).toContain('FX provider unreachable')
+  })
+
+  it('does not silently swallow a stale-rate error', async () => {
+    const rateService = {
+      getRate: vi.fn().mockRejectedValue(new Error('Rate cache expired and provider timed out')),
+    }
+    const app = buildApp(rateService)
+
+    const res = await request(app).get('/api/conversion/rate').expect(500)
+
+    expect(res.body.error).toBeDefined()
+    expect(res.body.error.message).toMatch(/Rate cache expired/)
+  })
+
+  it('response is the exact object returned by the service (faithful pass-through)', async () => {
+    const mockRate = {
+      rate: 1600,
+      source: 'coingecko',
+      fetchedAt: '2026-06-30T08:00:00.000Z',
+      expiresAt: '2026-06-30T08:05:00.000Z',
+    }
+    const rateService = { getRate: vi.fn().mockResolvedValue(mockRate) }
+    const app = buildApp(rateService)
+
+    const res = await request(app).get('/api/conversion/rate').expect(200)
+
+    expect(res.body).toEqual(mockRate)
+  })
+})

--- a/backend/src/routes/properties.test.ts
+++ b/backend/src/routes/properties.test.ts
@@ -1,0 +1,283 @@
+import express from 'express'
+import request from 'supertest'
+import { describe, it, expect, beforeEach } from 'vitest'
+import { createPropertiesRouter } from './properties.js'
+import { listingStore } from '../models/listingStore.js'
+import { ListingStatus, type CreateListingInput } from '../models/listing.js'
+
+const app = express()
+app.use('/api/properties', createPropertiesRouter())
+app.use((err: any, _req: any, res: any, _next: any) => {
+  res.status(err.status ?? 500).json({ error: { code: err.code, message: err.message } })
+})
+
+const PRIVATE_FIELDS = [
+  'whistleblowerId',
+  'negotiatedLandlordRateNgn',
+  'reviewedBy',
+  'reviewedAt',
+  'rejectionReason',
+  'dealId',
+]
+
+let seq = 0
+
+async function createApproved(input: Partial<CreateListingInput> = {}) {
+  seq += 1
+  const listing = await listingStore.create({
+    whistleblowerId: `wb-${seq}`,
+    address: input.address ?? `${seq} Test Street`,
+    city: input.city ?? 'Lagos',
+    area: input.area ?? 'Lekki',
+    bedrooms: input.bedrooms ?? 2,
+    bathrooms: input.bathrooms ?? 1,
+    annualRentNgn: input.annualRentNgn ?? 1_500_000,
+    outrightPriceNgn: input.outrightPriceNgn,
+    installmentBasePriceNgn: input.installmentBasePriceNgn,
+    negotiatedLandlordRateNgn: input.negotiatedLandlordRateNgn ?? 1_200_000,
+    description: input.description ?? 'A nice place',
+    photos: input.photos ?? [
+      'https://example.com/a.jpg',
+      'https://example.com/b.jpg',
+      'https://example.com/c.jpg',
+    ],
+  })
+  const approved = await listingStore.moderate(listing.listingId, ListingStatus.APPROVED, 'test-admin')
+  if (!approved) throw new Error('moderate returned null')
+  return approved
+}
+
+describe('Properties Routes', () => {
+  beforeEach(async () => {
+    seq = 0
+    await listingStore.clear()
+  })
+
+  describe('GET /api/properties/search', () => {
+    it('returns approved listings with a success wrapper', async () => {
+      await createApproved({ address: '10 Broad Street', area: 'Victoria Island' })
+
+      const res = await request(app).get('/api/properties/search').expect(200)
+
+      expect(res.body.success).toBe(true)
+      expect(res.body.total).toBe(1)
+      expect(res.body.data).toHaveLength(1)
+      expect(res.body.data[0].address).toBe('10 Broad Street')
+    })
+
+    it('omits private fields from every listing in the response', async () => {
+      await createApproved()
+
+      const res = await request(app).get('/api/properties/search').expect(200)
+
+      for (const listing of res.body.data) {
+        for (const field of PRIVATE_FIELDS) {
+          expect(listing).not.toHaveProperty(field)
+        }
+      }
+    })
+
+    it('does not return listings that are pending review', async () => {
+      await listingStore.create({
+        whistleblowerId: 'wb-pending',
+        address: '1 Pending Road',
+        city: 'Lagos',
+        area: 'Ikeja',
+        bedrooms: 1,
+        bathrooms: 1,
+        annualRentNgn: 900_000,
+        photos: ['https://example.com/p1.jpg', 'https://example.com/p2.jpg', 'https://example.com/p3.jpg'],
+      })
+
+      const res = await request(app).get('/api/properties/search').expect(200)
+
+      expect(res.body.total).toBe(0)
+      expect(res.body.data).toHaveLength(0)
+    })
+
+    it('does not return rejected listings', async () => {
+      const listing = await listingStore.create({
+        whistleblowerId: 'wb-rej',
+        address: '2 Rejected Ave',
+        city: 'Lagos',
+        area: 'Surulere',
+        bedrooms: 2,
+        bathrooms: 1,
+        annualRentNgn: 1_000_000,
+        photos: ['https://example.com/r1.jpg', 'https://example.com/r2.jpg', 'https://example.com/r3.jpg'],
+      })
+      await listingStore.moderate(listing.listingId, ListingStatus.REJECTED, 'admin', 'Incomplete info')
+
+      const res = await request(app).get('/api/properties/search').expect(200)
+
+      expect(res.body.total).toBe(0)
+    })
+
+    it('filters results by bedrooms', async () => {
+      await createApproved({ bedrooms: 2 })
+      await createApproved({ bedrooms: 3 })
+      await createApproved({ bedrooms: 3 })
+
+      const res = await request(app)
+        .get('/api/properties/search')
+        .query({ bedrooms: 3 })
+        .expect(200)
+
+      expect(res.body.total).toBe(2)
+      for (const item of res.body.data) {
+        expect(item.bedrooms).toBe(3)
+      }
+    })
+
+    it('paginates results with page and pageSize', async () => {
+      for (let i = 0; i < 5; i++) await createApproved()
+
+      const res = await request(app)
+        .get('/api/properties/search')
+        .query({ page: 2, pageSize: 2 })
+        .expect(200)
+
+      expect(res.body.total).toBe(5)
+      expect(res.body.page).toBe(2)
+      expect(res.body.pageSize).toBe(2)
+      expect(res.body.totalPages).toBe(3)
+      expect(res.body.data).toHaveLength(2)
+    })
+
+    it('clamps pageSize to the schema maximum (100)', async () => {
+      const res = await request(app)
+        .get('/api/properties/search')
+        .query({ pageSize: 9999 })
+        .expect(400)
+
+      expect(res.body.error.code).toBe('VALIDATION_ERROR')
+    })
+
+    it('rejects a negative page number', async () => {
+      const res = await request(app)
+        .get('/api/properties/search')
+        .query({ page: 0 })
+        .expect(400)
+
+      expect(res.body.error.code).toBe('VALIDATION_ERROR')
+    })
+
+    it('returns empty result when no listings match filters', async () => {
+      await createApproved({ bedrooms: 1 })
+
+      const res = await request(app)
+        .get('/api/properties/search')
+        .query({ bedrooms: 5 })
+        .expect(200)
+
+      expect(res.body.total).toBe(0)
+      expect(res.body.data).toEqual([])
+    })
+
+    it('exposes expected public fields', async () => {
+      await createApproved({
+        address: '5 Public Lane',
+        city: 'Abuja',
+        area: 'Maitama',
+        bedrooms: 3,
+        bathrooms: 2,
+        annualRentNgn: 2_000_000,
+        outrightPriceNgn: 2_200_000,
+        installmentBasePriceNgn: 2_400_000,
+        description: 'Spacious apartment',
+        photos: ['https://example.com/1.jpg', 'https://example.com/2.jpg', 'https://example.com/3.jpg'],
+      })
+
+      const res = await request(app).get('/api/properties/search').expect(200)
+      const item = res.body.data[0]
+
+      expect(item).toHaveProperty('listingId')
+      expect(item).toHaveProperty('address', '5 Public Lane')
+      expect(item).toHaveProperty('city', 'Abuja')
+      expect(item).toHaveProperty('area', 'Maitama')
+      expect(item).toHaveProperty('bedrooms', 3)
+      expect(item).toHaveProperty('bathrooms', 2)
+      expect(item).toHaveProperty('annualRentNgn', 2_000_000)
+      expect(item).toHaveProperty('outrightPriceNgn', 2_200_000)
+      expect(item).toHaveProperty('installmentBasePriceNgn', 2_400_000)
+      expect(item).toHaveProperty('description', 'Spacious apartment')
+      expect(item).toHaveProperty('photos')
+      expect(item).toHaveProperty('status', ListingStatus.APPROVED)
+      expect(item).toHaveProperty('createdAt')
+      expect(item).toHaveProperty('updatedAt')
+    })
+  })
+
+  describe('GET /api/properties/:id', () => {
+    it('returns an approved listing by id', async () => {
+      const approved = await createApproved({ address: '99 Id Street' })
+
+      const res = await request(app)
+        .get(`/api/properties/${approved.listingId}`)
+        .expect(200)
+
+      expect(res.body.success).toBe(true)
+      expect(res.body.data.listingId).toBe(approved.listingId)
+      expect(res.body.data.address).toBe('99 Id Street')
+    })
+
+    it('omits private fields from a single listing response', async () => {
+      const approved = await createApproved()
+
+      const res = await request(app)
+        .get(`/api/properties/${approved.listingId}`)
+        .expect(200)
+
+      for (const field of PRIVATE_FIELDS) {
+        expect(res.body.data).not.toHaveProperty(field)
+      }
+    })
+
+    it('returns 404 for a pending listing (not accessible publicly)', async () => {
+      const pending = await listingStore.create({
+        whistleblowerId: 'wb-x',
+        address: '1 Hidden Road',
+        city: 'Lagos',
+        area: 'Yaba',
+        bedrooms: 1,
+        bathrooms: 1,
+        annualRentNgn: 800_000,
+        photos: ['https://example.com/x1.jpg', 'https://example.com/x2.jpg', 'https://example.com/x3.jpg'],
+      })
+
+      const res = await request(app)
+        .get(`/api/properties/${pending.listingId}`)
+        .expect(404)
+
+      expect(res.body.error.code).toBe('NOT_FOUND')
+    })
+
+    it('returns 404 for a rejected listing', async () => {
+      const listing = await listingStore.create({
+        whistleblowerId: 'wb-y',
+        address: '2 Rejected Close',
+        city: 'Lagos',
+        area: 'Ikoyi',
+        bedrooms: 2,
+        bathrooms: 1,
+        annualRentNgn: 1_200_000,
+        photos: ['https://example.com/y1.jpg', 'https://example.com/y2.jpg', 'https://example.com/y3.jpg'],
+      })
+      await listingStore.moderate(listing.listingId, ListingStatus.REJECTED, 'admin', 'Bad photos')
+
+      const res = await request(app)
+        .get(`/api/properties/${listing.listingId}`)
+        .expect(404)
+
+      expect(res.body.error.code).toBe('NOT_FOUND')
+    })
+
+    it('returns 404 for a non-existent id', async () => {
+      const res = await request(app)
+        .get('/api/properties/non-existent-uuid')
+        .expect(404)
+
+      expect(res.body.error.code).toBe('NOT_FOUND')
+    })
+  })
+})

--- a/backend/src/routes/properties.ts
+++ b/backend/src/routes/properties.ts
@@ -4,12 +4,25 @@
 
 import { Router, Request, Response } from 'express'
 import { listingStore } from '../models/listingStore.js'
-import { ListingStatus } from '../models/listing.js'
+import { Listing, ListingStatus } from '../models/listing.js'
 import { propertySearchSchema } from '../schemas/listing.js'
 import { AppError } from '../errors/AppError.js'
 import { ErrorCode } from '../errors/errorCodes.js'
 
 const router = Router()
+
+function toPublicListing(listing: Listing) {
+  const {
+    whistleblowerId: _wb,
+    negotiatedLandlordRateNgn: _nr,
+    reviewedBy: _rb,
+    reviewedAt: _ra,
+    rejectionReason: _rr,
+    dealId: _di,
+    ...pub
+  } = listing
+  return pub
+}
 
 /**
  * GET /api/properties/search
@@ -26,7 +39,7 @@ router.get('/search', async (req: Request, res: Response, next) => {
 
     res.json({
       success: true,
-      data: result.listings,
+      data: result.listings.map(toPublicListing),
       total: result.total,
       page: result.page,
       pageSize: result.pageSize,
@@ -54,7 +67,7 @@ router.get('/:id', async (req: Request, res: Response, next) => {
 
     res.json({
       success: true,
-      data: listing,
+      data: toPublicListing(listing),
     })
   } catch (error) {
     next(error)

--- a/backend/src/routes/publicRoutes.test.ts
+++ b/backend/src/routes/publicRoutes.test.ts
@@ -1,0 +1,114 @@
+import express from 'express'
+import request from 'supertest'
+import { describe, it, expect } from 'vitest'
+import publicRouter from './publicRoutes.js'
+import { env } from '../schemas/env.js'
+
+const app = express()
+app.use(express.json())
+app.use(publicRouter)
+
+describe('Public Routes', () => {
+  describe('GET /soroban/config', () => {
+    it('returns rpcUrl, networkPassphrase, and contractId fields', async () => {
+      const res = await request(app).get('/soroban/config').expect(200)
+
+      expect(res.body).toHaveProperty('rpcUrl')
+      expect(res.body).toHaveProperty('networkPassphrase')
+      expect(res.body).toHaveProperty('contractId')
+    })
+
+    it('rpcUrl matches the configured env value', async () => {
+      const res = await request(app).get('/soroban/config').expect(200)
+
+      expect(res.body.rpcUrl).toBe(env.SOROBAN_RPC_URL)
+    })
+
+    it('networkPassphrase matches the configured env value', async () => {
+      const res = await request(app).get('/soroban/config').expect(200)
+
+      expect(res.body.networkPassphrase).toBe(env.SOROBAN_NETWORK_PASSPHRASE)
+    })
+
+    it('returns null for contractId when SOROBAN_CONTRACT_ID is not set', async () => {
+      const res = await request(app).get('/soroban/config').expect(200)
+
+      expect(res.body.contractId).toBeNull()
+    })
+
+    it('response has no extra undocumented fields', async () => {
+      const res = await request(app).get('/soroban/config').expect(200)
+
+      expect(Object.keys(res.body).sort()).toEqual(['contractId', 'networkPassphrase', 'rpcUrl'])
+    })
+  })
+
+  describe('POST /api/example/echo', () => {
+    it('echoes the message and includes receivedAt timestamp', async () => {
+      const res = await request(app)
+        .post('/api/example/echo')
+        .send({ message: 'hello world' })
+        .expect(200)
+
+      expect(res.body.echo).toBe('hello world')
+      expect(res.body.receivedAt).toBeDefined()
+      expect(new Date(res.body.receivedAt).getTime()).toBeGreaterThan(0)
+    })
+
+    it('includes originalTimestamp when provided', async () => {
+      const ts = Date.now()
+
+      const res = await request(app)
+        .post('/api/example/echo')
+        .send({ message: 'with timestamp', timestamp: ts })
+        .expect(200)
+
+      expect(res.body.originalTimestamp).toBe(ts)
+    })
+
+    it('omits originalTimestamp when not provided', async () => {
+      const res = await request(app)
+        .post('/api/example/echo')
+        .send({ message: 'no timestamp' })
+        .expect(200)
+
+      expect(res.body).not.toHaveProperty('originalTimestamp')
+    })
+
+    it('returns 400 when message is missing', async () => {
+      const res = await request(app)
+        .post('/api/example/echo')
+        .send({})
+        .expect(400)
+
+      expect(res.body.error.code).toBe('VALIDATION_ERROR')
+    })
+
+    it('returns 400 when message is an empty string', async () => {
+      const res = await request(app)
+        .post('/api/example/echo')
+        .send({ message: '' })
+        .expect(400)
+
+      expect(res.body.error.code).toBe('VALIDATION_ERROR')
+    })
+
+    it('returns 400 when message exceeds 100 characters', async () => {
+      const res = await request(app)
+        .post('/api/example/echo')
+        .send({ message: 'x'.repeat(101) })
+        .expect(400)
+
+      expect(res.body.error.code).toBe('VALIDATION_ERROR')
+    })
+
+    it('returns 400 when timestamp is not a positive integer', async () => {
+      const res = await request(app)
+        .post('/api/example/echo')
+        .send({ message: 'valid', timestamp: -1 })
+        .expect(400)
+
+      expect(res.body.error.code).toBe('VALIDATION_ERROR')
+    })
+  })
+})

--- a/backend/src/routes/quote.test.ts
+++ b/backend/src/routes/quote.test.ts
@@ -1,0 +1,162 @@
+import express from 'express'
+import request from 'supertest'
+import { describe, it, expect } from 'vitest'
+import { createQuoteRouter } from './quote.js'
+import { INTEREST_TIERS, computeOutrightBreakdown, computeInstallmentSchedule } from '../services/pricingService.js'
+
+const app = express()
+app.use('/api/quote', createQuoteRouter())
+app.use((err: any, _req: any, res: any, _next: any) => {
+  res.status(err.status ?? 500).json({ error: { code: err.code, message: err.message } })
+})
+
+describe('GET /api/quote', () => {
+  it('returns outright and all installment tiers for valid inputs', async () => {
+    const res = await request(app)
+      .get('/api/quote')
+      .query({ annualRentNgn: 2_000_000, depositPercent: 0.3 })
+      .expect(200)
+
+    expect(res.body.success).toBe(true)
+    const { data } = res.body
+    expect(data.annualRentNgn).toBe(2_000_000)
+    expect(data.depositPercent).toBe(0.3)
+    expect(data.outright).toBeDefined()
+    expect(data.outright.paymentType).toBe('outright')
+    for (const term of Object.keys(INTEREST_TIERS)) {
+      expect(data[`installment${term}`]).toBeDefined()
+    }
+  })
+
+  it('defaults depositPercent to 0.2 when omitted', async () => {
+    const res = await request(app)
+      .get('/api/quote')
+      .query({ annualRentNgn: 1_500_000 })
+      .expect(200)
+
+    expect(res.body.data.depositPercent).toBe(0.2)
+  })
+
+  it('outright amounts match the pricing service', async () => {
+    const annualRentNgn = 3_000_000
+    const depositPercent = 0.25
+    const expected = computeOutrightBreakdown(annualRentNgn, depositPercent)
+
+    const res = await request(app)
+      .get('/api/quote')
+      .query({ annualRentNgn, depositPercent })
+      .expect(200)
+
+    const { outright } = res.body.data
+    expect(outright.depositAmount).toBe(expected.depositAmount)
+    expect(outright.balanceDue).toBe(expected.balanceDue)
+    expect(outright.totalPayable).toBe(expected.totalPayable)
+  })
+
+  it('installment amounts match the pricing service for each tier', async () => {
+    const annualRentNgn = 2_400_000
+    const depositPercent = 0.2
+
+    const res = await request(app)
+      .get('/api/quote')
+      .query({ annualRentNgn, depositPercent })
+      .expect(200)
+
+    const { data } = res.body
+    for (const [term, rate] of Object.entries(INTEREST_TIERS)) {
+      const expected = computeInstallmentSchedule(annualRentNgn, depositPercent, parseInt(term, 10))
+      const tier = data[`installment${term}`]
+      expect(tier.termMonths).toBe(parseInt(term, 10))
+      expect(tier.interestRate).toBe(rate)
+      expect(tier.depositAmount).toBe(expected.depositAmount)
+      expect(tier.monthlyPayment).toBe(expected.monthlyPayment)
+      expect(tier.totalRepayment).toBe(expected.totalRepayment)
+    }
+  })
+
+  it('rejects missing annualRentNgn with 400', async () => {
+    const res = await request(app)
+      .get('/api/quote')
+      .query({})
+      .expect(400)
+
+    expect(res.body.error.code).toBe('VALIDATION_ERROR')
+  })
+
+  it('rejects non-positive annualRentNgn with 400', async () => {
+    const res = await request(app)
+      .get('/api/quote')
+      .query({ annualRentNgn: -1 })
+      .expect(400)
+
+    expect(res.body.error.code).toBe('VALIDATION_ERROR')
+  })
+
+  it('rejects annualRentNgn of zero with 400', async () => {
+    const res = await request(app)
+      .get('/api/quote')
+      .query({ annualRentNgn: 0 })
+      .expect(400)
+
+    expect(res.body.error.code).toBe('VALIDATION_ERROR')
+  })
+
+  it('rejects depositPercent below minimum (0.2) with 400', async () => {
+    const res = await request(app)
+      .get('/api/quote')
+      .query({ annualRentNgn: 2_000_000, depositPercent: 0.1 })
+      .expect(400)
+
+    expect(res.body.error.code).toBe('VALIDATION_ERROR')
+  })
+
+  it('rejects depositPercent above 1 with 400', async () => {
+    const res = await request(app)
+      .get('/api/quote')
+      .query({ annualRentNgn: 2_000_000, depositPercent: 1.5 })
+      .expect(400)
+
+    expect(res.body.error.code).toBe('VALIDATION_ERROR')
+  })
+
+  it('accepts depositPercent of exactly 1 (full upfront)', async () => {
+    const res = await request(app)
+      .get('/api/quote')
+      .query({ annualRentNgn: 1_000_000, depositPercent: 1 })
+      .expect(200)
+
+    expect(res.body.success).toBe(true)
+    expect(res.body.data.outright.balanceDue).toBe(0)
+  })
+
+  it('response shape includes all expected fields on outright tier', async () => {
+    const res = await request(app)
+      .get('/api/quote')
+      .query({ annualRentNgn: 2_000_000 })
+      .expect(200)
+
+    const { outright } = res.body.data
+    expect(outright).toHaveProperty('depositAmount')
+    expect(outright).toHaveProperty('balanceDue')
+    expect(outright).toHaveProperty('totalPayable')
+    expect(outright).toHaveProperty('paymentType', 'outright')
+  })
+
+  it('response shape includes all expected fields on installment tiers', async () => {
+    const res = await request(app)
+      .get('/api/quote')
+      .query({ annualRentNgn: 2_000_000 })
+      .expect(200)
+
+    for (const term of Object.keys(INTEREST_TIERS)) {
+      const tier = res.body.data[`installment${term}`]
+      expect(tier).toHaveProperty('depositAmount')
+      expect(tier).toHaveProperty('financedBalance')
+      expect(tier).toHaveProperty('interestAmount')
+      expect(tier).toHaveProperty('monthlyPayment')
+      expect(tier).toHaveProperty('totalRepayment')
+      expect(tier).toHaveProperty('termMonths')
+      expect(tier).toHaveProperty('interestRate')
+    }
+  })
+})

--- a/backend/src/schemas/listing.ts
+++ b/backend/src/schemas/listing.ts
@@ -79,6 +79,9 @@ export const listingFiltersSchema = z.object({
 
 export type ListingFiltersRequest = z.infer<typeof listingFiltersSchema>
 
+export const propertySearchSchema = listingFiltersSchema.omit({ status: true })
+export type PropertySearchRequest = z.infer<typeof propertySearchSchema>
+
 export const listingSuggestSchema = z.object({
   q: z.string().trim().min(1).max(100),
 })


### PR DESCRIPTION
…#1263, #1264)

# Title
Backend: Route tests for quote, conversion, properties, and public endpoints

# Body
## Summary

- Adds `quote.test.ts` and `conversion.test.ts` resolving #1264
- Adds `properties.test.ts` and `publicRoutes.test.ts` resolving #1263
- Fixes field-exposure boundary in `properties.ts` — strips `whistleblowerId`, `negotiatedLandlordRateNgn`, `reviewedBy`, `reviewedAt`, `rejectionReason`, and `dealId` from public responses
- Exports `propertySearchSchema` from `schemas/listing.ts` (was imported by `properties.ts` but not yet exported)

## What's covered

### `quote.test.ts` (12 tests)
- Valid inputs produce the correct outright breakdown and all three installment tiers (3/6/12 months), verified against the pricing service directly
- `depositPercent` defaults to 0.2
- Validation errors on missing, zero, negative, and out-of-range inputs return `VALIDATION_ERROR`
- Response shape asserts all expected fields (`depositAmount`, `balanceDue`, `monthlyPayment`, `termMonths`, `interestRate`, etc.)

### `conversion.test.ts` (5 tests)
- Happy path: response faithfully passes through `rate`, `source`, `fetchedAt`, `expiresAt` from the service
- Provider error (stale rate / network failure) surfaces as 500, not silently swallowed
- `getRate` called exactly once per request

### `properties.test.ts` (15 tests)
- Approved listings are returned by `/search` and `/:id`
- Private fields (`whistleblowerId`, `negotiatedLandlordRateNgn`, `reviewedBy`, `reviewedAt`, `rejectionReason`, `dealId`) are absent from all public responses
- `pending_review` and `rejected` listings return 404 on `/:id`; search returns 0 results for non-approved
- Filters (bedrooms), pagination (page/pageSize), and param validation (pageSize > 100, page < 1) all tested
- Public field shape asserted (listingId, address, city, area, bedrooms, bathrooms, prices, photos, status, timestamps)

### `publicRoutes.test.ts` (12 tests)
- `/soroban/config` returns exactly `{rpcUrl, networkPassphrase, contractId}` matching env, with `contractId: null` when not set
- `/api/example/echo` echoes message with `receivedAt`; includes `originalTimestamp` when provided, omits it otherwise
- Validation on echo: missing message, empty string, >100 chars, negative timestamp all return `VALIDATION_ERROR`

## Test plan
- [ ] Run `npm run test:ci` in `backend/` — all 44 new tests pass, no regressions introduced
- [ ] Pre-existing `dataRetentionService.test.ts` failure is unrelated and was present before this branch

Closes #1263
Closes #1264

