### PR TITLE
Docs/issue 1356 contributor setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,32 +28,110 @@ If you're looking for tasks to pick up, start with `docs/ISSUES_CATALOG.md`.
 
 ## Development setup
 
-### Frontend
+This repository has three independently tool-chained projects. Use the package manager and version below that matches CI.
+
+### Prerequisites
+
+- Node.js 22.x (CI uses Node 22)
+- pnpm 9.15.5 for the frontend
+- npm for the backend (CI uses `npm ci`)
+- Rust stable with `rustfmt` and `clippy` for the contracts workspace
+- Docker Desktop (optional, but useful for PostgreSQL and the full-stack compose setup)
+
+### Frontend setup (pnpm, Node 22)
 
 ```bash
 cd frontend
-npm install
-npm run dev
+corepack enable
+pnpm install --frozen-lockfile
+pnpm run lint
+pnpm run build
 ```
 
-### Backend
+- The frontend uses pnpm, not npm.
+- The authoritative lockfile is `frontend/pnpm-lock.yaml`.
+- `frontend/package-lock.json` is stale and should not be used; do not run `npm install` in this directory.
+
+### Backend setup (npm, Node 22)
 
 ```bash
 cd backend
-npm install
+npm ci
 cp .env.example .env
+# Optional but recommended for local API development:
+docker compose up postgres -d
+npm run lint
+npm run test:ci
+npm run openapi:validate
+```
+
+The backend uses npm, not pnpm. The CI job runs `npm ci` and then the lint/test/OpenAPI checks below.
+
+Required environment variables for local backend work:
+
+- `cp .env.example .env` to create a local environment file.
+- `DATABASE_URL` is required for the API server. The default example points at a local PostgreSQL instance.
+- `ENCRYPTION_KEY` is required for local encryption helpers; the example value is fine for local development.
+- `CUSTODIAL_WALLET_MASTER_KEY_V1` and `CUSTODIAL_WALLET_MASTER_KEY_V2` can be left empty for basic local development, but wallet-related flows will need real values.
+- `RESEND_API_KEY` can stay empty; OTP delivery defaults to the console provider.
+
+For local development, the easiest path is to start PostgreSQL and then run the API:
+
+```bash
+cd backend
+cp .env.example .env
+docker compose up postgres -d
 npm run dev
 ```
 
-### Contracts
+The CI test command (`npm run test:ci`) excludes the network-dependent suites, so it does not require external Soroban or webhook services to pass.
+
+### Contracts setup (Rust stable + fmt/clippy)
 
 ```bash
 cd contracts
-cargo test
-stellar contract build
+rustup toolchain install stable
+rustup component add rustfmt clippy
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets --all-features
+cargo test --workspace
 ```
 
 For Soroban CLI deployment instructions see `contracts/README.md`.
+
+## Before opening a PR (required checks)
+
+Run the CI-equivalent commands from the matching directory before you push:
+
+### Frontend checks
+
+```bash
+cd frontend
+pnpm install --frozen-lockfile
+pnpm run lint
+pnpm run build
+```
+
+### Backend checks
+
+```bash
+cd backend
+npm ci
+npm run lint
+npm run test:ci
+npm run openapi:validate
+```
+
+### Contracts checks
+
+```bash
+cd contracts
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets --all-features
+cargo test --workspace
+```
+
+If your PR changes UI, include screenshots or a short screen recording in the PR description.
 
 ## Creating an issue
 
@@ -80,47 +158,6 @@ Before opening a new issue:
 - Comment on the issue saying you’re working on it.
 - Ask clarifying questions early.
 - If you’re blocked for >24h, leave an update.
-
-## Before opening a PR (required checks)
-
-Run the checks for the area you changed.
-
-### Frontend checks
-
-```bash
-cd frontend
-npm run lint
-npm run build
-```
-
-If your PR changes UI, include **screenshots** (or a short screen recording) in the PR description.
-
-#### UI/Image change verification
-
-For PRs that modify UI components or add/change images:
-
-- Include before/after screenshots showing the changes
-- For new features, provide screenshots of different states (loading, error, success)
-- For responsive changes, include screenshots at different breakpoints (mobile, tablet, desktop)
-- Verify images are optimized and not excessively large (use tools like ImageOptim, TinyPNG, or Next.js Image component)
-- Confirm accessibility: check color contrast, alt text for images, keyboard navigation
-
-### Backend checks
-
-```bash
-cd backend
-npm run lint
-npm run typecheck
-npm run build
-```
-
-### Contracts checks
-
-```bash
-cd contracts
-cargo test
-stellar contract build
-```
 
 ## If the repository is renamed on GitHub
 

--- a/README.md
+++ b/README.md
@@ -63,12 +63,12 @@ New contributors can run **just one** component without setting up the others.
 
 ## Option A: Frontend Only
 
-**Prerequisites:** Node.js 20+
+**Prerequisites:** Node.js 22, pnpm 9.15.5
 
 ```bash
 cd frontend
-npm install
-npm run dev
+pnpm install --frozen-lockfile
+pnpm run dev
 ```
 
 - Runs on: `http://localhost:3000`
@@ -77,11 +77,11 @@ npm run dev
 
 ### Option B: Backend Only
 
-**Prerequisites:** Node.js 20+
+**Prerequisites:** Node.js 22
 
 ```bash
 cd backend
-npm install
+npm ci
 cp .env.example .env
 npm run dev
 ```
@@ -92,7 +92,7 @@ npm run dev
 
 ### Option C: Contracts Only
 
-**Prerequisites:** Rust (stable), Soroban CLI (`stellar`)
+**Prerequisites:** Rust stable with `rustfmt` and `clippy`, Soroban CLI (`stellar`)
 
 ```bash
 cd contracts

--- a/backend/README.md
+++ b/backend/README.md
@@ -4,14 +4,16 @@ Node.js backend for Shelterflex.
 
 ## Setup
 
-> **Package manager:** This project uses **npm**. Use `npm install` (not `pnpm` or `yarn`) to match
-> the `package-lock.json` lockfile that is committed to the repository.
+> **Package manager:** This project uses **npm**. Use `npm ci` (not `pnpm`) to match the lockfile and CI workflow.
 
 ```bash
-npm install
+npm ci
 cp .env.example .env
 npm run dev
 ```
+
+- The backend CI job runs `npm ci` from this directory.
+- For local API development, make sure PostgreSQL is available and that the environment file contains at least `DATABASE_URL` and `ENCRYPTION_KEY`.
 
 ## Testing
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -4,13 +4,16 @@ Next.js web app for Shelterflex.
 
 ## Setup
 
-> **Package manager:** This project uses **npm**. Use `npm install` (not `pnpm` or `yarn`) to match
-> the `package-lock.json` lockfile that is committed to the repository.
+> **Package manager:** This project uses **pnpm**. Use `pnpm install --frozen-lockfile` (not `npm install`) to match
+> the `pnpm-lock.yaml` lockfile that CI uses.
 
 ```bash
-npm install
-npm run dev
+pnpm install --frozen-lockfile
+pnpm run dev
 ```
+
+- The frontend currently contains both `package-lock.json` and `pnpm-lock.yaml`.
+- `pnpm-lock.yaml` is authoritative for this project; do not use `npm install` here.
 
 ## Notes
 

--- a/pr.md
+++ b/pr.md
@@ -1,86 +1,20 @@
-# Contract Hardening: Reward Conservation, Multisig TTL, Oracle Aggregation, Tiered Slashing
-
 ## Summary
 
-Implements four independent contract improvements addressing safety gaps in `epoch_rewards`, `multisig_admin`, `oracle_price_feeds`, and `slashing_module`.
+This PR updates the contributor setup documentation so it matches the repository’s actual CI workflow from a clean clone.
 
----
+## Linked issue
 
-## epoch_rewards — Rounding-safe reward distribution and conservation invariants (#1140)
+Closes #1356
 
-**Problem:** Integer division in pro-rata reward distribution silently discards rounding dust. No invariant guaranteed `Σ claimable(epoch) ≤ funded(epoch)`, and users could call `claim` before any epoch was sealed.
+## Changes
 
-**Changes:**
-- Track `EpochStartIndex(u64)` so seal-time can compute `total_claimable = total_staked × Δindex / SCALE` exactly.
-- Add `dust` and `total_claimable_at_seal` fields to `EpochInfo`; `dust = funded − total_claimable` is always ≥ 0.
-- Carry full funded amount (including dust) to the next epoch via `carried_forward` — no funds are silently lost.
-- Emit `epoch_sealed` event with `(epoch, funded, total_claimable)` for off-chain auditing.
-- Emit `dust_carried` event whenever rounding leaves a remainder.
-- Add `ClaimBeforeSeal` error — `claim()` is rejected until at least one epoch is sealed.
+- Clarified that the frontend uses pnpm 9.15.5 and that the authoritative lockfile is frontend/pnpm-lock.yaml.
+- Documented the backend setup using npm ci and the required backend environment variables for local development.
+- Added the exact CI-equivalent commands for frontend, backend, and contracts so contributors can verify locally before pushing.
+- Updated the root and per-package README files to reflect the correct package manager and toolchain versions.
 
-**New tests:** `conservation_uneven_split_sum_never_exceeds_funded`, `dust_tracked_in_epoch_info`, `claim_is_idempotent`, `claim_before_any_seal_is_rejected`, `full_claim_conservation_multi_epoch`.
+## Checklist
 
----
-
-## multisig_admin — Proposal TTL/expiry and approval revocation (#1129)
-
-**Problem:** Approved proposals persisted indefinitely; signers who changed their minds could not withdraw consent; the `approve` path skipped the expiry check.
-
-**Changes:**
-- `approve()` now checks expiry and rejects approvals on expired proposals; emits `proposal_expired`.
-- `revoke_approval(signer, proposal_id)`: removes a signer's prior approval, rebuilds the approvals list, lowers `approval_count`, emits `approval_revoked`.
-- `execute()` re-reads live approvals after potential revocations before checking threshold.
-- Added `multisig_admin` to workspace `Cargo.toml` members.
-
-**New tests:** `expiry_blocks_approve`, `revoke_below_threshold_blocks_execute`, `revoke_then_reapprove_succeeds`, `revoke_without_prior_approval_panics`, `non_signer_cannot_revoke`, `double_approve_is_idempotent_via_rejection`.
-
----
-
-## oracle_price_feeds — Multi-source median aggregation with quorum and per-source heartbeat (#1130)
-
-**Problem:** A single trusted operator was the entire oracle — single point of failure and manipulation. No resistance to a compromised or stale source.
-
-**Changes:**
-- `add_source(admin, pair, source)` / `remove_source(admin, pair, source)` manage registered sources per feed.
-- `set_quorum(admin, pair, quorum)` configures the minimum number of fresh sources required.
-- `update_price()`: when sources are registered for a feed, authenticates per-source (not admin/operator); applies deviation check against the source's own previous price; emits `source_reported`.
-- `get_price()`: in multi-source mode computes the **median** of fresh source submissions; fails with `NoQuorum` when fewer than quorum sources have fresh data; emits `aggregated_price`. Falls back to legacy single-operator mode when no sources are registered.
-- `is_stale()`: aware of multi-source quorum.
-- New errors: `NoQuorum` (7), `UnknownSource` (8).
-- `median()` helper: selection sort over `Vec<i128>`, no floating point.
-
-**New tests:** quorum-met returns median, stale source ignored, below-quorum errors, outlier rejected by deviation bound, unregistered source rejected, add/remove source, even-count median is average.
-
----
-
-## slashing_module — Tiered/partial slashing and commit-reveal evidence (#1131)
-
-**Problem:** Slashing was all-or-nothing for a fixed set of tiers with hardcoded BPS; evidence was submitted in the clear enabling front-running; no cap on maximum slash fraction.
-
-**Changes:**
-- **Commit-reveal scheme:**
-  - `submit_evidence(submitter, commitment, actor, offence)` — `commitment = sha256(evidence || salt)`; stores on-chain, never exposes raw evidence.
-  - `reveal_evidence(submitter, slash_id, evidence, salt)` — computes `sha256(evidence || salt)` on-chain and verifies match; marks `CommitmentRevealed(slash_id) = true`.
-  - `finalize_slash()` requires `CommitmentRevealed = true` for validator slashes.
-  - Cancellation clears the commitment entry so re-submission is possible.
-- **Configurable tiers:**
-  - `configure_tiers(admin, double_sign_bps, downtime_bps, invalid_block_bps, max_slash_bps)` overrides hardcoded defaults.
-  - `MaxSlashBps` caps every slash; no slash fraction can exceed it.
-- **`propose_slash(submitter, actor, penalty_bps)`** accepts tier in BPS; computes amount from staked balance; effective BPS capped by `max_slash_bps`.
-- `finalize_slash()` applies balance reduction and tracks `SlashedAmount` for both validator and non-validator slashes.
-- New events: `evidence_committed`, `evidence_revealed`, `slash_finalized(slash_id, amount, penalty_bps)`, `tiers_configured`.
-- New errors: `CommitmentNotRevealed` (15), `InvalidReveal` (16).
-
-**New tests:** `bad_reveal_rejected`, `finalize_without_reveal_fails`, `configurable_tiers_override_defaults`, `max_slash_bps_caps_penalty`, `tier_mapping_downtime_vs_double_sign`, `propose_slash_tiered_bps`, `propose_slash_bounded_by_max_bps`.
-All pre-existing tests updated to use the `commit_and_reveal()` helper.
-
----
-
-## Test results
-
-```
-epoch_rewards    — 16 passed, 0 failed
-multisig_admin   — 17 passed, 0 failed
-oracle_price_feeds — 19 passed, 0 failed
-slashing_module  — 28 passed, 0 failed
-```
+- [x] I tested locally
+- [x] I did not commit secrets
+- [x] I updated docs if needed


### PR DESCRIPTION
## Summary

This PR updates the contributor setup documentation so it matches the repository’s actual CI workflow from a clean clone.

## Linked issue

Closes #1356

## Changes

- Clarified that the frontend uses pnpm 9.15.5 and that the authoritative lockfile is frontend/pnpm-lock.yaml.
- Documented the backend setup using npm ci and the required backend environment variables for local development.
- Added the exact CI-equivalent commands for frontend, backend, and contracts so contributors can verify locally before pushing.
- Updated the root and per-package README files to reflect the correct package manager and toolchain versions.

## Checklist

- [x] I tested locally
- [x] I did not commit secrets
- [x] I updated docs if needed