### PR TITLE
feat: Replace mock data with real API endpoints across 4 frontend pages

### DIFF
--- a/frontend/app/dashboard/landlord/settings/page.tsx
+++ b/frontend/app/dashboard/landlord/settings/page.tsx
@@ -29,7 +29,13 @@ import { Switch } from "@/components/ui/switch";
 import { DashboardHeader } from "@/components/dashboard-header";
 import { LandlordSidebar } from "@/components/landlord/LandlordSidebar";
 import { apiFetch } from "@/lib/api";
-import { landlordPaymentHistory } from "@/lib/mockData";
+import {
+  listPayouts,
+  type LandlordPayout,
+  formatCurrency,
+  formatPayoutDate,
+  PAYOUT_STATUS_LABELS,
+} from "@/lib/landlordPayoutApi";
 
 export default function LandlordSettingsPage() {
   const [activeTab, setActiveTab] = useState<
@@ -38,6 +44,11 @@ export default function LandlordSettingsPage() {
   const [showPassword, setShowPassword] = useState(false);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
+  const [payouts, setPayouts] = useState<LandlordPayout[]>([]);
+  const [payoutsLoading, setPayoutsLoading] = useState(true);
+  const [payoutsError, setPayoutsError] = useState<string | null>(null);
+  const [payoutPage, setPayoutPage] = useState(1);
+  const [payoutTotalPages, setPayoutTotalPages] = useState(1);
   const [settings, setSettings] = useState({
     profile: {
       fullName: "",
@@ -73,6 +84,23 @@ export default function LandlordSettingsPage() {
     };
     fetchSettings();
   }, []);
+
+  useEffect(() => {
+    const fetchPayouts = async () => {
+      setPayoutsLoading(true);
+      setPayoutsError(null);
+      try {
+        const result = await listPayouts({ page: payoutPage, pageSize: 10 });
+        setPayouts(result.data);
+        setPayoutTotalPages(result.pagination.totalPages);
+      } catch (err: any) {
+        setPayoutsError(err?.message || "Failed to load payment history");
+      } finally {
+        setPayoutsLoading(false);
+      }
+    };
+    fetchPayouts();
+  }, [payoutPage]);
 
   const handleSave = async () => {
     setSaving(true);
@@ -397,22 +425,70 @@ export default function LandlordSettingsPage() {
 
                 <div className="border-t-2 border-foreground pt-6">
                   <h3 className="font-bold mb-4">Payment History</h3>
-                  <div className="space-y-3">
-                    {landlordPaymentHistory.map((payment) => (
-                      <div
-                        key={payment.date}
-                        className="flex items-center justify-between border-b border-foreground/10 pb-3"
-                      >
-                        <span className="text-muted-foreground">
-                          {payment.date}
-                        </span>
-                        <span className="font-bold">{payment.amount}</span>
-                        <span className="border-2 border-foreground bg-secondary px-2 py-0.5 text-sm font-bold">
-                          {payment.status}
-                        </span>
+                  {payoutsLoading ? (
+                    <div className="flex items-center justify-center py-8">
+                      <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+                    </div>
+                  ) : payoutsError ? (
+                    <p className="text-sm text-destructive py-4">{payoutsError}</p>
+                  ) : payouts.length === 0 ? (
+                    <p className="text-sm text-muted-foreground py-4">No payment history yet.</p>
+                  ) : (
+                    <>
+                      <div className="space-y-3">
+                        {payouts.map((payout) => (
+                          <div
+                            key={payout.id}
+                            className="flex items-center justify-between border-b border-foreground/10 pb-3"
+                          >
+                            <div>
+                              <span className="text-muted-foreground">
+                                {formatPayoutDate(payout.periodStart)} - {formatPayoutDate(payout.periodEnd)}
+                              </span>
+                              <p className="text-xs text-muted-foreground">{payout.propertyName}</p>
+                            </div>
+                            <span className="font-bold">{formatCurrency(payout.netAmount, payout.currency)}</span>
+                            <span className={`border-2 border-foreground px-2 py-0.5 text-sm font-bold ${
+                              payout.status === "completed"
+                                ? "bg-secondary"
+                                : payout.status === "failed"
+                                  ? "bg-destructive/20 text-destructive"
+                                  : payout.status === "delayed"
+                                    ? "bg-destructive/10 text-destructive"
+                                    : "bg-muted"
+                            }`}>
+                              {PAYOUT_STATUS_LABELS[payout.status] || payout.status}
+                            </span>
+                          </div>
+                        ))}
                       </div>
-                    ))}
-                  </div>
+                      {payoutTotalPages > 1 && (
+                        <div className="mt-4 flex items-center justify-between">
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            disabled={payoutPage <= 1}
+                            onClick={() => setPayoutPage((p) => p - 1)}
+                            className="border-2 border-foreground"
+                          >
+                            Previous
+                          </Button>
+                          <span className="text-sm text-muted-foreground">
+                            Page {payoutPage} of {payoutTotalPages}
+                          </span>
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            disabled={payoutPage >= payoutTotalPages}
+                            onClick={() => setPayoutPage((p) => p + 1)}
+                            className="border-2 border-foreground"
+                          >
+                            Next
+                          </Button>
+                        </div>
+                      )}
+                    </>
+                  )}
                 </div>
               </div>
             </Card>

--- a/frontend/app/dashboard/landlord/tenants/page.tsx
+++ b/frontend/app/dashboard/landlord/tenants/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import {
   ArrowLeft,
@@ -9,27 +9,32 @@ import {
   CheckCircle,
   UserX,
   AlertTriangle,
+  Loader2,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
-import { landlordTenants } from "@/lib/mockData";
+import { landlordApi, type LandlordTenant } from "@/lib/landlordApi";
 import { DashboardSidebar } from "@/components/dashboard/DashboardSidebar";
 
 export default function TenantsPage() {
+  const [tenants, setTenants] = useState<LandlordTenant[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    const timer = setTimeout(() => setIsLoading(false), 350);
-    return () => clearTimeout(timer);
+    const fetchTenants = async () => {
+      try {
+        const data = await landlordApi.getTenants();
+        setTenants(data);
+      } catch (err: any) {
+        setError(err?.message || "Failed to load tenants");
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    fetchTenants();
   }, []);
-
-  const tenantsUnavailable = !Array.isArray(landlordTenants);
-
-  const tenants = useMemo(
-    () => (Array.isArray(landlordTenants) ? landlordTenants : []),
-    [],
-  );
 
   const formatCurrency = (amount: number) => {
     return new Intl.NumberFormat("en-NG", {
@@ -39,6 +44,17 @@ export default function TenantsPage() {
     }).format(amount);
   };
 
+  const formatStatus = (status: string) => {
+    const map: Record<string, { label: string; className: string }> = {
+      current: { label: "CURRENT", className: "bg-primary text-primary-foreground" },
+      active: { label: "ACTIVE", className: "bg-primary text-primary-foreground" },
+      at_risk: { label: "AT RISK", className: "bg-destructive/80 text-white" },
+      defaulted: { label: "DEFAULTED", className: "bg-destructive text-white" },
+      completed: { label: "COMPLETED", className: "bg-secondary text-secondary-foreground" },
+    };
+    return map[status] || { label: status.toUpperCase(), className: "bg-muted text-muted-foreground" };
+  };
+
   return (
     <div className="min-h-screen bg-background">
       <DashboardSidebar
@@ -46,10 +62,8 @@ export default function TenantsPage() {
         userInfo={{ name: "Chief Okonkwo", roleLabel: "Landlord" }}
       />
 
-      {/* Main Content */}
       <main className="min-h-screen w-full pt-20 lg:ml-64">
         <div className="p-4 md:p-6 lg:p-8">
-          {/* Back Button */}
           <Link href="/dashboard/landlord" className="mb-6 inline-flex">
             <Button className="border-3 border-foreground bg-card px-4 py-2 font-bold shadow-[3px_3px_0px_0px_rgba(26,26,26,1)] transition-all hover:translate-x-0.5 hover:translate-y-0.5 hover:shadow-[2px_2px_0px_0px_rgba(26,26,26,1)]">
               <ArrowLeft className="mr-2 h-4 w-4" />
@@ -57,7 +71,6 @@ export default function TenantsPage() {
             </Button>
           </Link>
 
-          {/* Header */}
           <div className="mb-8">
             <h1 className="text-3xl font-bold lg:text-4xl">My Tenants</h1>
             <p className="mt-2 text-muted-foreground">
@@ -65,7 +78,6 @@ export default function TenantsPage() {
             </p>
           </div>
 
-          {/* Tenants Grid */}
           <div className="grid gap-6">
             {isLoading ? (
               Array.from({ length: 3 }).map((_, index) => (
@@ -78,20 +90,18 @@ export default function TenantsPage() {
                   <Skeleton className="h-24 w-full" />
                 </Card>
               ))
-            ) : tenantsUnavailable ? (
+            ) : error ? (
               <Card className="border-3 border-foreground bg-destructive/10 p-12 text-center shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
                 <AlertTriangle className="mx-auto h-16 w-16 text-destructive" />
-                <h3 className="mt-4 text-xl font-bold">Tenants unavailable</h3>
-                <p className="mt-2 text-muted-foreground">
-                  We couldn&apos;t load tenant records for this panel.
-                </p>
+                <h3 className="mt-4 text-xl font-bold">Failed to load tenants</h3>
+                <p className="mt-2 text-muted-foreground">{error}</p>
               </Card>
             ) : tenants.length === 0 ? (
               <Card className="border-3 border-foreground p-12 text-center shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]">
                 <UserX className="mx-auto h-16 w-16 text-muted-foreground" />
                 <h3 className="mt-4 text-xl font-bold">No Tenants Yet</h3>
                 <p className="mt-2 text-muted-foreground">
-                  This is an empty non-loading state. Tenants will appear here once they are assigned to your properties.
+                  Tenants will appear here once they are assigned to your properties.
                 </p>
                 <Link href="/dashboard/landlord/properties" className="mt-6 inline-block">
                   <Button className="border-3 border-foreground bg-primary font-bold shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] transition-all hover:translate-x-0.5 hover:translate-y-0.5 hover:shadow-[2px_2px_0px_0px_rgba(26,26,26,1)]">
@@ -101,74 +111,89 @@ export default function TenantsPage() {
                 </Link>
               </Card>
             ) : (
-              tenants.map((tenant) => (
-                <Card
-                  key={tenant.id}
-                  className="border-3 border-foreground p-6 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]"
-                >
-                  <div className="mb-4 flex items-start justify-between">
-                    <div>
-                      <div className="flex items-center gap-3">
-                        <h3 className="text-xl font-bold">{tenant.name}</h3>
-                        {tenant.verified && (
-                          <span className="inline-flex items-center gap-1 border-2 border-secondary bg-secondary/20 px-2 py-1 text-xs font-bold text-secondary">
-                            <CheckCircle className="h-3 w-3" /> Verified
-                          </span>
-                        )}
+              tenants.map((tenant) => {
+                const statusInfo = formatStatus(tenant.status);
+                return (
+                  <Card
+                    key={tenant.id}
+                    className={`border-3 border-foreground p-6 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] ${
+                      tenant.status === "at_risk" || tenant.status === "defaulted"
+                        ? "border-destructive"
+                        : ""
+                    }`}
+                  >
+                    <div className="mb-4 flex items-start justify-between">
+                      <div>
+                        <div className="flex items-center gap-3">
+                          <h3 className="text-xl font-bold">{tenant.name}</h3>
+                          {tenant.verified && (
+                            <span className="inline-flex items-center gap-1 border-2 border-secondary bg-secondary/20 px-2 py-1 text-xs font-bold text-secondary">
+                              <CheckCircle className="h-3 w-3" /> Verified
+                            </span>
+                          )}
+                        </div>
+                        <p className="mt-2 text-sm text-muted-foreground">
+                          {tenant.property}
+                        </p>
                       </div>
-                      <p className="mt-2 text-sm text-muted-foreground">
-                        {tenant.property}
-                      </p>
+                      <span className={`border-3 border-foreground px-3 py-1 font-mono text-xs font-bold ${statusInfo.className}`}>
+                        {statusInfo.label}
+                      </span>
                     </div>
-                    <span className="border-3 border-primary bg-primary px-3 py-1 font-mono text-xs font-bold text-primary-foreground">
-                      {tenant.status.toUpperCase()}
-                    </span>
-                  </div>
 
-                  <div className="border-t-2 border-dashed border-foreground pt-4">
-                    <div className="mb-4 grid grid-cols-2 gap-4 md:grid-cols-4">
-                      <div>
-                        <p className="text-xs text-muted-foreground">
-                          Lease Start
-                        </p>
-                        <p className="font-bold">{tenant.leaseStart}</p>
-                      </div>
-                      <div>
-                        <p className="text-xs text-muted-foreground">Lease End</p>
-                        <p className="font-bold">{tenant.leaseEnd}</p>
-                      </div>
-                      <div>
-                        <p className="text-xs text-muted-foreground">
-                          Monthly Payment
-                        </p>
-                        <p className="font-bold">
-                          {formatCurrency(tenant.monthlyPayment)}
-                        </p>
-                      </div>
-                      <div>
-                        <p className="text-xs text-muted-foreground">
-                          Total Paid
-                        </p>
-                        <p className="font-bold">
-                          {formatCurrency(tenant.totalPaid)}
-                        </p>
+                    <div className="border-t-2 border-dashed border-foreground pt-4">
+                      <div className="mb-4 grid grid-cols-2 gap-4 md:grid-cols-4">
+                        <div>
+                          <p className="text-xs text-muted-foreground">Lease Start</p>
+                          <p className="font-bold">
+                            {new Date(tenant.leaseStart).toLocaleDateString("en-NG", {
+                              year: "numeric",
+                              month: "short",
+                              day: "numeric",
+                            })}
+                          </p>
+                        </div>
+                        <div>
+                          <p className="text-xs text-muted-foreground">Lease End</p>
+                          <p className="font-bold">
+                            {new Date(tenant.leaseEnd).toLocaleDateString("en-NG", {
+                              year: "numeric",
+                              month: "short",
+                              day: "numeric",
+                            })}
+                          </p>
+                        </div>
+                        <div>
+                          <p className="text-xs text-muted-foreground">Monthly Payment</p>
+                          <p className="font-bold">
+                            {formatCurrency(tenant.monthlyPayment)}
+                          </p>
+                        </div>
+                        <div>
+                          <p className="text-xs text-muted-foreground">Total Paid</p>
+                          <p className="font-bold">
+                            {formatCurrency(tenant.totalPaid)}
+                          </p>
+                        </div>
                       </div>
                     </div>
-                  </div>
 
-                  <div className="mt-4 flex gap-3">
-                    <Link href="/messages" className="flex-1">
-                      <Button className="w-full border-3 border-foreground bg-primary font-bold shadow-[3px_3px_0px_0px_rgba(26,26,26,1)] transition-all hover:translate-x-0.5 hover:translate-y-0.5 hover:shadow-[2px_2px_0px_0px_rgba(26,26,26,1)]">
-                        <MessageSquare className="mr-2 h-4 w-4" />
-                        Message
-                      </Button>
-                    </Link>
-                    <Button className="flex-1 border-3 border-foreground bg-transparent font-bold hover:bg-muted">
-                      View Details
-                    </Button>
-                  </div>
-                </Card>
-              ))
+                    <div className="mt-4 flex gap-3">
+                      <Link href="/messages" className="flex-1">
+                        <Button className="w-full border-3 border-foreground bg-primary font-bold shadow-[3px_3px_0px_0px_rgba(26,26,26,1)] transition-all hover:translate-x-0.5 hover:translate-y-0.5 hover:shadow-[2px_2px_0px_0px_rgba(26,26,26,1)]">
+                          <MessageSquare className="mr-2 h-4 w-4" />
+                          Message
+                        </Button>
+                      </Link>
+                      <Link href={`/dashboard/landlord/properties`} className="flex-1">
+                        <Button className="w-full border-3 border-foreground bg-transparent font-bold hover:bg-muted">
+                          View Details
+                        </Button>
+                      </Link>
+                    </div>
+                  </Card>
+                );
+              })
             )}
           </div>
         </div>

--- a/frontend/app/dashboard/tenant/application/page.tsx
+++ b/frontend/app/dashboard/tenant/application/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import {
@@ -15,7 +15,7 @@ import {
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { DashboardHeader } from "@/components/dashboard-header";
-import { tenantApplicationProperties as properties } from "@/lib/mockData";
+import { getProperty, type PropertyListing } from "@/lib/propertiesApi";
 import {
   createTenantApplication,
   type TenantApplication,
@@ -38,13 +38,29 @@ export default function TenantApplicationPage() {
   const [submittedApplication, setSubmittedApplication] =
     useState<TenantApplication | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [property, setProperty] = useState<PropertyListing | null>(null);
+  const [propertyLoading, setPropertyLoading] = useState(true);
+  const [propertyError, setPropertyError] = useState<string | null>(null);
 
   const annualRent = Number(searchParams.get("amount")) || 2400000;
   const deposit = Number(searchParams.get("deposit")) || annualRent * 0.2;
   const duration = Number(searchParams.get("duration")) || 12;
   const propertyId = Number(searchParams.get("propertyId")) || 1;
 
-  const property = properties.find((p) => p.id === propertyId);
+  useEffect(() => {
+    const fetchProperty = async () => {
+      setPropertyLoading(true);
+      try {
+        const result = await getProperty(String(propertyId));
+        setProperty(result.data);
+      } catch (err: any) {
+        setPropertyError(err?.message || "Failed to load property details");
+      } finally {
+        setPropertyLoading(false);
+      }
+    };
+    fetchProperty();
+  }, [propertyId]);
   const totalAmount = annualRent - deposit;
   const monthlyPayment = totalAmount / duration;
 
@@ -64,8 +80,8 @@ export default function TenantApplicationPage() {
         deposit,
         duration,
         hasAgreedToTerms: hasAgreed,
-        propertyTitle: property?.title,
-        propertyLocation: property?.location,
+        propertyTitle: property?.address,
+        propertyLocation: [property?.city, property?.area].filter(Boolean).join(", "),
       });
 
       setSubmittedApplication(response.data);
@@ -188,34 +204,36 @@ export default function TenantApplicationPage() {
                 Property Details
               </h2>
 
-              <div className="mb-6 space-y-3">
-                <div>
-                  <h3 className="font-bold text-foreground">
-                    {property?.title}
-                  </h3>
-                  <div className="mt-1 flex items-center gap-1 text-sm text-muted-foreground">
-                    <MapPin className="h-4 w-4 shrink-0" />
-                    {property?.location}
-                  </div>
+              {propertyLoading ? (
+                <div className="flex items-center justify-center py-8">
+                  <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
                 </div>
+              ) : propertyError ? (
+                <p className="text-sm text-destructive py-4">{propertyError}</p>
+              ) : (
+                <div className="mb-6 space-y-3">
+                  <div>
+                    <h3 className="font-bold text-foreground">
+                      {property?.address || "Property"}
+                    </h3>
+                    <div className="mt-1 flex items-center gap-1 text-sm text-muted-foreground">
+                      <MapPin className="h-4 w-4 shrink-0" />
+                      {[property?.city, property?.area].filter(Boolean).join(", ")}
+                    </div>
+                  </div>
 
-                <div className="flex flex-wrap gap-3">
-                  <div className="flex items-center gap-1 border-2 border-foreground/30 bg-muted/50 px-2 py-1">
-                    <Bed className="h-4 w-4" />
-                    <span className="text-sm font-bold">{property?.beds}</span>
-                  </div>
-                  <div className="flex items-center gap-1 border-2 border-foreground/30 bg-muted/50 px-2 py-1">
-                    <Bath className="h-4 w-4" />
-                    <span className="text-sm font-bold">{property?.baths}</span>
-                  </div>
-                  <div className="flex items-center gap-1 border-2 border-foreground/30 bg-muted/50 px-2 py-1">
-                    <Square className="h-4 w-4" />
-                    <span className="text-sm font-bold">
-                      {property?.sqm} m²
-                    </span>
+                  <div className="flex flex-wrap gap-3">
+                    <div className="flex items-center gap-1 border-2 border-foreground/30 bg-muted/50 px-2 py-1">
+                      <Bed className="h-4 w-4" />
+                      <span className="text-sm font-bold">{property?.bedrooms}</span>
+                    </div>
+                    <div className="flex items-center gap-1 border-2 border-foreground/30 bg-muted/50 px-2 py-1">
+                      <Bath className="h-4 w-4" />
+                      <span className="text-sm font-bold">{property?.bathrooms}</span>
+                    </div>
                   </div>
                 </div>
-              </div>
+              )}
 
               {/* Payment Breakdown */}
               <div className="border-t-2 border-foreground/20 pt-6">

--- a/frontend/app/properties/[id]/PropertyDetailClient.tsx
+++ b/frontend/app/properties/[id]/PropertyDetailClient.tsx
@@ -50,7 +50,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
-import { allProperties } from "@/lib/mockData/properties";
+import { getProperty, type PropertyListing } from "@/lib/propertiesApi";
 import { AmenitiesLegend } from "@/components/properties/AmenitiesLegend";
 import { showSuccessToast, showErrorToast } from "@/lib/toast";
 import { apiPost } from "@/lib/api";
@@ -65,8 +65,6 @@ import { InspectionReportAccordion } from "@/components/properties/InspectionRep
 import { LandlordSnippet } from "@/components/properties/LandlordSnippet";
 import useAuthStore from "@/store/useAuthStore";
 import { propertyInspectionApi, type InspectionSummary } from "@/lib/propertyInspectionApi";
-
-const properties = allProperties;
 
 const featureIcons: { [key: string]: React.ElementType } = {
   "24/7 Power Supply": Wind,
@@ -120,6 +118,9 @@ export default function PropertyDetailClient({
   const [isSubmittingReport, setIsSubmittingReport] = useState(false);
   const [inspectionSummary, setInspectionSummary] = useState<InspectionSummary | null>(null);
   const [isLoadingInspection, setIsLoadingInspection] = useState(false);
+  const [listing, setListing] = useState<PropertyListing | null>(null);
+  const [isLoadingProperty, setIsLoadingProperty] = useState(true);
+  const [propertyError, setPropertyError] = useState<string | null>(null);
   const lightboxRef = useRef<HTMLDivElement>(null);
   const mainGalleryRef = useRef<HTMLDivElement>(null);
 
@@ -176,6 +177,23 @@ export default function PropertyDetailClient({
     }
   }, [showLightbox]);
 
+  // Fetch property from API
+  useEffect(() => {
+    const fetchProperty = async () => {
+      setIsLoadingProperty(true);
+      setPropertyError(null);
+      try {
+        const result = await getProperty(propertyId);
+        setListing(result.data);
+      } catch (err: any) {
+        setPropertyError(err?.message || "Failed to load property");
+      } finally {
+        setIsLoadingProperty(false);
+      }
+    };
+    fetchProperty();
+  }, [propertyId]);
+
   // Fetch inspection summary
   useEffect(() => {
     const fetchInspectionSummary = async () => {
@@ -194,9 +212,50 @@ export default function PropertyDetailClient({
     fetchInspectionSummary();
   }, [propertyId]);
 
-  const property = properties.find((p) => p.id === Number.parseInt(propertyId));
+  // Map API listing to the format the component expects
+  const property = listing ? {
+    id: Number.parseInt(listing.listingId) || 0,
+    title: listing.address,
+    location: [listing.city, listing.area].filter(Boolean).join(", "),
+    address: listing.address,
+    price: listing.annualRentNgn,
+    outrightPriceNgn: listing.outrightPriceNgn,
+    installmentBasePriceNgn: listing.installmentBasePriceNgn,
+    beds: listing.bedrooms,
+    baths: listing.bathrooms,
+    sqm: 0,
+    image: listing.photos?.[0] || "/placeholder.svg",
+    verificationStatus: listing.status === "approved" ? "VERIFIED" : listing.status.toUpperCase(),
+    tag: null,
+    tagColor: null,
+    description: listing.description || "",
+    features: [],
+    images: (listing.photos || []).map((url, idx) => ({
+      id: idx + 1,
+      label: `Photo ${idx + 1}`,
+      url,
+    })),
+    landlord: {
+      name: "Property Owner",
+      verified: false,
+      listings: 1,
+      responseTime: "Within 24 hours",
+    },
+    whistleblower: null,
+  } : null;
 
-  if (!property) {
+  if (isLoadingProperty) {
+    return (
+      <main className="min-h-screen bg-background flex items-center justify-center">
+        <div className="flex flex-col items-center gap-4">
+          <Loader2 className="h-8 w-8 animate-spin text-primary" />
+          <p className="text-muted-foreground font-mono">Loading property...</p>
+        </div>
+      </main>
+    );
+  }
+
+  if (propertyError || !property) {
     return (
       <main className="min-h-screen bg-background flex items-center justify-center">
         <div className="border-3 border-foreground bg-card p-12 text-center shadow-[6px_6px_0px_0px_rgba(26,26,26,1)]">

--- a/frontend/app/properties/[id]/page.tsx
+++ b/frontend/app/properties/[id]/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { allProperties } from "@/lib/mockData/properties";
+import { getProperty } from "@/lib/propertiesApi";
 import PropertyDetailClient from "./PropertyDetailClient";
 
 type PropertyPageProps = {
@@ -14,32 +14,36 @@ const defaultDescription =
 
 export async function generateMetadata({ params }: PropertyPageProps): Promise<Metadata> {
   const { id } = await params;
-  const property = allProperties.find((item) => item.id === Number.parseInt(id, 10));
 
-  if (!property) {
+  try {
+    const result = await getProperty(id);
+    const listing = result.data;
+
+    const title = `${listing.address} | ShelterFlex`;
+    const locationParts = [listing.city, listing.area].filter(Boolean).join(", ");
+    const description = listing.description
+      || `Discover this property in ${locationParts || "Nigeria"}, including ${listing.bedrooms} bedrooms, ${listing.bathrooms} bathrooms, and pricing details.`;
+
+    return {
+      title,
+      description,
+      openGraph: {
+        title,
+        description,
+        type: "website",
+      },
+      twitter: {
+        card: "summary",
+        title,
+        description,
+      },
+    };
+  } catch {
     return {
       title: defaultTitle,
       description: defaultDescription,
     };
   }
-
-  const title = `${property.title} - ${property.location} | ShelterFlex`;
-  const description = `Discover ${property.title} in ${property.location}, including key details like bedrooms, bathrooms, and pricing.`;
-
-  return {
-    title,
-    description,
-    openGraph: {
-      title,
-      description,
-      type: "website",
-    },
-    twitter: {
-      card: "summary",
-      title,
-      description,
-    },
-  };
 }
 
 export default async function PropertyDetailPage({ params }: PropertyPageProps) {

--- a/frontend/lib/landlordApi.ts
+++ b/frontend/lib/landlordApi.ts
@@ -62,6 +62,18 @@ export interface LandlordAnalytics {
   vacancyMetrics: VacancyMetrics;
 }
 
+export interface LandlordTenant {
+  id: string;
+  name: string;
+  property: string;
+  status: string;
+  leaseStart: string;
+  leaseEnd: string;
+  monthlyPayment: number;
+  totalPaid: number;
+  verified: boolean;
+}
+
 export const landlordApi = {
   getDashboardData: async (): Promise<LandlordDashboardData> => {
     return apiFetch<LandlordDashboardData>("/api/landlord/dashboard");
@@ -73,6 +85,10 @@ export const landlordApi = {
 
   getProperty: async (id: string | number): Promise<LandlordProperty> => {
     return apiFetch<LandlordProperty>(`/api/landlord/properties/${id}`);
+  },
+
+  getTenants: async (): Promise<LandlordTenant[]> => {
+    return apiFetch<LandlordTenant[]>("/api/landlord/tenants");
   },
 
   getApplications: async (): Promise<any[]> => {


### PR DESCRIPTION
Closes #1323 , Closes #1324, Closes #1325, Closes #1326

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Refactoring (no functional or behavioral changes)

---

## Summary

Replace mock/fixture data with real backend API calls across four frontend pages: landlord tenants, landlord settings payout history, tenant application, and property detail. Each page now fetches live data from existing backend endpoints, with proper loading, empty, and error states.

## Motivation / Context

These four pages were backed by static mock data, making them non-functional in production. Landlords couldn't see their actual tenants or payment history, tenants couldn't view their real applications, and property listings couldn't be viewed by their real IDs. This PR wires each page to the existing backend APIs, making them fully functional.

## Changes

### Issue #1325 — Landlord Tenants Page
- Added `LandlordTenant` interface and `getTenants()` to `landlordApi.ts`
- Replaced mock import with real API fetch from `/api/landlord/tenants`
- Added loading, error, and empty states
- At-risk and defaulted tenancies visually distinct (red border, destructive badges)
- Lease dates formatted from ISO strings

### Issue #1324 — Landlord Settings Payment History
- Replaced mock import with paginated data from `landlordPayoutApi.listPayouts()`
- Added loading, error, and empty states
- Real payout statuses (completed, delayed, failed) with distinct styling
- Pagination controls for navigating payout history
- Currency formatting via shared `formatCurrency` helper

### Issue #1323 — Tenant Application Page
- Replaced mock import with real data from `propertiesApi.getProperty()`
- Added loading and error states for property fetch
- Adapted property display to API fields (address, city, area, bedrooms, bathrooms)

### Issue #1326 — Property Detail Page
- Server component (`page.tsx`) fetches property for OpenGraph metadata generation
- Client component fetches property on mount with loading and error states
- Maps `PropertyListing` API response to component-compatible format
- Returns proper not-found page for unknown/unpublished listings
- No mock data imports remain in either file

## Testing

- `pnpm run lint` — passes (0 errors, pre-existing warnings only)
- `pnpm run build` — passes (all pages compile and generate successfully)
- Verified no `@/lib/mockData` imports remain in any modified file

## Tradeoffs

- The property detail page maps the API `PropertyListing` shape to the component's expected format. Fields like `features`, `landlord`, and `whistleblower` that aren't in the listings API are given sensible defaults, keeping the component functional while those features can be wired to their respective endpoints in follow-up work.