### PR TITLE
fix(backend): add safe manifest-based migration ordering

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -48,9 +48,23 @@ Tests are located in `src/**/*.test.ts` files and use Vitest + Supertest.
 
 ## Database migrations
 
-SQL migrations live in `migrations/` and are applied in filename order.
+SQL migrations live in `migrations/`.
 
-The repository includes a migration runner script in `src/repositories/test.ts` that:
+At runtime (`src/migrations/runMigrations.ts`), migrations are:
+
+- tracked by **exact filename** in `schema_migrations.filename`
+- wrapped in a transaction per file
+- skipped when that exact filename already exists in `schema_migrations`
+
+Because tracking is filename-based, renaming an already-applied migration is unsafe (it can make an applied migration look unapplied and cause re-execution).
+
+Ordering is resolved by `src/migrations/migrationOrdering.ts`:
+
+- legacy files are pinned in `migrations/migration-order.manifest.json` with unique integer positions
+- new files not listed in the manifest must use `YYYYMMDDHHMMSS_description.sql`
+- timestamp-prefixed files are appended in lexicographic order (chronological) and duplicate timestamps are rejected
+
+The repository includes a database setup script in `src/repositories/test.ts` that:
 
 - creates a `schema_migrations` table if missing
 - applies any `.sql` files not yet recorded
@@ -499,4 +513,3 @@ LOCAL_STORAGE_DIR=/tmp/shelterflex-dev
 ```
 
 This is useful for local development when you don't want to run MinIO.
-

--- a/backend/migrations/migration-order.manifest.json
+++ b/backend/migrations/migration-order.manifest.json
@@ -1,0 +1,269 @@
+{
+  "version": 1,
+  "legacyMigrations": [
+    {
+      "position": 1,
+      "filename": "001_init.sql"
+    },
+    {
+      "position": 2,
+      "filename": "002_ngn_deposits.sql"
+    },
+    {
+      "position": 3,
+      "filename": "003_conversions.sql"
+    },
+    {
+      "position": 4,
+      "filename": "003_receipt_indexer.sql"
+    },
+    {
+      "position": 5,
+      "filename": "004_wallets_and_linked_addresses.sql"
+    },
+    {
+      "position": 6,
+      "filename": "005_auth_tables.sql"
+    },
+    {
+      "position": 7,
+      "filename": "005_outbox.sql"
+    },
+    {
+      "position": 8,
+      "filename": "006_deal_listing_reward_store.sql"
+    },
+    {
+      "position": 9,
+      "filename": "007_job_scheduler.sql"
+    },
+    {
+      "position": 10,
+      "filename": "007_landlord_properties.sql"
+    },
+    {
+      "position": 11,
+      "filename": "007_user_tiers.sql"
+    },
+    {
+      "position": 12,
+      "filename": "008_audit_log.sql"
+    },
+    {
+      "position": 13,
+      "filename": "008_timelock_governance.sql"
+    },
+    {
+      "position": 14,
+      "filename": "008_webhook_replay.sql"
+    },
+    {
+      "position": 15,
+      "filename": "009_outbox_dead_status.sql"
+    },
+    {
+      "position": 16,
+      "filename": "010_landlord_profiles.sql"
+    },
+    {
+      "position": 17,
+      "filename": "011_tenant_applications.sql"
+    },
+    {
+      "position": 18,
+      "filename": "012_webhook_event_dedupe.sql"
+    },
+    {
+      "position": 19,
+      "filename": "013_api_idempotency.sql"
+    },
+    {
+      "position": 20,
+      "filename": "014_settlement_outbox.sql"
+    },
+    {
+      "position": 21,
+      "filename": "015_notifications.sql"
+    },
+    {
+      "position": 22,
+      "filename": "016_outbox_dlq_columns.sql"
+    },
+    {
+      "position": 23,
+      "filename": "016_public_application_intake.sql"
+    },
+    {
+      "position": 24,
+      "filename": "016_support_messages.sql"
+    },
+    {
+      "position": 25,
+      "filename": "017_whistleblower_ratings.sql"
+    },
+    {
+      "position": 26,
+      "filename": "018_property_issue_reports.sql"
+    },
+    {
+      "position": 27,
+      "filename": "019_full_payment_settlement_ledger.sql"
+    },
+    {
+      "position": 28,
+      "filename": "020_apartment_reviews.sql"
+    },
+    {
+      "position": 29,
+      "filename": "020_underwriting_decision_traces.sql"
+    },
+    {
+      "position": 30,
+      "filename": "021_kyc_documents.sql"
+    },
+    {
+      "position": 31,
+      "filename": "022_payment_disputes.sql"
+    },
+    {
+      "position": 32,
+      "filename": "023_reconciliation.sql"
+    },
+    {
+      "position": 33,
+      "filename": "024_sessions_device_tracking.sql"
+    },
+    {
+      "position": 34,
+      "filename": "025_job_scheduler_leases.sql"
+    },
+    {
+      "position": 35,
+      "filename": "025_property_photos.sql"
+    },
+    {
+      "position": 36,
+      "filename": "025_tenant_documents.sql"
+    },
+    {
+      "position": 37,
+      "filename": "026_fraud_detection.sql"
+    },
+    {
+      "position": 38,
+      "filename": "026_landlord_payouts.sql"
+    },
+    {
+      "position": 39,
+      "filename": "027_kyc_attempt_count.sql"
+    },
+    {
+      "position": 40,
+      "filename": "027_user_display_currency.sql"
+    },
+    {
+      "position": 41,
+      "filename": "028_landlord_property_listing_fields.sql"
+    },
+    {
+      "position": 42,
+      "filename": "028_onboarding_drafts.sql"
+    },
+    {
+      "position": 43,
+      "filename": "029_inspection_jobs.sql"
+    },
+    {
+      "position": 44,
+      "filename": "030_two_tier_pricing.sql"
+    },
+    {
+      "position": 45,
+      "filename": "031_rent_guarantee_policies.sql"
+    },
+    {
+      "position": 46,
+      "filename": "032_tenant_rating_card.sql"
+    },
+    {
+      "position": 47,
+      "filename": "033_background_check_results.sql"
+    },
+    {
+      "position": 48,
+      "filename": "033_erasure_requests.sql"
+    },
+    {
+      "position": 49,
+      "filename": "033_underwriting_ai_risk_score.sql"
+    },
+    {
+      "position": 50,
+      "filename": "034_add_missing_indexes.sql"
+    },
+    {
+      "position": 51,
+      "filename": "035_admin_rbac.sql"
+    },
+    {
+      "position": 52,
+      "filename": "036_listings_search_vector.sql"
+    },
+    {
+      "position": 53,
+      "filename": "036_tenant_document_presign.sql"
+    },
+    {
+      "position": 54,
+      "filename": "037_credit_score_snapshots.sql"
+    },
+    {
+      "position": 55,
+      "filename": "037_refresh_tokens.sql"
+    },
+    {
+      "position": 56,
+      "filename": "037_repayment_schedule.sql"
+    },
+    {
+      "position": 57,
+      "filename": "038_soroban_event_indexer.sql"
+    },
+    {
+      "position": 58,
+      "filename": "039_landlord_verification.sql"
+    },
+    {
+      "position": 59,
+      "filename": "039_soft_delete_data_retention.sql"
+    },
+    {
+      "position": 60,
+      "filename": "039_tenant_documents_deal_linkage.sql"
+    },
+    {
+      "position": 61,
+      "filename": "040_property_inspections.sql"
+    },
+    {
+      "position": 62,
+      "filename": "040_tenant_referral_programme.sql"
+    },
+    {
+      "position": 63,
+      "filename": "041_outbox_exactly_once.sql"
+    },
+    {
+      "position": 64,
+      "filename": "042_conversion_saga.sql"
+    },
+    {
+      "position": 65,
+      "filename": "043_stellar_sequence_allocator.sql"
+    },
+    {
+      "position": 66,
+      "filename": "044_signing_key_rotation.sql"
+    }
+  ]
+}

--- a/backend/src/migrations/migrationOrdering.test.ts
+++ b/backend/src/migrations/migrationOrdering.test.ts
@@ -1,0 +1,76 @@
+import { readFile, readdir } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import {
+  buildOrderedMigrationFiles,
+  type LegacyMigrationManifest,
+} from './migrationOrdering.js'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const migrationsDir = path.resolve(__dirname, '../../migrations')
+
+describe('migration ordering manifest', () => {
+  it('orders legacy migrations and appends timestamped migrations', async () => {
+    const sqlFiles = (await readdir(migrationsDir)).filter((file) => file.endsWith('.sql'))
+    const manifestRaw = await readFile(
+      path.join(migrationsDir, 'migration-order.manifest.json'),
+      'utf8',
+    )
+    const manifest = JSON.parse(manifestRaw) as LegacyMigrationManifest
+
+    const orderedFiles = buildOrderedMigrationFiles(sqlFiles, manifest)
+
+    expect(orderedFiles).toHaveLength(sqlFiles.length)
+    expect(new Set(orderedFiles).size).toBe(sqlFiles.length)
+
+    const manifestFiles = manifest.legacyMigrations
+      .sort((a, b) => a.position - b.position)
+      .map((entry) => entry.filename)
+    const manifestSet = new Set(manifestFiles)
+    const timestampedFiles = sqlFiles
+      .filter((file) => !manifestSet.has(file))
+      .sort((a, b) => a.localeCompare(b))
+    expect(orderedFiles).toEqual([...manifestFiles, ...timestampedFiles])
+  })
+
+  it('fails on duplicate legacy positions', () => {
+    expect(() =>
+      buildOrderedMigrationFiles(['001_init.sql', '002_ngn_deposits.sql'], {
+        version: 1,
+        legacyMigrations: [
+          { position: 1, filename: '001_init.sql' },
+          { position: 1, filename: '002_ngn_deposits.sql' },
+        ],
+      }),
+    ).toThrow('Duplicate migration position 1 in legacy manifest.')
+  })
+
+  it('fails when a new migration is not timestamp-prefixed', () => {
+    expect(() =>
+      buildOrderedMigrationFiles(['001_init.sql', 'new_feature.sql'], {
+        version: 1,
+        legacyMigrations: [{ position: 1, filename: '001_init.sql' }],
+      }),
+    ).toThrow(
+      'New migration must use timestamp prefix YYYYMMDDHHMMSS_description.sql: new_feature.sql',
+    )
+  })
+
+  it('fails when two timestamped migrations share a prefix', () => {
+    expect(() =>
+      buildOrderedMigrationFiles(
+        [
+          '001_init.sql',
+          '20260727120000_add_table.sql',
+          '20260727120000_add_index.sql',
+        ],
+        {
+          version: 1,
+          legacyMigrations: [{ position: 1, filename: '001_init.sql' }],
+        },
+      ),
+    ).toThrow('Duplicate migration timestamp prefix 20260727120000 detected.')
+  })
+})

--- a/backend/src/migrations/migrationOrdering.ts
+++ b/backend/src/migrations/migrationOrdering.ts
@@ -1,0 +1,80 @@
+import { readFile, readdir } from 'node:fs/promises'
+import path from 'node:path'
+
+const LEGACY_MANIFEST_FILENAME = 'migration-order.manifest.json'
+const LEGACY_PREFIX = /^\d{3}_.+\.sql$/
+const TIMESTAMPED_PREFIX = /^(\d{14})_[a-z0-9][a-z0-9_]*\.sql$/i
+
+export type LegacyMigrationManifest = {
+  version: number
+  legacyMigrations: Array<{
+    position: number
+    filename: string
+  }>
+}
+
+export async function getOrderedMigrationFiles(migrationsDir: string): Promise<string[]> {
+  const sqlFiles = (await readdir(migrationsDir)).filter((file) => file.endsWith('.sql'))
+  const manifestPath = path.join(migrationsDir, LEGACY_MANIFEST_FILENAME)
+  const manifestRaw = await readFile(manifestPath, 'utf8')
+  const manifest = JSON.parse(manifestRaw) as LegacyMigrationManifest
+
+  return buildOrderedMigrationFiles(sqlFiles, manifest)
+}
+
+export function buildOrderedMigrationFiles(
+  sqlFiles: string[],
+  manifest: LegacyMigrationManifest,
+): string[] {
+  const files = Array.from(new Set(sqlFiles))
+
+  const positions = new Set<number>()
+  const manifestFilenames = new Set<string>()
+  for (const entry of manifest.legacyMigrations) {
+    if (positions.has(entry.position)) {
+      throw new Error(`Duplicate migration position ${entry.position} in legacy manifest.`)
+    }
+    positions.add(entry.position)
+
+    if (manifestFilenames.has(entry.filename)) {
+      throw new Error(`Duplicate migration filename ${entry.filename} in legacy manifest.`)
+    }
+    manifestFilenames.add(entry.filename)
+
+    if (!files.includes(entry.filename)) {
+      throw new Error(`Legacy migration missing from disk: ${entry.filename}`)
+    }
+  }
+
+  const unmanagedLegacy = files.filter(
+    (file) => LEGACY_PREFIX.test(file) && !manifestFilenames.has(file),
+  )
+  if (unmanagedLegacy.length > 0) {
+    throw new Error(
+      `Legacy-prefixed migrations must be declared in ${LEGACY_MANIFEST_FILENAME}: ${unmanagedLegacy.join(', ')}`,
+    )
+  }
+
+  const timestampedFiles = files.filter((file) => !manifestFilenames.has(file))
+  const timestampPrefixes = new Set<string>()
+  for (const file of timestampedFiles) {
+    const match = TIMESTAMPED_PREFIX.exec(file)
+    if (!match) {
+      throw new Error(
+        `New migration must use timestamp prefix YYYYMMDDHHMMSS_description.sql: ${file}`,
+      )
+    }
+
+    const prefix = match[1]
+    if (timestampPrefixes.has(prefix)) {
+      throw new Error(`Duplicate migration timestamp prefix ${prefix} detected.`)
+    }
+    timestampPrefixes.add(prefix)
+  }
+
+  const orderedLegacy = [...manifest.legacyMigrations]
+    .sort((a, b) => a.position - b.position)
+    .map((entry) => entry.filename)
+
+  return [...orderedLegacy, ...timestampedFiles.sort((a, b) => a.localeCompare(b))]
+}

--- a/backend/src/migrations/runMigrations.ts
+++ b/backend/src/migrations/runMigrations.ts
@@ -1,6 +1,7 @@
-import { readFile, readdir } from 'node:fs/promises'
+import { readFile } from 'node:fs/promises'
 import path from 'node:path'
 import { Pool } from 'pg'
+import { getOrderedMigrationFiles } from './migrationOrdering.js'
 
 const DB_CONNECT_RETRIES = parseInt(process.env.DB_CONNECT_RETRIES ?? '5', 10)
 const DB_CONNECT_RETRY_MS = parseInt(process.env.DB_CONNECT_RETRY_MS ?? '2000', 10)
@@ -52,9 +53,7 @@ export async function runMigrationsIfNeeded() {
       )
     `)
 
-    const files = (await readdir(migrationsDir))
-      .filter((file) => file.endsWith('.sql'))
-      .sort((a, b) => a.localeCompare(b))
+    const files = await getOrderedMigrationFiles(migrationsDir)
 
     for (const file of files) {
       const alreadyApplied = await pool.query(

--- a/backend/src/repositories/test.ts
+++ b/backend/src/repositories/test.ts
@@ -1,6 +1,7 @@
-import { readFile, readdir } from "node:fs/promises";
+import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { getOrderedMigrationFiles } from "../migrations/migrationOrdering.js";
 
 const databaseUrl = process.env.DATABASE_URL;
 
@@ -23,9 +24,7 @@ async function runMigrations(pool: any): Promise<void> {
     )
   `);
 
-  const files = (await readdir(migrationsDir))
-    .filter((file) => file.endsWith(".sql"))
-    .sort((a, b) => a.localeCompare(b));
+  const files = await getOrderedMigrationFiles(migrationsDir);
 
   for (const file of files) {
     const alreadyApplied = await pool.query(


### PR DESCRIPTION
## Summary
Adds explicit, production-safe migration ordering without renaming historical migration files that may already be applied. The backend now reads a legacy ordering manifest and enforces timestamp prefixes for new migrations.

## Linked issue (recommended)
Closes Shelterflex/monorepo#1355.

## Changes
- Added `backend/migrations/migration-order.manifest.json` to pin unique positions for legacy migrations.
- Added `backend/src/migrations/migrationOrdering.ts` to:
  - validate manifest uniqueness/existence,
  - prevent unmanaged legacy-prefixed migrations,
  - require `YYYYMMDDHHMMSS_description.sql` for new migrations,
  - reject duplicate timestamp prefixes,
  - compute deterministic execution order.
- Updated `runMigrationsIfNeeded` and `src/repositories/test.ts` to use shared ordering logic.
- Added `backend/src/migrations/migrationOrdering.test.ts` to fail on duplicate positions/prefix collisions.
- Documented runner ordering/tracking and filename-safety in `backend/README.md`.

## Contract Upgrade Details (if applicable)
N/A

## How to test
- [x] `cd backend && npm ci`
- [x] `cd backend && npm run lint`
- [x] `cd backend && npm run test:ci`
- [x] `cd backend && npm run openapi:validate`
- [x] Optional from-scratch check run: `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:55432/shelterflex npx tsx src/repositories/test.ts` (fails early on pre-existing `005_outbox.sql`/`001_init.sql` incompatibility unrelated to this issue).

## Security Considerations
- [x] No secrets or sensitive data are logged
- [x] No changes to authentication/authorization logic without review
- [x] No changes to admin/upgrade logic without review

## Screenshots (if UI)
N/A

## Checklist
- [x] I linked an issue (or explained why one is not needed)
- [x] I tested locally
- [x] I did not commit secrets
- [x] I updated docs if needed
- [x] Code follows the project's style guidelines
- [x] CI checks pass
- [x] If UI changes: I included before/after screenshots
- [x] If images added/changed: I verified they are optimized and accessible
