### PR TITLE
fix(frontend): standardize auth form validation and error handling

### DIFF
--- a/frontend/FORM_VALIDATION_CONVENTION.md
+++ b/frontend/FORM_VALIDATION_CONVENTION.md
@@ -1,0 +1,38 @@
+# Frontend Form Validation & Error Handling Convention
+
+This convention is the baseline for all frontend forms.
+
+## Audited forms in this change
+
+- `app/login/page.tsx`
+- `app/signup/page.tsx`
+- `app/verify-otp/page.tsx`
+- Shared default behavior in `hooks/useAppForm.ts`
+
+## Required implementation pattern
+
+1. **Schema source**: use `lib/formSchemas.ts` (no per-page standalone schema files).
+2. **Validation timing**: use React Hook Form with `mode: "onBlur"` and `reValidateMode: "onBlur"`.
+3. **Server error mapping**: parse backend `details/fieldErrors` and map each server field error to `setError(field, ...)`.
+4. **Accessible errors**:
+   - Field errors must be linked with `aria-describedby`.
+   - Invalid controls must set `aria-invalid`.
+   - Error text must use `role="alert"`.
+5. **Submission safety**:
+   - Disable all submit controls while `isSubmitting` is true.
+   - Prevent duplicate submits by relying on RHF submit state and in-handler guard.
+6. **Focus and recovery**:
+   - Keep `shouldFocusError: true` so failed submit moves focus to the first invalid field.
+   - Preserve user-entered values after failed submit.
+   - Clear field-level/server errors when users edit affected fields.
+
+## Utility for server error handling
+
+Use `lib/formErrors.ts`:
+
+- `parseFormError(error, fallbackMessage)` returns a generic user message + field error map.
+- `extractFieldErrors(details)` supports both flat and `fieldErrors` response shapes.
+
+## Note on idempotency
+
+Forms that create durable records or move money must include an idempotency key in request headers/body. Auth OTP request/verify flows are non-monetary and are unchanged in this issue.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -19,6 +19,7 @@ pnpm run dev
 
 - This frontend is currently UI-first and uses mock data under `lib/mockData/`.
 - Backend integration should be centralized under `lib/` (avoid scattering raw `fetch` calls in components).
+- Form validation/error-handling standards: `FORM_VALIDATION_CONVENTION.md`.
 
 ## Design System Showcase
 

--- a/frontend/app/login/page.test.tsx
+++ b/frontend/app/login/page.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import LoginPage from "./page";
+
+const pushMock = vi.fn();
+const searchParamsMock = new URLSearchParams();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushMock }),
+  useSearchParams: () => searchParamsMock,
+}));
+
+vi.mock("@/components/wallet/StellarWalletConnect", () => ({
+  StellarWalletConnect: () => <div>wallet-connect</div>,
+}));
+
+vi.mock("@/lib/authApi", () => ({
+  requestOtp: vi.fn(),
+}));
+
+import { requestOtp } from "@/lib/authApi";
+
+type MockRequestOtp = Mock<typeof requestOtp>;
+
+function pendingPromise() {
+  return new Promise(() => undefined);
+}
+
+describe("Login form validation consistency", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows validation errors on submit/blur and focuses the first invalid field", async () => {
+    render(<LoginPage />);
+
+    const emailInput = screen.getByLabelText("Email Address");
+    await userEvent.click(screen.getByRole("button", { name: "Continue" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Email is required")).toBeInTheDocument();
+      expect(emailInput).toHaveFocus();
+    });
+  });
+
+  it("maps server field errors back to form fields", async () => {
+    const mockRequestOtp = requestOtp as MockRequestOtp;
+    const error = new Error("Validation failed") as Error & { details?: unknown };
+    error.details = { fieldErrors: { email: ["Email is not registered"] } };
+    mockRequestOtp.mockRejectedValue(error);
+
+    render(<LoginPage />);
+
+    await userEvent.type(screen.getByLabelText("Email Address"), "test@example.com");
+    await userEvent.click(screen.getByRole("button", { name: "Continue" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Email is not registered")).toBeInTheDocument();
+    });
+  });
+
+  it("prevents double-submit while request is in-flight", async () => {
+    const mockRequestOtp = requestOtp as MockRequestOtp;
+    mockRequestOtp.mockReturnValue(pendingPromise() as ReturnType<typeof requestOtp>);
+
+    render(<LoginPage />);
+
+    await userEvent.type(screen.getByLabelText("Email Address"), "test@example.com");
+    const submitButton = screen.getByRole("button", { name: "Continue" });
+
+    await userEvent.click(submitButton);
+    await userEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(submitButton).toBeDisabled();
+      expect(mockRequestOtp).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, Suspense } from "react";
+import React, { Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { ArrowRight, Loader2, Wallet } from "lucide-react";
@@ -11,39 +11,51 @@ import { StellarWalletConnect } from "@/components/wallet/StellarWalletConnect";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { loginSchema, type LoginFormData } from "@/lib/schemas";
+import { loginSchema, type LoginFormValues } from "@/lib/formSchemas";
+import { parseFormError } from "@/lib/formErrors";
 
 function LoginForm() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const returnTo = searchParams.get("returnTo");
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
 
   const {
     register,
     handleSubmit,
-    formState: { errors },
-  } = useForm<LoginFormData>({
+    setError,
+    setFocus,
+    clearErrors,
+    formState: { errors, isSubmitting },
+  } = useForm<LoginFormValues>({
     resolver: zodResolver(loginSchema),
+    mode: "onBlur",
+    reValidateMode: "onBlur",
+    shouldFocusError: true,
   });
 
-  const onSubmit = async (data: LoginFormData) => {
-    setError(null);
-    setLoading(true);
+  const onSubmit = async (data: LoginFormValues) => {
+    if (isSubmitting) return;
 
+    clearErrors("root");
     try {
       await requestOtp(data.email);
-      
-      const verifyOtpUrl = returnTo 
+
+      const verifyOtpUrl = returnTo
         ? `/verify-otp?email=${encodeURIComponent(data.email)}&returnTo=${encodeURIComponent(returnTo)}`
         : `/verify-otp?email=${encodeURIComponent(data.email)}`;
-      
+
       router.push(verifyOtpUrl);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Something went wrong");
-    } finally {
-      setLoading(false);
+    } catch (error) {
+      const { message, fieldErrors } = parseFormError(error, "Something went wrong");
+      const firstField = Object.keys(fieldErrors)[0];
+
+      if (firstField === "email") {
+        setError("email", { type: "server", message: fieldErrors.email });
+        setFocus("email");
+        return;
+      }
+
+      setError("root.serverError", { type: "server", message });
     }
   };
 
@@ -54,9 +66,7 @@ function LoginForm() {
           <Link href="/" className="inline-block font-mono text-3xl font-black">
             SHELTER<span className="text-primary">FLEX</span>
           </Link>
-          <p className="mt-2 text-muted-foreground">
-            Choose your sign-in method
-          </p>
+          <p className="mt-2 text-muted-foreground">Choose your sign-in method</p>
         </div>
 
         <div className="border-3 border-foreground bg-card p-8 shadow-[8px_8px_0px_0px_rgba(26,26,26,1)]">
@@ -74,32 +84,36 @@ function LoginForm() {
             </TabsList>
 
             <TabsContent value="email" className="space-y-4">
-              {error && (
-                <div className="border-2 border-destructive bg-destructive/10 p-3 text-sm font-medium text-destructive">
-                  {error}
+              {errors.root?.serverError?.message && (
+                <div
+                  role="alert"
+                  className="border-2 border-destructive bg-destructive/10 p-3 text-sm font-medium text-destructive"
+                >
+                  {errors.root.serverError.message}
                 </div>
               )}
 
-              <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
+              <form onSubmit={handleSubmit(onSubmit)} className="space-y-6" noValidate>
                 <div className="space-y-2">
-                  <label
-                    htmlFor="email"
-                    className="block font-mono text-sm font-bold"
-                  >
+                  <label htmlFor="email" className="block font-mono text-sm font-bold">
                     Email Address
                   </label>
                   <Input
                     id="email"
                     type="email"
-                    {...register("email")}
+                    {...register("email", {
+                      onChange: () => clearErrors(["email", "root.serverError"]),
+                    })}
                     placeholder="you@email.com"
+                    aria-invalid={Boolean(errors.email)}
+                    aria-describedby={errors.email ? "login-email-error" : undefined}
                     className={`border-3 border-foreground py-6 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] focus:translate-x-0.5 focus:translate-y-0.5 focus:shadow-[2px_2px_0px_0px_rgba(26,26,26,1)] ${
                       errors.email ? "border-destructive" : ""
                     }`}
-                    disabled={loading}
+                    disabled={isSubmitting}
                   />
-                  {errors.email && (
-                    <p className="text-xs font-bold text-destructive">
+                  {errors.email?.message && (
+                    <p id="login-email-error" role="alert" className="text-xs font-bold text-destructive">
                       {errors.email.message}
                     </p>
                   )}
@@ -107,15 +121,15 @@ function LoginForm() {
 
                 <Button
                   type="submit"
-                  disabled={loading}
+                  disabled={isSubmitting}
                   className="w-full border-3 border-foreground bg-primary px-8 py-6 text-lg font-bold shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] transition-all hover:translate-x-0.5 hover:translate-y-0.5 hover:shadow-[2px_2px_0px_0px_rgba(26,26,26,1)] disabled:opacity-60"
                 >
-                  {loading ? (
+                  {isSubmitting ? (
                     <Loader2 className="mr-2 h-5 w-5 animate-spin" />
                   ) : (
                     <ArrowRight className="ml-2 h-5 w-5" />
                   )}
-                  {loading ? "Sending OTP..." : "Continue"}
+                  {isSubmitting ? "Sending OTP..." : "Continue"}
                 </Button>
               </form>
             </TabsContent>
@@ -128,10 +142,7 @@ function LoginForm() {
           <div className="mt-6 text-center">
             <p className="text-muted-foreground">
               Don&apos;t have an account?{" "}
-              <Link
-                href="/signup"
-                className="font-bold text-primary hover:underline"
-              >
+              <Link href="/signup" className="font-bold text-primary hover:underline">
                 Sign up
               </Link>
             </p>

--- a/frontend/app/signup/page.test.tsx
+++ b/frontend/app/signup/page.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import SignupPage from "./page";
+
+const pushMock = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushMock }),
+}));
+
+vi.mock("@/components/wallet/StellarWalletConnect", () => ({
+  StellarWalletConnect: () => <div>wallet-connect</div>,
+}));
+
+vi.mock("@/lib/authApi", () => ({
+  requestOtp: vi.fn(),
+}));
+
+import { requestOtp } from "@/lib/authApi";
+
+type MockRequestOtp = Mock<typeof requestOtp>;
+
+function pendingPromise() {
+  return new Promise(() => undefined);
+}
+
+describe("Signup form validation consistency", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("validates on submit and focuses first invalid field", async () => {
+    render(<SignupPage />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Create Account" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Full name must be at least 2 characters")).toBeInTheDocument();
+      expect(screen.getByLabelText("Full Name")).toHaveFocus();
+    });
+  });
+
+  it("maps server-side field errors to matching inputs", async () => {
+    const mockRequestOtp = requestOtp as MockRequestOtp;
+    const error = new Error("Validation failed") as Error & { details?: unknown };
+    error.details = { fieldErrors: { email: ["Email is already in use"] } };
+    mockRequestOtp.mockRejectedValue(error);
+
+    render(<SignupPage />);
+
+    await userEvent.type(screen.getByLabelText("Full Name"), "Valid User");
+    await userEvent.type(screen.getByLabelText("Email Address"), "user@example.com");
+    await userEvent.type(screen.getByLabelText("Phone Number"), "08012345678");
+    await userEvent.type(screen.getByLabelText("Password"), "Password1");
+    await userEvent.click(screen.getByLabelText(/I agree to the/i));
+
+    await userEvent.click(screen.getByRole("button", { name: "Create Account" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Email is already in use")).toBeInTheDocument();
+    });
+  });
+
+  it("prevents duplicate submission while waiting for response", async () => {
+    const mockRequestOtp = requestOtp as MockRequestOtp;
+    mockRequestOtp.mockReturnValue(pendingPromise() as ReturnType<typeof requestOtp>);
+
+    render(<SignupPage />);
+
+    await userEvent.type(screen.getByLabelText("Full Name"), "Valid User");
+    await userEvent.type(screen.getByLabelText("Email Address"), "user@example.com");
+    await userEvent.type(screen.getByLabelText("Phone Number"), "08012345678");
+    await userEvent.type(screen.getByLabelText("Password"), "Password1");
+    await userEvent.click(screen.getByLabelText(/I agree to the/i));
+
+    const submitButton = screen.getByRole("button", { name: "Create Account" });
+    await userEvent.click(submitButton);
+    await userEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(submitButton).toBeDisabled();
+      expect(mockRequestOtp).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/frontend/app/signup/page.tsx
+++ b/frontend/app/signup/page.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, Suspense } from "react";
 import Link from "next/link";
-import { ArrowRight, Eye, EyeOff, Check, Wallet } from "lucide-react";
+import { ArrowRight, Eye, EyeOff, Check, Wallet, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { StellarWalletConnect } from "@/components/wallet/StellarWalletConnect";
@@ -12,22 +12,35 @@ import { useRouter } from "next/navigation";
 import { requestOtp } from "@/lib/authApi";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { signupSchema, type SignupFormData } from "@/lib/schemas";
+import { accountSignupSchema, type AccountSignupFormValues } from "@/lib/formSchemas";
+import { parseFormError } from "@/lib/formErrors";
+
+const SIGNUP_FIELDS: Array<keyof AccountSignupFormValues> = [
+  "fullName",
+  "email",
+  "phone",
+  "password",
+  "terms",
+];
 
 export default function SignupPage() {
   const router = useRouter();
   const [showPassword, setShowPassword] = useState(false);
   const [userType, setUserType] = useState<"tenant" | "landlord">("tenant");
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
 
   const {
     register,
     handleSubmit,
     watch,
-    formState: { errors },
-  } = useForm<SignupFormData>({
-    resolver: zodResolver(signupSchema),
+    setError,
+    setFocus,
+    clearErrors,
+    formState: { errors, isSubmitting },
+  } = useForm<AccountSignupFormValues>({
+    resolver: zodResolver(accountSignupSchema),
+    mode: "onBlur",
+    reValidateMode: "onBlur",
+    shouldFocusError: true,
     defaultValues: {
       fullName: "",
       email: "",
@@ -39,25 +52,37 @@ export default function SignupPage() {
 
   const password = watch("password", "");
 
-  const onSubmit = async (data: SignupFormData) => {
-    setError(null);
-    setLoading(true);
-    
+  const onSubmit = async (data: AccountSignupFormValues) => {
+    if (isSubmitting) return;
+
+    clearErrors("root");
+
     try {
       await requestOtp(data.email);
       router.push(`/verify-otp?email=${encodeURIComponent(data.email)}`);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Registration failed");
-    } finally {
-      setLoading(false);
+    } catch (error) {
+      const { message, fieldErrors } = parseFormError(error, "Registration failed");
+      const firstField = Object.keys(fieldErrors).find((field) => SIGNUP_FIELDS.includes(field as keyof AccountSignupFormValues));
+
+      if (firstField) {
+        const key = firstField as keyof AccountSignupFormValues;
+        setError(key, { type: "server", message: fieldErrors[firstField] });
+        if (key !== "terms") {
+          setFocus(key);
+        }
+      }
+
+      if (!firstField) {
+        setError("root.serverError", { type: "server", message });
+      }
     }
   };
 
   const handleUserTypeKeyDown: React.KeyboardEventHandler<HTMLDivElement> = (e) => {
-    if (e.key !== "ArrowLeft" && e.key !== "ArrowRight") return
-    e.preventDefault()
-    setUserType((prev) => (prev === "tenant" ? "landlord" : "tenant"))
-  }
+    if (e.key !== "ArrowLeft" && e.key !== "ArrowRight") return;
+    e.preventDefault();
+    setUserType((prev) => (prev === "tenant" ? "landlord" : "tenant"));
+  };
 
   return (
     <main className="min-h-screen bg-muted flex items-center justify-center py-12 px-4">
@@ -66,9 +91,7 @@ export default function SignupPage() {
           <Link href="/" className="inline-block font-mono text-3xl font-black">
             SHELTER<span className="text-primary">FLEX</span>
           </Link>
-          <p className="mt-2 text-muted-foreground">
-            Create your account to get started.
-          </p>
+          <p className="mt-2 text-muted-foreground">Create your account to get started.</p>
         </div>
 
         <div className="border-3 border-foreground bg-card p-8 shadow-[8px_8px_0px_0px_rgba(26,26,26,1)]">
@@ -92,7 +115,6 @@ export default function SignupPage() {
             </TabsContent>
 
             <TabsContent value="email" className="space-y-5">
-              {/* User Type Selector */}
               <fieldset className="mb-6">
                 <legend className="mb-2 block font-mono text-sm font-bold">I am a</legend>
                 <div className="grid grid-cols-2 gap-3" role="radiogroup" aria-label="Account type" onKeyDown={handleUserTypeKeyDown}>
@@ -101,11 +123,12 @@ export default function SignupPage() {
                     onClick={() => setUserType("tenant")}
                     role="radio"
                     aria-checked={userType === "tenant"}
+                    disabled={isSubmitting}
                     className={`border-3 border-foreground p-4 font-mono font-bold transition-all ${
                       userType === "tenant"
                         ? "bg-primary text-primary-foreground shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]"
                         : "bg-background shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] hover:translate-x-0.5 hover:translate-y-0.5 hover:shadow-[2px_2px_0px_0px_rgba(26,26,26,1)]"
-                    }`}
+                    } disabled:opacity-60`}
                   >
                     Tenant
                   </button>
@@ -114,30 +137,37 @@ export default function SignupPage() {
                     onClick={() => setUserType("landlord")}
                     role="radio"
                     aria-checked={userType === "landlord"}
+                    disabled={isSubmitting}
                     className={`border-3 border-foreground p-4 font-mono font-bold transition-all ${
                       userType === "landlord"
                         ? "bg-primary text-primary-foreground shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]"
                         : "bg-background shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] hover:translate-x-0.5 hover:translate-y-0.5 hover:shadow-[2px_2px_0px_0px_rgba(26,26,26,1)]"
-                    }`}
+                    } disabled:opacity-60`}
                   >
                     Landlord
                   </button>
                 </div>
               </fieldset>
 
-              {/* Whistleblower Option */}
               <div className="mb-6">
-                <p className="text-xs text-muted-foreground mb-2">
-                  Or earn money reporting vacant apartments:
-                </p>
+                <p className="text-xs text-muted-foreground mb-2">Or earn money reporting vacant apartments:</p>
                 <Link href="/whistleblower/signup">
-                  <Button className="w-full border-3 border-foreground bg-secondary px-4 py-3 font-mono font-bold transition-all shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] hover:translate-x-0.5 hover:translate-y-0.5 hover:shadow-[2px_2px_0px_0px_rgba(26,26,26,1)]">
+                  <Button
+                    disabled={isSubmitting}
+                    className="w-full border-3 border-foreground bg-secondary px-4 py-3 font-mono font-bold transition-all shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] hover:translate-x-0.5 hover:translate-y-0.5 hover:shadow-[2px_2px_0px_0px_rgba(26,26,26,1)]"
+                  >
                     Become a Whistleblower
                   </Button>
                 </Link>
               </div>
 
-              <form onSubmit={handleSubmit(onSubmit)} className="space-y-5">
+              {errors.root?.serverError?.message && (
+                <div role="alert" className="border-2 border-destructive bg-destructive/10 p-3 text-sm font-medium text-destructive">
+                  {errors.root.serverError.message}
+                </div>
+              )}
+
+              <form onSubmit={handleSubmit(onSubmit)} className="space-y-5" noValidate>
                 <div className="space-y-2">
                   <label htmlFor="full-name" className="block font-mono text-sm font-bold">
                     Full Name
@@ -145,14 +175,17 @@ export default function SignupPage() {
                   <Input
                     id="full-name"
                     type="text"
-                    {...register("fullName")}
+                    {...register("fullName", { onChange: () => clearErrors(["fullName", "root.serverError"]) })}
                     placeholder="Enter your full name"
+                    aria-invalid={Boolean(errors.fullName)}
+                    aria-describedby={errors.fullName ? "signup-full-name-error" : undefined}
+                    disabled={isSubmitting}
                     className={`border-3 border-foreground py-6 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] focus:translate-x-0.5 focus:translate-y-0.5 focus:shadow-[2px_2px_0px_0px_rgba(26,26,26,1)] ${
                       errors.fullName ? "border-destructive" : ""
                     }`}
                   />
-                  {errors.fullName && (
-                    <p className="text-xs font-bold text-destructive">
+                  {errors.fullName?.message && (
+                    <p id="signup-full-name-error" role="alert" className="text-xs font-bold text-destructive">
                       {errors.fullName.message}
                     </p>
                   )}
@@ -165,14 +198,17 @@ export default function SignupPage() {
                   <Input
                     id="email"
                     type="email"
-                    {...register("email")}
+                    {...register("email", { onChange: () => clearErrors(["email", "root.serverError"]) })}
                     placeholder="you@email.com"
+                    aria-invalid={Boolean(errors.email)}
+                    aria-describedby={errors.email ? "signup-email-error" : undefined}
+                    disabled={isSubmitting}
                     className={`border-3 border-foreground py-6 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] focus:translate-x-0.5 focus:translate-y-0.5 focus:shadow-[2px_2px_0px_0px_rgba(26,26,26,1)] ${
                       errors.email ? "border-destructive" : ""
                     }`}
                   />
-                  {errors.email && (
-                    <p className="text-xs font-bold text-destructive">
+                  {errors.email?.message && (
+                    <p id="signup-email-error" role="alert" className="text-xs font-bold text-destructive">
                       {errors.email.message}
                     </p>
                   )}
@@ -185,14 +221,17 @@ export default function SignupPage() {
                   <Input
                     id="phone"
                     type="tel"
-                    {...register("phone")}
+                    {...register("phone", { onChange: () => clearErrors(["phone", "root.serverError"]) })}
                     placeholder="08X XXX XXXX"
+                    aria-invalid={Boolean(errors.phone)}
+                    aria-describedby={errors.phone ? "signup-phone-error" : undefined}
+                    disabled={isSubmitting}
                     className={`border-3 border-foreground py-6 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] focus:translate-x-0.5 focus:translate-y-0.5 focus:shadow-[2px_2px_0px_0px_rgba(26,26,26,1)] ${
                       errors.phone ? "border-destructive" : ""
                     }`}
                   />
-                  {errors.phone && (
-                    <p className="text-xs font-bold text-destructive">
+                  {errors.phone?.message && (
+                    <p id="signup-phone-error" role="alert" className="text-xs font-bold text-destructive">
                       {errors.phone.message}
                     </p>
                   )}
@@ -206,8 +245,11 @@ export default function SignupPage() {
                     <Input
                       id="password"
                       type={showPassword ? "text" : "password"}
-                      {...register("password")}
+                      {...register("password", { onChange: () => clearErrors(["password", "root.serverError"]) })}
                       placeholder="Create a password"
+                      aria-invalid={Boolean(errors.password)}
+                      aria-describedby={errors.password ? "signup-password-error" : undefined}
+                      disabled={isSubmitting}
                       className={`border-3 border-foreground py-6 pr-12 shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] focus:translate-x-0.5 focus:translate-y-0.5 focus:shadow-[2px_2px_0px_0px_rgba(26,26,26,1)] ${
                         errors.password ? "border-destructive" : ""
                       }`}
@@ -218,16 +260,13 @@ export default function SignupPage() {
                       className="absolute right-4 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
                       aria-label={showPassword ? "Hide password" : "Show password"}
                       aria-pressed={showPassword}
+                      disabled={isSubmitting}
                     >
-                      {showPassword ? (
-                        <EyeOff className="h-5 w-5" />
-                      ) : (
-                        <Eye className="h-5 w-5" />
-                      )}
+                      {showPassword ? <EyeOff className="h-5 w-5" /> : <Eye className="h-5 w-5" />}
                     </button>
                   </div>
-                  {errors.password && (
-                    <p className="text-xs font-bold text-destructive">
+                  {errors.password?.message && (
+                    <p id="signup-password-error" role="alert" className="text-xs font-bold text-destructive">
                       {errors.password.message}
                     </p>
                   )}
@@ -242,32 +281,27 @@ export default function SignupPage() {
                         valid: /\d/.test(password),
                       },
                     ].map((rule) => (
-                      <div
-                        key={rule.label}
-                        className="flex items-center gap-2 text-xs"
-                      >
+                      <div key={rule.label} className="flex items-center gap-2 text-xs">
                         <div
                           className={`h-4 w-4 border-2 border-foreground flex items-center justify-center ${rule.valid ? "bg-secondary" : "bg-background"}`}
                         >
                           {rule.valid && <Check className="h-3 w-3" />}
                         </div>
-                        <span
-                          className={
-                            rule.valid ? "text-foreground" : "text-muted-foreground"
-                          }
-                        >
-                          {rule.label}
-                        </span>
+                        <span className={rule.valid ? "text-foreground" : "text-muted-foreground"}>{rule.label}</span>
                       </div>
                     ))}
                   </div>
                 </div>
 
                 <div className="pt-2 space-y-1">
-                  <label className="flex items-start gap-3 cursor-pointer">
+                  <label className="flex items-start gap-3 cursor-pointer" htmlFor="signup-terms">
                     <input
+                      id="signup-terms"
                       type="checkbox"
-                      {...register("terms")}
+                      {...register("terms", { onChange: () => clearErrors(["terms", "root.serverError"]) })}
+                      aria-invalid={Boolean(errors.terms)}
+                      aria-describedby={errors.terms ? "signup-terms-error" : undefined}
+                      disabled={isSubmitting}
                       className={`mt-1 h-5 w-5 border-2 border-foreground accent-primary ${
                         errors.terms ? "border-destructive" : ""
                       }`}
@@ -289,8 +323,8 @@ export default function SignupPage() {
                       </Link>
                     </span>
                   </label>
-                  {errors.terms && (
-                    <p className="text-xs font-bold text-destructive">
+                  {errors.terms?.message && (
+                    <p id="signup-terms-error" role="alert" className="text-xs font-bold text-destructive">
                       {errors.terms.message}
                     </p>
                   )}
@@ -298,13 +332,22 @@ export default function SignupPage() {
 
                 <Button
                   type="submit"
-                  disabled={loading}
+                  disabled={isSubmitting}
                   className={`w-full border-3 border-foreground px-8 py-6 text-lg font-bold shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] transition-all hover:translate-x-0.5 hover:translate-y-0.5 hover:shadow-[2px_2px_0px_0px_rgba(26,26,26,1)] ${
                     userType === "tenant" ? "bg-primary" : "bg-secondary"
                   } disabled:opacity-60`}
                 >
-                  {loading ? "Creating Account..." : "Create Account"}
-                  <ArrowRight className="ml-2 h-5 w-5" />
+                  {isSubmitting ? (
+                    <>
+                      <Loader2 className="mr-2 h-5 w-5 animate-spin" />
+                      Creating Account...
+                    </>
+                  ) : (
+                    <>
+                      Create Account
+                      <ArrowRight className="ml-2 h-5 w-5" />
+                    </>
+                  )}
                 </Button>
               </form>
             </TabsContent>
@@ -313,10 +356,7 @@ export default function SignupPage() {
           <div className="mt-6 text-center">
             <p className="text-muted-foreground">
               Already have an account?{" "}
-              <Link
-                href="/login"
-                className="font-bold text-primary hover:underline"
-              >
+              <Link href="/login" className="font-bold text-primary hover:underline">
                 Sign in
               </Link>
             </p>

--- a/frontend/app/verify-otp/page.tsx
+++ b/frontend/app/verify-otp/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, Suspense } from "react";
+import React, { Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { ArrowRight, Loader2 } from "lucide-react";
@@ -8,6 +8,10 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { verifyOtp } from "@/lib/authApi";
 import { handleAuthRedirect } from "@/lib/auth";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { otpSchema, type OtpFormValues } from "@/lib/formSchemas";
+import { parseFormError } from "@/lib/formErrors";
 
 function VerifyOtpForm() {
   const router = useRouter();
@@ -15,23 +19,32 @@ function VerifyOtpForm() {
   const email = searchParams.get("email") ?? "";
   const returnTo = searchParams.get("returnTo");
 
-  const [otp, setOtp] = useState("");
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const {
+    register,
+    handleSubmit,
+    setError,
+    setFocus,
+    clearErrors,
+    formState: { errors, isSubmitting },
+  } = useForm<OtpFormValues>({
+    resolver: zodResolver(otpSchema),
+    mode: "onBlur",
+    reValidateMode: "onBlur",
+    shouldFocusError: true,
+    defaultValues: { otp: "" },
+  });
 
-  const handleSubmit: React.FormEventHandler<HTMLFormElement> = async (e) => {
-    e.preventDefault();
-    setError(null);
-    setLoading(true);
+  const onSubmit = async (data: OtpFormValues) => {
+    if (isSubmitting) return;
+
+    clearErrors("root");
 
     try {
-      const res = await verifyOtp(email, otp);
-      
-      // Use handleAuthRedirect to handle returnTo or default to role-based dashboard
+      const res = await verifyOtp(email, data.otp);
+
       if (returnTo) {
         handleAuthRedirect(returnTo);
       } else {
-        // Fallback to role-based dashboard routing
         const roleRoutes: Record<string, string> = {
           tenant: "/dashboard/tenant",
           landlord: "/dashboard/landlord",
@@ -39,10 +52,14 @@ function VerifyOtpForm() {
         };
         router.push(roleRoutes[res.user.role] ?? "/dashboard/tenant");
       }
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Invalid OTP");
-    } finally {
-      setLoading(false);
+    } catch (error) {
+      const { message, fieldErrors } = parseFormError(error, "Invalid OTP");
+      if (fieldErrors.otp) {
+        setError("otp", { type: "server", message: fieldErrors.otp });
+        setFocus("otp");
+        return;
+      }
+      setError("root.serverError", { type: "server", message });
     }
   };
 
@@ -61,55 +78,56 @@ function VerifyOtpForm() {
         <div className="border-3 border-foreground bg-card p-8 shadow-[8px_8px_0px_0px_rgba(26,26,26,1)]">
           <h1 className="mb-6 font-mono text-2xl font-black">Verify OTP</h1>
 
-          {error && (
-            <div className="mb-4 border-2 border-destructive bg-destructive/10 p-3 text-sm font-medium text-destructive">
-              {error}
+          {errors.root?.serverError?.message && (
+            <div role="alert" className="mb-4 border-2 border-destructive bg-destructive/10 p-3 text-sm font-medium text-destructive">
+              {errors.root.serverError.message}
             </div>
           )}
 
-          <form onSubmit={handleSubmit} className="space-y-6">
+          <form onSubmit={handleSubmit(onSubmit)} className="space-y-6" noValidate>
             <div>
-              <label
-                htmlFor="otp"
-                className="mb-2 block font-mono text-sm font-bold"
-              >
+              <label htmlFor="otp" className="mb-2 block font-mono text-sm font-bold">
                 One-Time Password
               </label>
               <Input
                 id="otp"
                 type="text"
                 inputMode="numeric"
-                value={otp}
-                onChange={(e) => setOtp(e.target.value)}
+                {...register("otp", { onChange: () => clearErrors(["otp", "root.serverError"]) })}
                 placeholder="123456"
-                className="border-3 border-foreground py-6 text-center text-2xl tracking-[0.5em] shadow-[4px_4px_0px_0px_rgba(26,26,26,1)]"
-                required
-                disabled={loading}
+                aria-invalid={Boolean(errors.otp)}
+                aria-describedby={errors.otp ? "otp-error" : undefined}
+                className={`border-3 border-foreground py-6 text-center text-2xl tracking-[0.5em] shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] ${
+                  errors.otp ? "border-destructive" : ""
+                }`}
+                disabled={isSubmitting}
                 maxLength={6}
               />
+              {errors.otp?.message && (
+                <p id="otp-error" role="alert" className="mt-2 text-xs font-bold text-destructive">
+                  {errors.otp.message}
+                </p>
+              )}
             </div>
 
             <Button
               type="submit"
-              disabled={loading}
+              disabled={isSubmitting}
               className="w-full border-3 border-foreground bg-primary px-8 py-6 text-lg font-bold shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] transition-all hover:translate-x-0.5 hover:translate-y-0.5 hover:shadow-[2px_2px_0px_0px_rgba(26,26,26,1)] disabled:opacity-60"
             >
-              {loading ? (
+              {isSubmitting ? (
                 <Loader2 className="mr-2 h-5 w-5 animate-spin" />
               ) : (
                 <ArrowRight className="ml-2 h-5 w-5" />
               )}
-              {loading ? "Verifying..." : "Verify & Sign In"}
+              {isSubmitting ? "Verifying..." : "Verify & Sign In"}
             </Button>
           </form>
 
           <div className="mt-6 text-center">
             <p className="text-muted-foreground text-sm">
               Didn&apos;t receive it?{" "}
-              <Link
-                href={`/login`}
-                className="font-bold text-primary hover:underline"
-              >
+              <Link href="/login" className="font-bold text-primary hover:underline">
                 Try again
               </Link>
             </p>

--- a/frontend/hooks/useAppForm.ts
+++ b/frontend/hooks/useAppForm.ts
@@ -50,7 +50,9 @@ export function useAppForm<T extends FieldValues>({
   const form = useForm<T>({
     resolver: zodResolver(schema),
     defaultValues: mergedDefaults,
-    mode: "onChange",
+    mode: "onBlur",
+    reValidateMode: "onBlur",
+    shouldFocusError: true,
     ...rest,
   });
 

--- a/frontend/lib/formErrors.ts
+++ b/frontend/lib/formErrors.ts
@@ -1,0 +1,51 @@
+import { parseBackendError } from "@/lib/errors";
+
+export type FieldErrors = Record<string, string>;
+
+function toMessage(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    const [first] = value;
+    return typeof first === "string" ? first : undefined;
+  }
+  return undefined;
+}
+
+export function extractFieldErrors(details: unknown): FieldErrors {
+  if (!details || typeof details !== "object") {
+    return {};
+  }
+
+  const rawDetails = details as Record<string, unknown>;
+  const maybeFieldErrors = rawDetails.fieldErrors;
+  const source =
+    maybeFieldErrors && typeof maybeFieldErrors === "object" && !Array.isArray(maybeFieldErrors)
+      ? (maybeFieldErrors as Record<string, unknown>)
+      : rawDetails;
+
+  return Object.fromEntries(
+    Object.entries(source)
+      .map(([field, value]) => [field, toMessage(value)])
+      .filter((entry): entry is [string, string] => Boolean(entry[1]))
+  );
+}
+
+export function parseFormError(error: unknown, fallbackMessage: string): {
+  message: string;
+  fieldErrors: FieldErrors;
+} {
+  const parsed = parseBackendError(error, fallbackMessage);
+  const details =
+    parsed.details ??
+    (error && typeof error === "object" && "details" in error
+      ? (error as { details?: unknown }).details
+      : undefined);
+  const fieldErrors = extractFieldErrors(details);
+
+  return {
+    message: parsed.userMessage || fallbackMessage,
+    fieldErrors,
+  };
+}

--- a/frontend/lib/formSchemas.ts
+++ b/frontend/lib/formSchemas.ts
@@ -36,6 +36,19 @@ export const signupSchema = z.object({
   name: z.string().min(2, "Name must be at least 2 characters"),
 });
 
+export const accountSignupSchema = z.object({
+  fullName: z.string().min(2, "Full name must be at least 2 characters"),
+  email: emailSchema,
+  phone: z.string().min(10, "Phone number must be at least 10 digits"),
+  password: z
+    .string()
+    .min(8, "Password must be at least 8 characters")
+    .regex(/\d/, "Password must contain at least one number"),
+  terms: z.literal(true, {
+    errorMap: () => ({ message: "You must agree to the Terms and Privacy Policy" }),
+  }),
+});
+
 // ── Staking ───────────────────────────────────────────────────────────────────
 
 export const stakeSchema = z.object({
@@ -102,6 +115,7 @@ export const preScreenSchema = z.object({
 export type LoginFormValues = z.infer<typeof loginSchema>;
 export type OtpFormValues = z.infer<typeof otpSchema>;
 export type SignupFormValues = z.infer<typeof signupSchema>;
+export type AccountSignupFormValues = z.infer<typeof accountSignupSchema>;
 export type StakeFormValues = z.infer<typeof stakeSchema>;
 export type DepositFormValues = z.infer<typeof depositSchema>;
 export type WhistleblowerFormValues = z.infer<typeof whistleblowerSchema>;


### PR DESCRIPTION
## Summary

Standardize frontend auth form validation and error handling for login, signup, and OTP verification by converging on shared schemas, consistent RHF validation timing, server field-error mapping, accessible error rendering, and submit in-flight protection.

## Linked issue (recommended)

Closes Shelterflex/monorepo#1352.

## Changes

- Added form validation/error-handling convention doc: `frontend/FORM_VALIDATION_CONVENTION.md`
- Linked convention in `frontend/README.md`
- Updated shared form defaults in `hooks/useAppForm.ts` to `onBlur` + focus-first-error behavior
- Added `frontend/lib/formErrors.ts` for backend `details/fieldErrors` extraction and parsing
- Added `accountSignupSchema` in `frontend/lib/formSchemas.ts`
- Refactored:
  - `frontend/app/login/page.tsx`
  - `frontend/app/signup/page.tsx`
  - `frontend/app/verify-otp/page.tsx`
  to use consistent schema-driven validation, field/server error mapping, accessibility attributes, and disabled submit while in-flight
- Added focused tests:
  - `frontend/app/login/page.test.tsx`
  - `frontend/app/signup/page.test.tsx`
  covering validation behavior, server error mapping, and double-submit prevention

## Contract Upgrade Details (if applicable)

N/A — no contract changes.

## How to test

- [x] `cd frontend && pnpm install --frozen-lockfile`
- [x] `cd frontend && pnpm exec vitest run app/login/page.test.tsx app/signup/page.test.tsx`
- [x] `cd frontend && pnpm run lint`
- [x] `cd frontend && pnpm run build`

## Security Considerations

- [x] No secrets or sensitive data are logged
- [x] No authz/admin privilege model changes
- [x] No contract/admin upgrade logic changes

## Screenshots (if UI)

UI behavior change is limited to validation and error states; no visual redesign.

## Checklist

- [x] I linked an issue (or explained why one is not needed)
- [x] I tested locally
- [x] I did not commit secrets
- [x] I updated docs if needed
- [x] Code follows the project's style guidelines
- [x] CI checks pass locally for frontend lint/build
- [ ] If UI changes: I included before/after screenshots
- [ ] If images added/changed: I verified they are optimized and accessible
