### PR TITLE
fix(frontend): correct currency conversion formatting display

### DIFF
--- a/frontend/app/wallet/WalletClient.tsx
+++ b/frontend/app/wallet/WalletClient.tsx
@@ -18,6 +18,7 @@ import {
 } from "lucide-react";
 import { handleError, showSuccessToast } from "@/lib/toast";
 import { generateLedgerCsv, downloadCsv } from "@/lib/csvExport";
+import { formatConversionRate, formatNgn, formatUsdc } from "@/lib/currency";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -111,14 +112,6 @@ interface LedgerData {
   hasMore: boolean;
 }
 
-function formatNgn(amount: number) {
-  return new Intl.NumberFormat("en-NG", {
-    style: "currency",
-    currency: "NGN",
-    minimumFractionDigits: 0,
-  }).format(amount);
-}
-
 function humanizeEntryType(type: string) {
   const normalized = type.trim().replaceAll("_", " ");
   if (!normalized) return "Activity";
@@ -159,6 +152,13 @@ function getTypesFromFilterIds(filterIds: string[]): WalletLedgerType[] {
 function getFilterLabel(filterId: string): string {
   const group = FILTER_GROUPS.find((g) => g.id === filterId);
   return group?.label ?? filterId;
+}
+
+function formatDateTime(iso: string): string {
+  return new Intl.DateTimeFormat("en-NG", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(iso));
 }
 
 function WalletPageContent() {
@@ -564,7 +564,9 @@ function WalletPageContent() {
                       <>
                         {currency.code === "NGN"
                           ? formatNgn(currencyBalance.available)
-                          : `${currency.symbol}${currencyBalance.available.toFixed(2)}`}
+                          : currency.code === "USDC"
+                            ? formatUsdc(currencyBalance.available)
+                            : `${currency.symbol}${currencyBalance.available.toFixed(2)}`}
                       </>
                     )}
                   </CardTitle>
@@ -576,7 +578,11 @@ function WalletPageContent() {
                     </p>
                     {currencyBalance && currencyBalance.held > 0 && (
                       <Badge variant="outline" className="text-xs">
-                        Held: {currency.code === "NGN" ? formatNgn(currencyBalance.held) : `${currency.symbol}${currencyBalance.held.toFixed(2)}`}
+                        Held: {currency.code === "NGN"
+                          ? formatNgn(currencyBalance.held)
+                          : currency.code === "USDC"
+                            ? formatUsdc(currencyBalance.held)
+                            : `${currency.symbol}${currencyBalance.held.toFixed(2)}`}
                       </Badge>
                     )}
                   </div>
@@ -631,25 +637,43 @@ function WalletPageContent() {
                       {conversionQuote.type === "success" && (
                         <div className="space-y-2">
                           <div className="flex items-center justify-between text-sm">
-                            <span className="text-muted-foreground">You will receive</span>
+                            <span className="text-muted-foreground">Estimated converted amount</span>
                             <span className="font-mono font-bold">
-                              {selectedCurrency === "NGN" ? "$" : "₦"}
-                              {conversionQuote.data.estimatedToAmount.toFixed(2)}
+                              {selectedCurrency === "NGN"
+                                ? formatUsdc(conversionQuote.data.estimatedToAmount)
+                                : formatNgn(conversionQuote.data.estimatedToAmount)}
                             </span>
                           </div>
                           <div className="flex items-center justify-between text-xs text-muted-foreground">
                             <span>Rate</span>
-                            <span>1 {selectedCurrency} = {conversionQuote.data.rate.toFixed(4)} {selectedCurrency === "NGN" ? "USDC" : "NGN"}</span>
+                            <span>
+                              1 {selectedCurrency} = {formatConversionRate(
+                                conversionQuote.data.rate,
+                                selectedCurrency === "NGN" ? "USDC" : "NGN",
+                                "en-NG",
+                              )}
+                            </span>
                           </div>
                           <div className="flex items-center justify-between text-xs text-muted-foreground">
                             <span>Fees</span>
-                            <span>{selectedCurrency === "NGN" ? "₦" : "$"}{conversionQuote.data.fees.toFixed(2)}</span>
+                            <span>{selectedCurrency === "NGN"
+                              ? formatNgn(conversionQuote.data.fees)
+                              : formatUsdc(conversionQuote.data.fees)}</span>
+                          </div>
+                          <div className="flex items-center justify-between text-xs text-muted-foreground">
+                            <span>Rate valid until</span>
+                            <time dateTime={conversionQuote.data.expiresAt}>
+                              {formatDateTime(conversionQuote.data.expiresAt)}
+                            </time>
                           </div>
                           {conversionQuote.data.disclaimer && (
                             <p className="text-xs text-muted-foreground italic">
                               {conversionQuote.data.disclaimer}
                             </p>
                           )}
+                          <p className="text-xs text-muted-foreground">
+                            Settlement currency: {selectedCurrency}. This preview does not change the amount charged.
+                          </p>
                         </div>
                       )}
                     </div>

--- a/frontend/app/wallet/page.test.tsx
+++ b/frontend/app/wallet/page.test.tsx
@@ -45,15 +45,24 @@ vi.mock("@/lib/csvExport", () => ({
 vi.mock("@/lib/walletApi", () => ({
   getNgnBalance: vi.fn(),
   getNgnLedger: vi.fn(),
+  getMultiCurrencyBalance: vi.fn(),
+  getConversionQuote: vi.fn(),
 }));
 
 import { useSearchParams } from "next/navigation";
-import { getNgnBalance, getNgnLedger } from "@/lib/walletApi";
+import {
+  getConversionQuote,
+  getMultiCurrencyBalance,
+  getNgnBalance,
+  getNgnLedger,
+} from "@/lib/walletApi";
 import { downloadCsv } from "@/lib/csvExport";
 
 type MockUseSearchParams = Mock<typeof useSearchParams>;
 type MockGetNgnBalance = Mock<typeof getNgnBalance>;
 type MockGetNgnLedger = Mock<typeof getNgnLedger>;
+type MockGetMultiCurrencyBalance = Mock<typeof getMultiCurrencyBalance>;
+type MockGetConversionQuote = Mock<typeof getConversionQuote>;
 type MockDownloadCsv = Mock<typeof downloadCsv>;
 
 function ledgerEntry(overrides?: Partial<{ id: string; type: string }>) {
@@ -76,6 +85,27 @@ describe("Wallet CSV export", () => {
 
     const mockLedger = getNgnLedger as MockGetNgnLedger;
     mockLedger.mockResolvedValue({ entries: [ledgerEntry()], nextCursor: null });
+
+    const mockMultiCurrencyBalance = getMultiCurrencyBalance as MockGetMultiCurrencyBalance;
+    mockMultiCurrencyBalance.mockResolvedValue({
+      balances: [
+        { currency: "NGN", available: 0, held: 0, total: 0 },
+        { currency: "USDC", available: 0, held: 0, total: 0 },
+        { currency: "REWARDS", available: 0, held: 0, total: 0 },
+      ],
+    });
+
+    const mockConversionQuote = getConversionQuote as MockGetConversionQuote;
+    mockConversionQuote.mockResolvedValue({
+      quoteId: "q-1",
+      fromCurrency: "NGN",
+      toCurrency: "USDC",
+      fromAmount: 1,
+      estimatedToAmount: 0.001,
+      rate: 0.001,
+      fees: 0.01,
+      expiresAt: "2026-01-01T00:10:00.000Z",
+    });
 
     const mockUseSearchParams = useSearchParams as MockUseSearchParams;
     mockUseSearchParams.mockReturnValue(new URLSearchParams() as any);

--- a/frontend/components/staking/ngn-flow/QuoteDisplay.test.tsx
+++ b/frontend/components/staking/ngn-flow/QuoteDisplay.test.tsx
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QuoteDisplay } from "./QuoteDisplay";
+import type { Quote } from "@/lib/ngnStakingApi";
+
+function makeQuote(): Quote {
+  return {
+    id: "quote-1",
+    ngnAmount: 160000,
+    usdcAmount: 98.1234567,
+    fxRate: 1632.45,
+    fees: {
+      conversionFee: 1500,
+      platformFee: 350,
+      total: 1850,
+    },
+    createdAt: "2026-07-27T10:00:00.000Z",
+    expiresAt: "2026-07-27T10:10:00.000Z",
+  };
+}
+
+describe("QuoteDisplay", () => {
+  it("shows converted amount labels with rate timestamp and settlement currency", () => {
+    render(
+      <QuoteDisplay quote={makeQuote()} onConfirm={vi.fn()} onCancel={vi.fn()} />
+    );
+
+    expect(screen.getByText("Converted amount (estimated)")).toBeInTheDocument();
+    expect(screen.getByText("98.123457 USDC")).toBeInTheDocument();
+    expect(screen.getByText("1 USDC = 1,632.4500 NGN")).toBeInTheDocument();
+    expect(screen.getByText("Rate timestamp")).toBeInTheDocument();
+    expect(screen.getByText("Quote valid until")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Settlement currency: NGN\. Conversion preview does not change the NGN amount charged\./i)
+    ).toBeInTheDocument();
+  });
+
+  it("triggers callbacks from quote actions", async () => {
+    const user = userEvent.setup();
+    const onConfirm = vi.fn();
+    const onCancel = vi.fn();
+    const quote = makeQuote();
+    render(
+      <QuoteDisplay quote={quote} onConfirm={onConfirm} onCancel={onCancel} />
+    );
+
+    await user.click(screen.getByRole("button", { name: /confirm quote/i }));
+    expect(onConfirm).toHaveBeenCalledWith(quote);
+
+    await user.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/components/staking/ngn-flow/QuoteDisplay.tsx
+++ b/frontend/components/staking/ngn-flow/QuoteDisplay.tsx
@@ -7,6 +7,7 @@ import React from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import type { Quote } from '@/lib/ngnStakingApi';
+import { formatConversionRate, formatDecimal, formatNgn } from '@/lib/currency';
 
 export interface QuoteDisplayProps {
   quote: Quote;
@@ -21,12 +22,15 @@ export function QuoteDisplay({
   onCancel,
   isLoading = false,
 }: QuoteDisplayProps) {
-  const formatAmount = (amount: number, decimals: number = 2) => {
-    return amount.toLocaleString('en-US', {
-      minimumFractionDigits: decimals,
-      maximumFractionDigits: decimals,
-    });
-  };
+  const formattedRateTime = new Intl.DateTimeFormat('en-NG', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(new Date(quote.createdAt));
+
+  const formattedExpiry = new Intl.DateTimeFormat('en-NG', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(new Date(quote.expiresAt));
 
   return (
     <Card>
@@ -41,33 +45,48 @@ export function QuoteDisplay({
         <div className="space-y-3 rounded-lg border p-4">
           <div className="flex justify-between">
             <span className="text-sm text-muted-foreground">NGN Amount</span>
-            <span className="font-medium">₦{formatAmount(quote.ngnAmount)}</span>
+            <span className="font-medium">{formatNgn(quote.ngnAmount)}</span>
           </div>
 
           <div className="flex justify-between">
-            <span className="text-sm text-muted-foreground">USDC Amount</span>
-            <span className="font-medium">{formatAmount(quote.usdcAmount, 6)} USDC</span>
+            <span className="text-sm text-muted-foreground">Converted amount (estimated)</span>
+            <span className="font-medium">
+              {formatDecimal(quote.usdcAmount, { locale: 'en-US', minimumFractionDigits: 6, maximumFractionDigits: 6 })} USDC
+            </span>
           </div>
 
           <div className="flex justify-between">
             <span className="text-sm text-muted-foreground">Exchange Rate</span>
-            <span className="font-medium">₦{formatAmount(quote.fxRate)}/USDC</span>
+            <span className="font-medium">1 USDC = {formatConversionRate(quote.fxRate, 'NGN', 'en-NG')}</span>
+          </div>
+
+          <div className="flex justify-between text-sm">
+            <span className="text-muted-foreground">Rate timestamp</span>
+            <time dateTime={quote.createdAt}>{formattedRateTime}</time>
+          </div>
+
+          <div className="flex justify-between text-sm">
+            <span className="text-muted-foreground">Quote valid until</span>
+            <time dateTime={quote.expiresAt}>{formattedExpiry}</time>
           </div>
 
           <div className="border-t pt-3 space-y-2">
             <div className="flex justify-between text-sm">
               <span className="text-muted-foreground">Conversion Fee</span>
-              <span>₦{formatAmount(quote.fees.conversionFee)}</span>
+              <span>{formatNgn(quote.fees.conversionFee)}</span>
             </div>
             <div className="flex justify-between text-sm">
               <span className="text-muted-foreground">Platform Fee</span>
-              <span>₦{formatAmount(quote.fees.platformFee)}</span>
+              <span>{formatNgn(quote.fees.platformFee)}</span>
             </div>
             <div className="flex justify-between font-medium">
               <span>Total Fees</span>
-              <span>₦{formatAmount(quote.fees.total)}</span>
+              <span>{formatNgn(quote.fees.total)}</span>
             </div>
           </div>
+          <p className="text-xs text-muted-foreground">
+            Settlement currency: NGN. Conversion preview does not change the NGN amount charged.
+          </p>
         </div>
 
         {/* Action Buttons */}

--- a/frontend/components/staking/ngn-flow/StatusTracker.tsx
+++ b/frontend/components/staking/ngn-flow/StatusTracker.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Loader2, CheckCircle2 } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
+import { formatUsdc } from "@/lib/currency";
 
 // Type definitions
 export interface StakingPosition {
@@ -93,13 +94,6 @@ function ConfirmedStatus({ position }: ConfirmedStatusProps) {
     });
   };
 
-  const formatAmount = (amount: number) => {
-    return amount.toLocaleString("en-US", {
-      minimumFractionDigits: 2,
-      maximumFractionDigits: 6,
-    });
-  };
-
   return (
     <Card className="border-green-200 bg-green-50/50">
       <CardContent className="space-y-4 py-6">
@@ -118,7 +112,7 @@ function ConfirmedStatus({ position }: ConfirmedStatusProps) {
         <div className="space-y-3 rounded-lg border border-green-200 bg-white p-4">
           <div className="flex justify-between">
             <span className="text-sm text-muted-foreground">Staked Amount</span>
-            <span className="font-medium">{formatAmount(position.amount)} USDC</span>
+            <span className="font-medium">{formatUsdc(position.amount)}</span>
           </div>
 
           <div className="flex justify-between">

--- a/frontend/lib/__tests__/currency.test.ts
+++ b/frontend/lib/__tests__/currency.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { formatMoney, formatNgn, formatUsdc, roundCurrencyAmount } from "@/lib/currency";
+import {
+  formatByPreference,
+  formatConversionRate,
+  formatMoney,
+  formatNgn,
+  formatUsdc,
+  roundCurrencyAmount,
+} from "@/lib/currency";
 
 describe("currency formatting", () => {
   it("rounds NGN half-up to two decimals at positive boundaries", () => {
@@ -29,5 +36,21 @@ describe("currency formatting", () => {
   it("uses locale-specific symbol placement through Intl", () => {
     expect(formatNgn(1234.5, "fr-FR")).toMatch(/1[\s\u202f]234,50/);
     expect(formatNgn(1234.5, "fr-FR")).toContain("NGN");
+  });
+
+  it("formats NGN correctly for RTL locales", () => {
+    expect(formatNgn(1234.5, "ar-EG")).toContain("١٬٢٣٤٫٥٠");
+  });
+
+  it("keeps transacted values stable when toggling display currency", () => {
+    const amountNgn = "156799.505";
+    const amountUsdc = "98.000001";
+
+    expect(formatByPreference(amountNgn, amountUsdc, "NGN", "en-NG")).toBe("₦156,799.51");
+    expect(formatByPreference(amountNgn, amountUsdc, "USDC", "en-US")).toBe("98.00 USDC");
+  });
+
+  it("formats conversion rates with fixed precision and output currency label", () => {
+    expect(formatConversionRate(0.0006345, "USDC", "en-US")).toBe("0.000635 USDC");
   });
 });

--- a/frontend/lib/currency.ts
+++ b/frontend/lib/currency.ts
@@ -13,6 +13,12 @@ interface FormatMoneyOptions {
   locale?: string;
 }
 
+interface FormatDecimalOptions {
+  locale?: string;
+  minimumFractionDigits?: number;
+  maximumFractionDigits?: number;
+}
+
 const DEFAULT_LOCALE = "en-NG";
 
 export const CURRENCY_POLICIES: Record<SupportedCurrency, CurrencyPolicy> = {
@@ -93,6 +99,30 @@ export function formatCompactNgn(amount: number | string, locale = DEFAULT_LOCAL
 
 export function formatUsdc(amount: number | string, locale?: string): string {
   return formatMoney(amount, "USDC", { locale });
+}
+
+export function formatDecimal(
+  amount: number | string,
+  options: FormatDecimalOptions = {},
+): string {
+  const value = toFiniteNumber(amount);
+
+  return new Intl.NumberFormat(options.locale ?? DEFAULT_LOCALE, {
+    minimumFractionDigits: options.minimumFractionDigits ?? 2,
+    maximumFractionDigits: options.maximumFractionDigits ?? 2,
+  }).format(value);
+}
+
+export function formatConversionRate(
+  rate: number | string,
+  outputCurrency: SupportedCurrency,
+  locale?: string,
+): string {
+  return `${formatDecimal(rate, {
+    locale,
+    minimumFractionDigits: 4,
+    maximumFractionDigits: 6,
+  })} ${outputCurrency}`;
 }
 
 export function formatDual(


### PR DESCRIPTION
## Summary

Fixes currency formatting/conversion display correctness for wallet and NGN staking quote surfaces by routing money rendering through `frontend/lib/currency.ts`, standardizing conversion-rate formatting, and adding settlement/rate-validity context for converted values.

## Linked issue (recommended)

Closes Shelterflex/monorepo#1353.

## Changes

- Replaced inline wallet money formatting (`toFixed`, manual symbol concatenation) with shared currency utilities for NGN/USDC amounts.
- Added shared `formatDecimal` and `formatConversionRate` helpers in `frontend/lib/currency.ts`.
- Updated conversion preview copy to explicitly label converted estimates, show quote-rate validity timestamp, and clarify settlement currency.
- Updated NGN staking `QuoteDisplay` to use shared formatting and show rate timestamp + quote validity.
- Updated staking status card USDC amount rendering to shared utility.
- Added/expanded tests for:
  - rounding + locale/RTL formatting,
  - conversion rate formatting,
  - display toggle behavior on canonical NGN/USDC values,
  - quote display labels/timestamps,
  - wallet page mocks for multi-currency/quote paths.

## Contract Upgrade Details (if applicable)

N/A

## How to test

- [x] `cd frontend && pnpm install --frozen-lockfile`
- [x] `cd frontend && pnpm run lint`
- [x] `cd frontend && pnpm run build`
- [x] `cd frontend && pnpm exec vitest run lib/__tests__/currency.test.ts components/staking/ngn-flow/QuoteDisplay.test.tsx components/staking/ngn-flow/StatusTracker.test.tsx app/wallet/page.test.tsx`

## Security Considerations

- [x] No auth/authorization changes.
- [x] No secrets added.
- [x] Changes are presentation/formatting focused; settlement semantics are explicitly clarified in UI copy.

## Screenshots (if UI)

UI text/formatting change only; no screenshot bundle attached in this PR.

## Checklist

- [x] I linked an issue.
- [x] I tested locally.
- [x] I did not commit secrets.
- [x] I updated docs if needed.
- [x] Code follows the project's style guidelines.
- [x] CI checks pass locally for required frontend lint/build.
