### PR TITLE
feat: improve landlord payouts view - formatting, drill-down, a11y

### DIFF
--- a/frontend/app/dashboard/landlord/payouts/page.tsx
+++ b/frontend/app/dashboard/landlord/payouts/page.tsx
@@ -1,53 +1,76 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
-import Link from "next/link";
+import { useState, useEffect, useCallback, useMemo } from "react";
+import { useSearchParams, useRouter, usePathname } from "next/navigation";
 import {
-  DollarSign, Search, Filter, X,
-  AlertTriangle, CheckCircle2, Clock, XCircle, MinusCircle, ChevronDown,
-  ChevronUp, TrendingUp, TrendingDown, BarChart3, Calendar,
+  DollarSign, Filter, X,
+  AlertTriangle, ChevronDown, ChevronUp, TrendingUp, TrendingDown,
+  BarChart3, Calendar,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Card } from "@/components/ui/card";
+import {
+  Table, TableHeader, TableBody, TableRow, TableHead, TableCell,
+} from "@/components/ui/table";
 import { DashboardHeader } from "@/components/dashboard-header";
 import { DashboardSidebar } from "@/components/dashboard/DashboardSidebar";
 import { PayoutDrillDown } from "@/components/landlord/payout-drill-down";
 import {
-  getPayoutSchedule, getPayoutDetail,
-  formatCurrency, formatPeriodLabel,
+  getPayoutSchedule,
+  formatCurrency, formatPayoutDate, formatPeriodLabel,
   DELAY_REASON_LABELS, PAYOUT_STATUS_LABELS, PAYOUT_CHANNEL_LABELS,
   type PayoutPeriod, type PayoutScheduleSummary, type LandlordPayout,
   type PayoutStatus, type PayoutChannel, type PayoutGrouping,
 } from "@/lib/landlordPayoutApi";
 
-const STATUSES: PayoutStatus[] = ["scheduled", "processing", "completed", "delayed", "failed", "on_hold"];
-const CHANNELS: PayoutChannel[] = ["bank_transfer", "mobile_money", "crypto_wallet", "check"];
+const STATUSES: PayoutStatus[] = [
+  "scheduled", "processing", "completed", "delayed", "failed", "on_hold",
+];
+const CHANNELS: PayoutChannel[] = [
+  "bank_transfer", "mobile_money", "crypto_wallet", "check",
+];
+
+const STATUS_CLASSES: Record<PayoutStatus, string> = {
+  scheduled: "bg-blue-100 text-blue-800 border-blue-300",
+  processing: "bg-indigo-100 text-indigo-800 border-indigo-300",
+  completed: "bg-green-100 text-green-800 border-green-300",
+  delayed: "bg-amber-100 text-amber-800 border-amber-300",
+  failed: "bg-red-100 text-red-800 border-red-300",
+  on_hold: "bg-gray-100 text-gray-800 border-gray-300",
+};
 
 function StatusBadge({ status }: { status: PayoutStatus }) {
-  const cfg: Record<PayoutStatus, string> = {
-    scheduled: "bg-blue-100 text-blue-800 border-blue-300",
-    processing: "bg-indigo-100 text-indigo-800 border-indigo-300",
-    completed: "bg-green-100 text-green-800 border-green-300",
-    delayed: "bg-amber-100 text-amber-800 border-amber-300",
-    failed: "bg-red-100 text-red-800 border-red-300",
-    on_hold: "bg-gray-100 text-gray-800 border-gray-300",
-  };
-  return <Badge className={`text-xs font-bold ${cfg[status]}`}>{PAYOUT_STATUS_LABELS[status]}</Badge>;
+  return (
+    <Badge
+      className={`text-xs font-bold ${STATUS_CLASSES[status]}`}
+      aria-label={`Status: ${PAYOUT_STATUS_LABELS[status]}`}
+    >
+      {PAYOUT_STATUS_LABELS[status]}
+    </Badge>
+  );
 }
 
 export default function LandlordPayoutSchedulePage() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const drillPayoutId = searchParams.get("payout");
+
   const [periods, setPeriods] = useState<PayoutPeriod[]>([]);
   const [summary, setSummary] = useState<PayoutScheduleSummary | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [statusFilter, setStatusFilter] = useState<PayoutStatus | "">("");
-  const [channelFilter, setChannelFilter] = useState<PayoutChannel | "">("");
-  const [grouping, setGrouping] = useState<PayoutGrouping>("monthly");
+  const [statusFilter, setStatusFilter] = useState<PayoutStatus | "">(
+    (searchParams.get("status") as PayoutStatus) || "",
+  );
+  const [channelFilter, setChannelFilter] = useState<PayoutChannel | "">(
+    (searchParams.get("channel") as PayoutChannel) || "",
+  );
+  const [grouping, setGrouping] = useState<PayoutGrouping>(
+    (searchParams.get("grouping") as PayoutGrouping) || "monthly",
+  );
   const [expandedPeriod, setExpandedPeriod] = useState<string | null>(null);
-  // Drill-down state
-  const [drillPayout, setDrillPayout] = useState<LandlordPayout | null>(null);
-  const [drillLoading, setDrillLoading] = useState(false);
 
   const fetchData = useCallback(async () => {
     setLoading(true);
@@ -69,17 +92,64 @@ export default function LandlordPayoutSchedulePage() {
 
   useEffect(() => { fetchData(); }, [fetchData]);
 
-  const handleDrillDown = async (payout: LandlordPayout) => {
-    setDrillLoading(true);
-    try {
-      const result = await getPayoutDetail(payout.id);
-      setDrillPayout(result.data);
-    } catch {
-      setDrillPayout(payout);
-    } finally {
-      setDrillLoading(false);
+  const handleDrillDown = useCallback((payoutId: string) => {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set("payout", payoutId);
+    router.push(`${pathname}?${params.toString()}`, { scroll: false });
+  }, [router, pathname, searchParams]);
+
+  const closeDrillDown = useCallback(() => {
+    const params = new URLSearchParams(searchParams.toString());
+    params.delete("payout");
+    const qs = params.toString();
+    router.push(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
+  }, [router, pathname, searchParams]);
+
+  const handleFilterChange = useCallback((setter: (v: any) => void) => (value: any) => {
+    setter(value);
+    // Update URL params for filters
+    const params = new URLSearchParams(searchParams.toString());
+    if (value) {
+      params.set("status", statusFilter || "");
+      params.set("channel", channelFilter || "");
     }
-  };
+  }, [searchParams, statusFilter, channelFilter]);
+
+  const summaryCards = useMemo(() => {
+    if (!summary) return null;
+    return (
+      <div className="mb-6 grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+        <Card className="border-3 border-foreground p-4 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
+          <div className="flex items-center gap-2 text-sm font-bold uppercase text-muted-foreground">
+            <TrendingUp className="h-4 w-4" aria-hidden="true" />Gross Total
+          </div>
+          <p className="mt-1 text-2xl font-bold">{formatCurrency(summary.totalGross, summary.currency)}</p>
+        </Card>
+        <Card className="border-3 border-foreground p-4 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
+          <div className="flex items-center gap-2 text-sm font-bold uppercase text-muted-foreground">
+            <TrendingDown className="h-4 w-4" aria-hidden="true" />Total Deductions
+          </div>
+          <p className="mt-1 text-2xl font-bold text-red-600">
+            -{formatCurrency(summary.totalDeductions, summary.currency)}
+          </p>
+        </Card>
+        <Card className="border-3 border-foreground p-4 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
+          <div className="flex items-center gap-2 text-sm font-bold uppercase text-muted-foreground">
+            <DollarSign className="h-4 w-4" aria-hidden="true" />Net Payout
+          </div>
+          <p className="mt-1 text-2xl font-bold text-green-700">{formatCurrency(summary.totalNet, summary.currency)}</p>
+        </Card>
+        <Card className="border-3 border-foreground p-4 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
+          <div className="flex items-center gap-2 text-sm font-bold uppercase text-muted-foreground">
+            <AlertTriangle className="h-4 w-4" aria-hidden="true" />Delayed / On Hold
+          </div>
+          <p className="mt-1 text-2xl font-bold text-amber-600">
+            {summary.delayedPayouts} / {summary.onHoldPayouts}
+          </p>
+        </Card>
+      </div>
+    );
+  }, [summary]);
 
   return (
     <div className="min-h-screen bg-background">
@@ -100,61 +170,60 @@ export default function LandlordPayoutSchedulePage() {
           </div>
 
           {/* Summary Cards */}
-          {summary && (
-            <div className="mb-6 grid gap-4 md:grid-cols-2 lg:grid-cols-4">
-              <Card className="border-3 border-foreground p-4 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
-                <div className="flex items-center gap-2 text-sm font-bold uppercase text-muted-foreground">
-                  <TrendingUp className="h-4 w-4" />Gross Total
-                </div>
-                <p className="mt-1 text-2xl font-bold">{formatCurrency(summary.totalGross, summary.currency)}</p>
-              </Card>
-              <Card className="border-3 border-foreground p-4 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
-                <div className="flex items-center gap-2 text-sm font-bold uppercase text-muted-foreground">
-                  <TrendingDown className="h-4 w-4" />Total Deductions
-                </div>
-                <p className="mt-1 text-2xl font-bold text-red-600">-{formatCurrency(summary.totalDeductions, summary.currency)}</p>
-              </Card>
-              <Card className="border-3 border-foreground p-4 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
-                <div className="flex items-center gap-2 text-sm font-bold uppercase text-muted-foreground">
-                  <DollarSign className="h-4 w-4" />Net Payout
-                </div>
-                <p className="mt-1 text-2xl font-bold text-green-700">{formatCurrency(summary.totalNet, summary.currency)}</p>
-              </Card>
-              <Card className="border-3 border-foreground p-4 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
-                <div className="flex items-center gap-2 text-sm font-bold uppercase text-muted-foreground">
-                  <AlertTriangle className="h-4 w-4" />Delayed / On Hold
-                </div>
-                <p className="mt-1 text-2xl font-bold text-amber-600">{summary.delayedPayouts} / {summary.onHoldPayouts}</p>
-              </Card>
-            </div>
-          )}
+          {summaryCards}
 
           {/* Filters */}
           <Card className="mb-6 border-3 border-foreground p-4 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] md:p-6">
             <div className="flex flex-col gap-4 md:flex-row md:items-end">
               <div className="w-full md:w-44">
-                <label className="mb-1 block text-sm font-bold"><Filter className="mr-1 inline h-3.5 w-3.5" />Status</label>
-                <select value={statusFilter} onChange={(e) => setStatusFilter(e.target.value as PayoutStatus | "")} className="w-full border-3 border-foreground bg-background px-3 py-2 text-sm shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] focus:outline-none">
+                <label htmlFor="status-filter" className="mb-1 block text-sm font-bold">
+                  <Filter className="mr-1 inline h-3.5 w-3.5" aria-hidden="true" />Status
+                </label>
+                <select
+                  id="status-filter"
+                  value={statusFilter}
+                  onChange={(e) => setStatusFilter(e.target.value as PayoutStatus | "")}
+                  className="w-full border-3 border-foreground bg-background px-3 py-2 text-sm shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] focus:outline-none"
+                >
                   <option value="">All Statuses</option>
                   {STATUSES.map((s) => <option key={s} value={s}>{PAYOUT_STATUS_LABELS[s]}</option>)}
                 </select>
               </div>
               <div className="w-full md:w-44">
-                <label className="mb-1 block text-sm font-bold"><Filter className="mr-1 inline h-3.5 w-3.5" />Channel</label>
-                <select value={channelFilter} onChange={(e) => setChannelFilter(e.target.value as PayoutChannel | "")} className="w-full border-3 border-foreground bg-background px-3 py-2 text-sm shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] focus:outline-none">
+                <label htmlFor="channel-filter" className="mb-1 block text-sm font-bold">
+                  <Filter className="mr-1 inline h-3.5 w-3.5" aria-hidden="true" />Channel
+                </label>
+                <select
+                  id="channel-filter"
+                  value={channelFilter}
+                  onChange={(e) => setChannelFilter(e.target.value as PayoutChannel | "")}
+                  className="w-full border-3 border-foreground bg-background px-3 py-2 text-sm shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] focus:outline-none"
+                >
                   <option value="">All Channels</option>
                   {CHANNELS.map((c) => <option key={c} value={c}>{PAYOUT_CHANNEL_LABELS[c]}</option>)}
                 </select>
               </div>
               <div className="w-full md:w-40">
-                <label className="mb-1 block text-sm font-bold"><Calendar className="mr-1 inline h-3.5 w-3.5" />Grouping</label>
-                <select value={grouping} onChange={(e) => setGrouping(e.target.value as PayoutGrouping)} className="w-full border-3 border-foreground bg-background px-3 py-2 text-sm shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] focus:outline-none">
+                <label htmlFor="grouping" className="mb-1 block text-sm font-bold">
+                  <Calendar className="mr-1 inline h-3.5 w-3.5" aria-hidden="true" />Grouping
+                </label>
+                <select
+                  id="grouping"
+                  value={grouping}
+                  onChange={(e) => setGrouping(e.target.value as PayoutGrouping)}
+                  className="w-full border-3 border-foreground bg-background px-3 py-2 text-sm shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] focus:outline-none"
+                >
                   <option value="monthly">Monthly</option>
                   <option value="weekly">Weekly</option>
                 </select>
               </div>
               {(statusFilter || channelFilter) && (
-                <Button variant="outline" onClick={() => { setStatusFilter(""); setChannelFilter(""); }} className="border-2 border-foreground font-bold">
+                <Button
+                  variant="outline"
+                  onClick={() => { setStatusFilter(""); setChannelFilter(""); }}
+                  className="border-2 border-foreground font-bold"
+                  aria-label="Clear all filters"
+                >
                   <X className="mr-1 h-4 w-4" />Clear
                 </Button>
               )}
@@ -163,113 +232,40 @@ export default function LandlordPayoutSchedulePage() {
 
           {/* Timeline */}
           {loading ? (
-            <div className="space-y-4">
+            <div className="space-y-4" role="status" aria-label="Loading payout schedule">
+              <p className="sr-only">Loading payout schedule...</p>
               {Array.from({ length: 3 }).map((_, i) => (
                 <Card key={i} className="animate-pulse border-3 border-foreground p-6 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
-                  <div className="h-6 w-32 bg-muted" />
-                  <div className="mt-4 h-4 w-48 bg-muted" />
+                  <div className="h-6 w-32 bg-muted rounded" />
+                  <div className="mt-4 h-4 w-48 bg-muted rounded" />
                 </Card>
               ))}
             </div>
           ) : error ? (
-            <Card className="border-3 border-destructive p-6 text-center">
-              <XCircle className="mx-auto h-12 w-12 text-destructive" />
+            <Card className="border-3 border-destructive p-6 text-center" role="alert">
               <p className="mt-4 font-bold text-destructive">{error}</p>
-              <Button onClick={fetchData} className="mt-4 border-2 border-foreground font-bold">Retry</Button>
+              <Button onClick={fetchData} className="mt-4 border-2 border-foreground font-bold" aria-label="Retry loading payout schedule">
+                Retry
+              </Button>
             </Card>
           ) : periods.length === 0 ? (
             <Card className="border-3 border-foreground p-8 text-center shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
-              <BarChart3 className="mx-auto h-16 w-16 text-muted-foreground" />
+              <BarChart3 className="mx-auto h-16 w-16 text-muted-foreground" aria-hidden="true" />
               <p className="mt-4 text-lg font-bold">No payouts scheduled</p>
               <p className="mt-2 text-sm text-muted-foreground">
                 {statusFilter || channelFilter ? "Try adjusting your filters" : "Payouts will appear here once scheduled"}
               </p>
             </Card>
           ) : (
-            <div className="space-y-4">
+            <div className="space-y-4" role="list" aria-label="Payout periods">
               {periods.map((period) => (
-                <Card key={period.periodLabel} className="border-3 border-foreground shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
-                  {/* Period Header */}
-                  <button
-                    onClick={() => setExpandedPeriod(expandedPeriod === period.periodLabel ? null : period.periodLabel)}
-                    className="flex w-full items-center justify-between p-4 text-left"
-                  >
-                    <div className="flex items-center gap-3">
-                      <Calendar className="h-5 w-5 text-muted-foreground" />
-                      <span className="text-lg font-bold">{formatPeriodLabel(period.periodLabel)}</span>
-                      {period.delayedCount > 0 && (
-                        <Badge className="border-amber-300 bg-amber-100 text-xs font-bold text-amber-800">
-                          <AlertTriangle className="mr-1 h-3 w-3" />{period.delayedCount} delayed
-                        </Badge>
-                      )}
-                    </div>
-                    <div className="flex items-center gap-6">
-                      <div className="text-right">
-                        <p className="text-xs font-bold uppercase text-muted-foreground">Net</p>
-                        <p className="font-bold text-green-700">{formatCurrency(period.netTotal)}</p>
-                      </div>
-                      <div className="text-right">
-                        <p className="text-xs font-bold uppercase text-muted-foreground">Gross</p>
-                        <p className="font-bold">{formatCurrency(period.grossTotal)}</p>
-                      </div>
-                      {expandedPeriod === period.periodLabel ? <ChevronUp className="h-5 w-5" /> : <ChevronDown className="h-5 w-5" />}
-                    </div>
-                  </button>
-
-                  {/* Period Summary Bar */}
-                  <div className="border-t-2 border-foreground/10 bg-muted/30 px-4 py-3">
-                    <div className="grid grid-cols-4 gap-4 text-center text-sm">
-                      <div>
-                        <p className="font-bold text-muted-foreground">Payouts</p>
-                        <p className="font-bold">{period.payoutCount}</p>
-                      </div>
-                      <div>
-                        <p className="font-bold text-muted-foreground">Gross</p>
-                        <p className="font-bold">{formatCurrency(period.grossTotal)}</p>
-                      </div>
-                      <div>
-                        <p className="font-bold text-red-600">Deductions</p>
-                        <p className="font-bold text-red-600">-{formatCurrency(period.deductionsTotal)}</p>
-                      </div>
-                      <div>
-                        <p className="font-bold text-green-700">Net</p>
-                        <p className="font-bold text-green-700">{formatCurrency(period.netTotal)}</p>
-                      </div>
-                    </div>
-                  </div>
-
-                  {/* Expanded Payout List */}
-                  {expandedPeriod === period.periodLabel && (
-                    <div className="border-t-2 border-foreground/10">
-                      {period.payouts.map((payout) => (
-                        <button
-                          key={payout.id}
-                          onClick={() => handleDrillDown(payout)}
-                          className="flex w-full items-center justify-between border-b border-foreground/5 px-4 py-3 text-left transition-colors hover:bg-muted/50 last:border-0"
-                        >
-                          <div className="flex items-center gap-3">
-                            <StatusBadge status={payout.status} />
-                            <div>
-                              <p className="font-bold">{payout.propertyName}</p>
-                              <p className="text-xs text-muted-foreground">
-                                {new Date(payout.scheduledDate).toLocaleDateString()}
-                                {payout.delayReasons.length > 0 && (
-                                  <span className="ml-2 text-amber-600">
-                                    — {payout.delayReasons.map(r => DELAY_REASON_LABELS[r as keyof typeof DELAY_REASON_LABELS]).join(", ")}
-                                  </span>
-                                )}
-                              </p>
-                            </div>
-                          </div>
-                          <div className="text-right">
-                            <p className="font-bold">{formatCurrency(payout.netAmount, payout.currency)}</p>
-                            <p className="text-xs text-muted-foreground">{formatCurrency(payout.grossAmount, payout.currency)} gross</p>
-                          </div>
-                        </button>
-                      ))}
-                    </div>
-                  )}
-                </Card>
+                <PeriodCard
+                  key={period.periodLabel}
+                  period={period}
+                  expanded={expandedPeriod === period.periodLabel}
+                  onToggle={() => setExpandedPeriod(expandedPeriod === period.periodLabel ? null : period.periodLabel)}
+                  onDrillDown={handleDrillDown}
+                />
               ))}
             </div>
           )}
@@ -277,12 +273,140 @@ export default function LandlordPayoutSchedulePage() {
       </main>
 
       {/* Drill-down Modal */}
-      {(drillPayout || drillLoading) && (
+      {drillPayoutId && (
         <PayoutDrillDown
-          payout={drillPayout}
-          onClose={() => setDrillPayout(null)}
+          payoutId={drillPayoutId}
+          onClose={closeDrillDown}
         />
       )}
     </div>
+  );
+}
+
+/* ── Period Card ──────────────────────────────────────────────────────────── */
+
+function PeriodCard({
+  period,
+  expanded,
+  onToggle,
+  onDrillDown,
+}: {
+  period: PayoutPeriod;
+  expanded: boolean;
+  onToggle: () => void;
+  onDrillDown: (payoutId: string) => void;
+}) {
+  return (
+    <Card
+      className="border-3 border-foreground shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]"
+      role="listitem"
+    >
+      {/* Period Header */}
+      <button
+        onClick={onToggle}
+        className="flex w-full items-center justify-between p-4 text-left"
+        aria-expanded={expanded}
+        aria-controls={`period-${period.periodLabel}`}
+      >
+        <div className="flex items-center gap-3">
+          <Calendar className="h-5 w-5 text-muted-foreground" aria-hidden="true" />
+          <span className="text-lg font-bold">{formatPeriodLabel(period.periodLabel)}</span>
+          {period.delayedCount > 0 && (
+            <Badge
+              className="border-amber-300 bg-amber-100 text-xs font-bold text-amber-800"
+              aria-label={`${period.delayedCount} delayed payout${period.delayedCount > 1 ? "s" : ""}`}
+            >
+              <AlertTriangle className="mr-1 h-3 w-3" aria-hidden="true" />{period.delayedCount} delayed
+            </Badge>
+          )}
+        </div>
+        <div className="flex items-center gap-6">
+          <div className="text-right">
+            <p className="text-xs font-bold uppercase text-muted-foreground">Net</p>
+            <p className="font-bold text-green-700">{formatCurrency(period.netTotal)}</p>
+          </div>
+          <div className="text-right">
+            <p className="text-xs font-bold uppercase text-muted-foreground">Gross</p>
+            <p className="font-bold">{formatCurrency(period.grossTotal)}</p>
+          </div>
+          {expanded
+            ? <ChevronUp className="h-5 w-5" aria-hidden="true" />
+            : <ChevronDown className="h-5 w-5" aria-hidden="true" />}
+        </div>
+      </button>
+
+      {/* Period Summary Bar */}
+      <div className="border-t-2 border-foreground/10 bg-muted/30 px-4 py-3">
+        <div className="grid grid-cols-4 gap-4 text-center text-sm">
+          <div>
+            <p className="font-bold text-muted-foreground">Payouts</p>
+            <p className="font-bold">{period.payoutCount}</p>
+          </div>
+          <div>
+            <p className="font-bold text-muted-foreground">Gross</p>
+            <p className="font-bold">{formatCurrency(period.grossTotal)}</p>
+          </div>
+          <div>
+            <p className="font-bold text-red-600">Deductions</p>
+            <p className="font-bold text-red-600">-{formatCurrency(period.deductionsTotal)}</p>
+          </div>
+          <div>
+            <p className="font-bold text-green-700">Net</p>
+            <p className="font-bold text-green-700">{formatCurrency(period.netTotal)}</p>
+          </div>
+        </div>
+      </div>
+
+      {/* Expanded Payout Table */}
+      {expanded && (
+        <div
+          id={`period-${period.periodLabel}`}
+          className="border-t-2 border-foreground/10"
+        >
+          <Table aria-label={`Payouts for ${formatPeriodLabel(period.periodLabel)}`}>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-[120px]">Status</TableHead>
+                <TableHead>Property</TableHead>
+                <TableHead className="text-right">Net</TableHead>
+                <TableHead className="text-right">Gross</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {period.payouts.map((payout) => (
+                <TableRow key={payout.id}>
+                  <TableCell>
+                    <StatusBadge status={payout.status} />
+                  </TableCell>
+                  <TableCell>
+                    <button
+                      onClick={() => onDrillDown(payout.id)}
+                      className="text-left font-bold hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                      aria-label={`View payout details for ${payout.propertyName}`}
+                    >
+                      {payout.propertyName}
+                    </button>
+                    <p className="text-xs text-muted-foreground">
+                      {formatPayoutDate(payout.scheduledDate)}
+                      {payout.delayReasons.length > 0 && (
+                        <span className="ml-2 text-amber-600">
+                          &mdash; {payout.delayReasons.map((r) => DELAY_REASON_LABELS[r as keyof typeof DELAY_REASON_LABELS]).join(", ")}
+                        </span>
+                      )}
+                    </p>
+                  </TableCell>
+                  <TableCell className="text-right font-bold text-green-700">
+                    {formatCurrency(payout.netAmount, payout.currency)}
+                  </TableCell>
+                  <TableCell className="text-right text-sm text-muted-foreground">
+                    {formatCurrency(payout.grossAmount, payout.currency)}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+    </Card>
   );
 }

--- a/frontend/components/landlord/PayoutScheduleSelector.tsx
+++ b/frontend/components/landlord/PayoutScheduleSelector.tsx
@@ -1,11 +1,18 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useRef, useEffect } from "react";
 import * as RadioGroup from "@radix-ui/react-radio-group";
 import { toast } from "sonner";
-import { Loader2 } from "lucide-react";
+import { Loader2, AlertTriangle } from "lucide-react";
+import { Button } from "@/components/ui/button";
 
 export type PayoutSchedule = "activation" | "weekly" | "monthly";
+
+const SCHEDULE_LABELS: Record<PayoutSchedule, string> = {
+  activation: "On Deal Activation",
+  weekly: "Weekly",
+  monthly: "Monthly",
+};
 
 interface PayoutScheduleSelectorProps {
   initialSchedule?: PayoutSchedule;
@@ -16,27 +23,43 @@ export function PayoutScheduleSelector({
 }: PayoutScheduleSelectorProps) {
   const [schedule, setSchedule] = useState<PayoutSchedule>(initialSchedule);
   const [isSaving, setIsSaving] = useState(false);
+  const [pendingValue, setPendingValue] = useState<PayoutSchedule | null>(null);
+  const confirmDialogRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!pendingValue) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setPendingValue(null);
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    confirmDialogRef.current?.focus();
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [pendingValue]);
 
   const handleScheduleChange = async (value: string) => {
     const newSchedule = value as PayoutSchedule;
+    if (newSchedule === schedule) return;
+    setPendingValue(newSchedule);
+  };
+
+  const confirmChange = async () => {
+    if (!pendingValue) return;
+    const newSchedule = pendingValue;
+    setPendingValue(null);
     setSchedule(newSchedule);
     setIsSaving(true);
 
     try {
       const response = await fetch("/api/landlord/payout/preferences", {
         method: "PATCH",
-        headers: {
-          "Content-Type": "application/json",
-        },
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ schedule: newSchedule }),
       });
 
       if (!response.ok) throw new Error("Failed to update preferences");
-      
-      toast.success("Payout schedule updated successfully");
-    } catch (error) {
+      toast.success(`Payout schedule changed to ${SCHEDULE_LABELS[newSchedule]}`);
+    } catch {
       toast.error("Failed to update payout schedule. Please try again.");
-      // Optionally revert to original state
       setSchedule(initialSchedule);
     } finally {
       setIsSaving(false);
@@ -54,7 +77,7 @@ export function PayoutScheduleSelector({
             Choose when you want to receive your payouts.
           </p>
         </div>
-        {isSaving && <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />}
+        {isSaving && <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" aria-label="Saving" />}
       </div>
 
       <RadioGroup.Root
@@ -62,61 +85,71 @@ export function PayoutScheduleSelector({
         value={schedule}
         onValueChange={handleScheduleChange}
         disabled={isSaving}
+        aria-label="Payout schedule frequency"
       >
-        <div className="flex items-center space-x-2">
-          <RadioGroup.Item
-            value="activation"
-            id="activation"
-            className="peer h-4 w-4 rounded-full border border-primary text-primary shadow focus:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary"
-          >
-            <RadioGroup.Indicator className="flex items-center justify-center">
-              <div className="h-2 w-2 rounded-full bg-primary-foreground" />
-            </RadioGroup.Indicator>
-          </RadioGroup.Item>
-          <label
-            htmlFor="activation"
-            className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
-          >
-            On Deal Activation
-          </label>
-        </div>
-        
-        <div className="flex items-center space-x-2">
-          <RadioGroup.Item
-            value="weekly"
-            id="weekly"
-            className="peer h-4 w-4 rounded-full border border-primary text-primary shadow focus:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary"
-          >
-            <RadioGroup.Indicator className="flex items-center justify-center">
-              <div className="h-2 w-2 rounded-full bg-primary-foreground" />
-            </RadioGroup.Indicator>
-          </RadioGroup.Item>
-          <label
-            htmlFor="weekly"
-            className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
-          >
-            Weekly
-          </label>
-        </div>
-
-        <div className="flex items-center space-x-2">
-          <RadioGroup.Item
-            value="monthly"
-            id="monthly"
-            className="peer h-4 w-4 rounded-full border border-primary text-primary shadow focus:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary"
-          >
-            <RadioGroup.Indicator className="flex items-center justify-center">
-              <div className="h-2 w-2 rounded-full bg-primary-foreground" />
-            </RadioGroup.Indicator>
-          </RadioGroup.Item>
-          <label
-            htmlFor="monthly"
-            className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
-          >
-            Monthly
-          </label>
-        </div>
+        {(["activation", "weekly", "monthly"] as PayoutSchedule[]).map((option) => (
+          <div key={option} className="flex items-center space-x-2">
+            <RadioGroup.Item
+              value={option}
+              id={option}
+              className="peer h-4 w-4 rounded-full border border-primary text-primary shadow focus:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary"
+            >
+              <RadioGroup.Indicator className="flex items-center justify-center">
+                <div className="h-2 w-2 rounded-full bg-primary-foreground" />
+              </RadioGroup.Indicator>
+            </RadioGroup.Item>
+            <label
+              htmlFor={option}
+              className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+            >
+              {SCHEDULE_LABELS[option]}
+            </label>
+          </div>
+        ))}
       </RadioGroup.Root>
+
+      {/* Confirmation Dialog */}
+      {pendingValue && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-foreground/50 p-4"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Confirm schedule change"
+          onClick={(e) => { if (e.target === e.currentTarget) setPendingValue(null); }}
+        >
+          <div
+            ref={confirmDialogRef}
+            tabIndex={-1}
+            className="w-full max-w-sm rounded-lg border-3 border-foreground bg-card p-6 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] focus:outline-none"
+          >
+            <div className="flex items-center gap-3">
+              <AlertTriangle className="h-6 w-6 text-amber-600" aria-hidden="true" />
+              <h4 className="text-lg font-bold">Change payout schedule?</h4>
+            </div>
+            <p className="mt-3 text-sm text-muted-foreground">
+              This will change your payout frequency from{" "}
+              <strong>{SCHEDULE_LABELS[schedule]}</strong> to{" "}
+              <strong>{SCHEDULE_LABELS[pendingValue]}</strong>.
+              Changes take effect for upcoming payouts.
+            </p>
+            <div className="mt-6 flex justify-end gap-3">
+              <Button
+                variant="outline"
+                onClick={() => setPendingValue(null)}
+                className="border-2 border-foreground font-bold"
+              >
+                Cancel
+              </Button>
+              <Button
+                onClick={confirmChange}
+                className="border-2 border-foreground font-bold"
+              >
+                Confirm change
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/components/landlord/payout-drill-down.tsx
+++ b/frontend/components/landlord/payout-drill-down.tsx
@@ -1,153 +1,293 @@
 "use client";
 
-import { X, AlertTriangle, Clock, CheckCircle2, XCircle, MinusCircle, ChevronDown, ChevronUp } from "lucide-react";
+import { useEffect, useRef, useCallback, useState } from "react";
+import {
+  X, AlertTriangle, Clock, CheckCircle2, XCircle, MinusCircle,
+  ChevronDown, ChevronUp, Loader2, RotateCcw,
+} from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Card } from "@/components/ui/card";
 import {
-  formatCurrency,
-  DELAY_REASON_LABELS,
-  DEDUCTION_TYPE_LABELS,
-  PAYOUT_STATUS_LABELS,
-  PAYOUT_CHANNEL_LABELS,
+  getPayoutDetail,
+  formatCurrency, formatPayoutDate, formatPayoutDateTime,
+  DELAY_REASON_LABELS, DEDUCTION_TYPE_LABELS,
+  PAYOUT_STATUS_LABELS, PAYOUT_CHANNEL_LABELS,
   type LandlordPayout,
 } from "@/lib/landlordPayoutApi";
-import { useState } from "react";
 
 interface PayoutDrillDownProps {
-  payout: LandlordPayout | null;
+  payoutId: string;
   onClose: () => void;
 }
 
-function StatusIcon({ status }: { status: string }) {
+function StatusIcon({ status, className = "" }: { status: string; className?: string }) {
+  const srLabel = PAYOUT_STATUS_LABELS[status as keyof typeof PAYOUT_STATUS_LABELS] ?? status;
   switch (status) {
-    case "completed": return <CheckCircle2 className="h-5 w-5 text-green-600" />;
-    case "delayed": return <AlertTriangle className="h-5 w-5 text-amber-600" />;
-    case "failed": return <XCircle className="h-5 w-5 text-red-600" />;
-    case "on_hold": return <MinusCircle className="h-5 w-5 text-blue-600" />;
-    default: return <Clock className="h-5 w-5 text-muted-foreground" />;
+    case "completed":
+      return <CheckCircle2 className={`h-5 w-5 text-green-600 ${className}`} aria-hidden="true" />;
+    case "delayed":
+      return <AlertTriangle className={`h-5 w-5 text-amber-600 ${className}`} aria-hidden="true" />;
+    case "failed":
+      return <XCircle className={`h-5 w-5 text-red-600 ${className}`} aria-hidden="true" />;
+    case "on_hold":
+      return <MinusCircle className={`h-5 w-5 text-blue-600 ${className}`} aria-hidden="true" />;
+    default:
+      return <Clock className={`h-5 w-5 text-muted-foreground ${className}`} aria-hidden="true" />;
   }
 }
 
-export function PayoutDrillDown({ payout, onClose }: PayoutDrillDownProps) {
+const STATUS_CLASSES: Record<string, string> = {
+  scheduled: "bg-blue-100 text-blue-800 border-blue-300",
+  processing: "bg-indigo-100 text-indigo-800 border-indigo-300",
+  completed: "bg-green-100 text-green-800 border-green-300",
+  delayed: "bg-amber-100 text-amber-800 border-amber-300",
+  failed: "bg-red-100 text-red-800 border-red-300",
+  on_hold: "bg-gray-100 text-gray-800 border-gray-300",
+};
+
+export function PayoutDrillDown({ payoutId, onClose }: PayoutDrillDownProps) {
+  const [payout, setPayout] = useState<LandlordPayout | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
   const [deductionsOpen, setDeductionsOpen] = useState(true);
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
 
-  if (!payout) return null;
+  const fetchDetail = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await getPayoutDetail(payoutId);
+      setPayout(result.data);
+    } catch (err: any) {
+      setError(err?.message || "Failed to load payout details");
+    } finally {
+      setLoading(false);
+    }
+  }, [payoutId]);
 
-  const statusConfig: Record<string, string> = {
-    scheduled: "bg-blue-100 text-blue-800 border-blue-300",
-    processing: "bg-indigo-100 text-indigo-800 border-indigo-300",
-    completed: "bg-green-100 text-green-800 border-green-300",
-    delayed: "bg-amber-100 text-amber-800 border-amber-300",
-    failed: "bg-red-100 text-red-800 border-red-300",
-    on_hold: "bg-gray-100 text-gray-800 border-gray-300",
-  };
+  useEffect(() => {
+    previousFocusRef.current = document.activeElement as HTMLElement;
+    fetchDetail();
+  }, [fetchDetail]);
+
+  // Focus trap + Escape key
+  useEffect(() => {
+    if (loading) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onClose();
+        return;
+      }
+      if (e.key !== "Tab" || !dialogRef.current) return;
+      const focusable = dialogRef.current.querySelectorAll<HTMLElement>(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+      );
+      if (focusable.length === 0) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    // Auto-focus the dialog
+    dialogRef.current?.focus();
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      previousFocusRef.current?.focus();
+    };
+  }, [loading, onClose]);
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-foreground/50 p-4">
-      <Card className="max-h-[90vh] w-full max-w-2xl overflow-y-auto border-3 border-foreground bg-card p-6 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-foreground/50 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Payout details"
+      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+    >
+      <Card
+        ref={dialogRef}
+        tabIndex={-1}
+        className="max-h-[90vh] w-full max-w-2xl overflow-y-auto border-3 border-foreground bg-card p-6 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] focus:outline-none"
+      >
+        {/* Header */}
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
-            <StatusIcon status={payout.status} />
+            {!loading && payout && <StatusIcon status={payout.status} />}
             <h3 className="text-lg font-bold">Payout Details</h3>
           </div>
-          <Button size="sm" variant="outline" onClick={onClose} className="border-2 border-foreground font-bold">
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={onClose}
+            className="border-2 border-foreground font-bold"
+            aria-label="Close payout details"
+          >
             Close
           </Button>
         </div>
 
-        {/* Header Info */}
-        <div className="mt-4 border-3 border-foreground bg-muted p-4">
-          <div className="flex items-center justify-between">
-            <div>
-              <p className="font-bold">{payout.propertyName}</p>
-              <p className="text-sm text-muted-foreground">
-                {new Date(payout.periodStart).toLocaleDateString()} — {new Date(payout.periodEnd).toLocaleDateString()}
-              </p>
+        {/* Loading state */}
+        {loading && (
+          <div className="mt-6 space-y-4" role="status" aria-label="Loading payout details">
+            <p className="sr-only">Loading payout details...</p>
+            <div className="flex items-center justify-center py-8">
+              <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" aria-hidden="true" />
             </div>
-            <Badge className={`text-xs font-bold ${statusConfig[payout.status] || ""}`}>
-              {PAYOUT_STATUS_LABELS[payout.status]}
-            </Badge>
-          </div>
-          <div className="mt-3 grid grid-cols-3 gap-4 text-center">
-            <div>
-              <p className="text-xs font-bold uppercase text-muted-foreground">Gross</p>
-              <p className="text-lg font-bold">{formatCurrency(payout.grossAmount, payout.currency)}</p>
-            </div>
-            <div>
-              <p className="text-xs font-bold uppercase text-muted-foreground">Deductions</p>
-              <p className="text-lg font-bold text-red-600">-{formatCurrency(payout.deductions.reduce((s, d) => s + d.amount, 0), payout.currency)}</p>
-            </div>
-            <div>
-              <p className="text-xs font-bold uppercase text-muted-foreground">Net</p>
-              <p className="text-lg font-bold text-green-700">{formatCurrency(payout.netAmount, payout.currency)}</p>
-            </div>
-          </div>
-        </div>
-
-        {/* Channel & Dates */}
-        <div className="mt-4 grid grid-cols-2 gap-3">
-          <div className="border-2 border-foreground/20 p-3">
-            <p className="text-xs font-bold uppercase text-muted-foreground">Payout Channel</p>
-            <p className="font-bold">{PAYOUT_CHANNEL_LABELS[payout.channel]}</p>
-          </div>
-          <div className="border-2 border-foreground/20 p-3">
-            <p className="text-xs font-bold uppercase text-muted-foreground">Scheduled Date</p>
-            <p className="font-bold">{new Date(payout.scheduledDate).toLocaleDateString()}</p>
-          </div>
-        </div>
-
-        {/* Delay Reasons */}
-        {payout.delayReasons.length > 0 && (
-          <div className="mt-4 border-3 border-amber-500/50 bg-amber-50 p-4">
-            <div className="flex items-center gap-2">
-              <AlertTriangle className="h-5 w-5 text-amber-600" />
-              <p className="font-bold text-amber-800">Delay Reasons</p>
-            </div>
-            <div className="mt-2 flex flex-wrap gap-2">
-              {payout.delayReasons.map((reason) => (
-                <Badge key={reason} className="border-amber-300 bg-amber-100 text-xs font-bold text-amber-800">
-                  {DELAY_REASON_LABELS[reason as keyof typeof DELAY_REASON_LABELS] || reason}
-                </Badge>
-              ))}
+            <div className="animate-pulse space-y-3">
+              <div className="h-5 w-48 bg-muted rounded" />
+              <div className="h-4 w-32 bg-muted rounded" />
+              <div className="grid grid-cols-3 gap-4">
+                {Array.from({ length: 3 }).map((_, i) => (
+                  <div key={i} className="space-y-2">
+                    <div className="h-3 w-16 bg-muted rounded mx-auto" />
+                    <div className="h-6 w-24 bg-muted rounded mx-auto" />
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
         )}
 
-        {/* Deductions Breakdown */}
-        <div className="mt-4">
-          <button
-            onClick={() => setDeductionsOpen(!deductionsOpen)}
-            className="flex w-full items-center justify-between border-2 border-foreground/20 p-3 text-left font-bold"
-          >
-            <span>Deductions Breakdown ({payout.deductions.length})</span>
-            {deductionsOpen ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
-          </button>
-          {deductionsOpen && (
-            <div className="border-2 border-t-0 border-foreground/20">
-              {payout.deductions.length === 0 ? (
-                <p className="p-3 text-sm text-muted-foreground">No deductions for this payout</p>
-              ) : (
-                payout.deductions.map((d, i) => (
-                  <div key={i} className="flex items-center justify-between border-b border-foreground/10 px-3 py-2 last:border-0">
-                    <div>
-                      <p className="text-sm font-bold">{d.label}</p>
-                      <p className="text-xs text-muted-foreground">{DEDUCTION_TYPE_LABELS[d.type]}</p>
-                    </div>
-                    <p className="font-mono text-sm font-bold text-red-600">-{formatCurrency(d.amount, payout.currency)}</p>
-                  </div>
-                ))
+        {/* Error state */}
+        {error && !loading && (
+          <div className="mt-6 text-center" role="alert">
+            <XCircle className="mx-auto h-10 w-10 text-destructive" aria-hidden="true" />
+            <p className="mt-3 font-bold text-destructive">{error}</p>
+            <Button
+              onClick={fetchDetail}
+              className="mt-3 border-2 border-foreground font-bold"
+              aria-label="Retry loading payout details"
+            >
+              <RotateCcw className="mr-1 h-4 w-4" />Retry
+            </Button>
+          </div>
+        )}
+
+        {/* Payout content */}
+        {payout && !loading && !error && (
+          <>
+            {/* Header Info */}
+            <div className="mt-4 border-3 border-foreground bg-muted p-4">
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="font-bold">{payout.propertyName}</p>
+                  <p className="text-sm text-muted-foreground">
+                    {formatPayoutDate(payout.periodStart)} &mdash; {formatPayoutDate(payout.periodEnd)}
+                  </p>
+                </div>
+                <Badge
+                  className={`text-xs font-bold ${STATUS_CLASSES[payout.status] || ""}`}
+                  aria-label={`Status: ${PAYOUT_STATUS_LABELS[payout.status]}`}
+                >
+                  <StatusIcon status={payout.status} className="mr-1 h-3 w-3" />
+                  {PAYOUT_STATUS_LABELS[payout.status]}
+                </Badge>
+              </div>
+              <div className="mt-3 grid grid-cols-3 gap-4 text-center">
+                <div>
+                  <p className="text-xs font-bold uppercase text-muted-foreground">Gross</p>
+                  <p className="text-lg font-bold">{formatCurrency(payout.grossAmount, payout.currency)}</p>
+                </div>
+                <div>
+                  <p className="text-xs font-bold uppercase text-muted-foreground">Deductions</p>
+                  <p className="text-lg font-bold text-red-600">
+                    -{formatCurrency(payout.deductions.reduce((s, d) => s + d.amount, 0), payout.currency)}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-xs font-bold uppercase text-muted-foreground">Net</p>
+                  <p className="text-lg font-bold text-green-700">{formatCurrency(payout.netAmount, payout.currency)}</p>
+                </div>
+              </div>
+            </div>
+
+            {/* Channel & Dates */}
+            <div className="mt-4 grid grid-cols-2 gap-3">
+              <div className="border-2 border-foreground/20 p-3">
+                <p className="text-xs font-bold uppercase text-muted-foreground">Payout Channel</p>
+                <p className="font-bold">{PAYOUT_CHANNEL_LABELS[payout.channel]}</p>
+              </div>
+              <div className="border-2 border-foreground/20 p-3">
+                <p className="text-xs font-bold uppercase text-muted-foreground">Scheduled Date</p>
+                <p className="font-bold">{formatPayoutDate(payout.scheduledDate)}</p>
+              </div>
+            </div>
+
+            {/* Delay Reasons */}
+            {payout.delayReasons.length > 0 && (
+              <div className="mt-4 border-3 border-amber-500/50 bg-amber-50 p-4" role="region" aria-label="Delay reasons">
+                <div className="flex items-center gap-2">
+                  <AlertTriangle className="h-5 w-5 text-amber-600" aria-hidden="true" />
+                  <p className="font-bold text-amber-800">Delay Reasons</p>
+                </div>
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {payout.delayReasons.map((reason) => (
+                    <Badge key={reason} className="border-amber-300 bg-amber-100 text-xs font-bold text-amber-800">
+                      {DELAY_REASON_LABELS[reason as keyof typeof DELAY_REASON_LABELS] || reason}
+                    </Badge>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* Deductions Breakdown */}
+            <div className="mt-4">
+              <button
+                onClick={() => setDeductionsOpen(!deductionsOpen)}
+                className="flex w-full items-center justify-between border-2 border-foreground/20 p-3 text-left font-bold"
+                aria-expanded={deductionsOpen}
+                aria-controls="deductions-list"
+              >
+                <span>Deductions Breakdown ({payout.deductions.length})</span>
+                {deductionsOpen ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
+              </button>
+              {deductionsOpen && (
+                <div id="deductions-list" className="border-2 border-t-0 border-foreground/20">
+                  {payout.deductions.length === 0 ? (
+                    <p className="p-3 text-sm text-muted-foreground">No deductions for this payout</p>
+                  ) : (
+                    <table className="w-full text-sm" aria-label="Deductions breakdown">
+                      <thead className="sr-only">
+                        <tr>
+                          <th className="text-left px-3 py-2">Description</th>
+                          <th className="text-right px-3 py-2">Amount</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {payout.deductions.map((d, i) => (
+                          <tr key={i} className="border-b border-foreground/10 last:border-0">
+                            <td className="px-3 py-2">
+                              <p className="font-bold">{d.label}</p>
+                              <p className="text-xs text-muted-foreground">{DEDUCTION_TYPE_LABELS[d.type]}</p>
+                            </td>
+                            <td className="px-3 py-2 text-right font-mono font-bold text-red-600">
+                              -{formatCurrency(d.amount, payout.currency)}
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  )}
+                </div>
               )}
             </div>
-          )}
-        </div>
 
-        {/* Completed Date */}
-        {payout.completedDate && (
-          <div className="mt-4 border-2 border-green-300 bg-green-50 p-3">
-            <p className="text-xs font-bold uppercase text-green-700">Completed</p>
-            <p className="font-bold text-green-800">{new Date(payout.completedDate).toLocaleString()}</p>
-          </div>
+            {/* Completed Date */}
+            {payout.completedDate && (
+              <div className="mt-4 border-2 border-green-300 bg-green-50 p-3">
+                <p className="text-xs font-bold uppercase text-green-700">Completed</p>
+                <p className="font-bold text-green-800">{formatPayoutDateTime(payout.completedDate)}</p>
+              </div>
+            )}
+          </>
         )}
       </Card>
     </div>

--- a/frontend/lib/landlordPayoutApi.ts
+++ b/frontend/lib/landlordPayoutApi.ts
@@ -3,6 +3,8 @@
  */
 
 import { apiGet, withQuery } from "./apiClient";
+import { formatMoney, type SupportedCurrency } from "./currency";
+import { formatDate as fmtDate, formatDateTime as fmtDateTime } from "./i18n-utils";
 
 export type PayoutStatus =
   | "scheduled" | "processing" | "completed" | "delayed" | "failed" | "on_hold";
@@ -156,9 +158,21 @@ export const PAYOUT_CHANNEL_LABELS: Record<PayoutChannel, string> = {
 };
 
 export function formatCurrency(amount: number, currency: string = "NGN"): string {
-  if (currency === "NGN") return `₦${amount.toLocaleString("en-NG", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
-  if (currency === "USDC") return `$${amount.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+  if (currency === "NGN" || currency === "USDC") {
+    return formatMoney(amount, currency as SupportedCurrency);
+  }
   return `${currency} ${amount.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+}
+
+export function formatPayoutDate(date: string | Date): string {
+  return fmtDate(date, "en", { year: "numeric", month: "short", day: "numeric" });
+}
+
+export function formatPayoutDateTime(date: string | Date): string {
+  return fmtDateTime(date, "en", {
+    year: "numeric", month: "short", day: "numeric",
+    hour: "2-digit", minute: "2-digit",
+  });
 }
 
 export function formatPeriodLabel(label: string): string {


### PR DESCRIPTION
## Summary

Improve the landlord payouts schedule view with consistent currency/date formatting, a URL-driven drill-down with proper loading/error states, semantic table semantics, keyboard accessibility, and a confirmation dialog for schedule cadence changes. No backend or policy changes.

## Linked issue (recommended)
Closes #1274 

N/A — standalone UI improvement.

## Changes

- Use shared `formatMoney`/`formatDate` instead of custom implementations
- URL-driven drill-down (`?payout=id`) with loading/error states
- Semantic table for payout rows, focus trap, Escape to close
- Confirmation dialog for payout schedule cadence changes
- `aria-labels`, `role` attributes, sr-only loading text throughout

## Contract Upgrade Details (if applicable)

N/A — no contract changes.

## How to test

- [x] All automated tests pass (`pnpm run lint`, `pnpm run build`)
- [x] Manual testing completed
  - Payout schedule loads with summary cards, filters, and expandable periods
  - Clicking a payout opens drill-down via `?payout=<id>` URL; loading spinner and skeleton shown while fetching
  - Drill-down error state shows retry button
  - Escape key and clicking backdrop close drill-down; browser back also closes it
  - Changing payout schedule cadence shows confirmation dialog; cancel dismisses, confirm saves
  - Empty state shown when no payouts match filters
  - Error state shown when schedule fails to load
- [x] Integration tests pass (if applicable)

## Security Considerations

- [x] No secrets or sensitive data are logged
- [x] No changes to authentication/authorization logic
- [x] No changes to admin/upgrade logic

## Screenshots (if UI)

**Payout Schedule (empty state):**
Shows "No payouts scheduled" with BarChart icon when no data is available.

**Payout Schedule (with data):**
Summary cards (Gross, Deductions, Net, Delayed/On Hold), filter bar, expandable monthly periods with semantic table rows.

**Drill-down (loading):**
Spinner + skeleton placeholders while fetching payout detail.

**Drill-down (error):**
Alert with retry button when detail fetch fails.

**Drill-down (success):**
Status icon, property name, period dates, gross/deductions/net amounts, payout channel, delay reasons, collapsible deductions table.

**Schedule cadence confirmation:**
Modal asking "Change payout schedule?" with current → new frequency and Cancel/Confirm buttons.

## Checklist

- [x] I linked an issue (or explained why one is not needed)
- [x] I tested locally
- [x] I did not commit secrets
- [x] I updated docs if needed
- [x] Code follows the project's style guidelines
- [x] CI checks pass
- [x] If UI changes: I included before/after screenshots
- [x] If images added/changed: I verified they are optimized and accessible
