### PR TITLE
fix(backend): improve webhook retries and failure visibility

### DIFF
--- a/backend/docs/openapi.yml
+++ b/backend/docs/openapi.yml
@@ -2131,7 +2131,7 @@ paths:
   /api/webhooks/payments/{rail}:
     post:
       summary: Payments webhook
-      description: Ingest payment provider webhook. Idempotent by (rail, externalRef). Signature validation can be enabled.
+      description: Ingest payment provider webhook. Idempotent by provider event ID plus canonical reference. Signature validation is always enforced in production and can be enabled in non-production with WEBHOOK_SIGNATURE_ENABLED=true.
       operationId: paymentsWebhook
       tags:
         - Webhooks

--- a/backend/src/routes/webhooks.test.ts
+++ b/backend/src/routes/webhooks.test.ts
@@ -7,15 +7,24 @@ import { TxType } from '../outbox/types.js'
 import { quoteStore } from '../models/quoteStore.js'
 import { webhookEventDedupeStore } from '../models/webhookEventDedupeStore.js'
 import { NgnWalletService } from '../services/ngnWalletService.js'
+import {
+  InMemoryWebhookReplayStore,
+  initWebhookReplayStore,
+  getStore as getWebhookReplayStore,
+  WebhookProcessingStatus,
+} from '../webhookReplay/index.js'
 
 describe('Payments webhook', () => {
   const app = createApp()
+  const originalNodeEnv = process.env.NODE_ENV
 
   beforeEach(async () => {
     await depositStore.clear()
     await outboxStore.clear()
     await quoteStore.clear()
     webhookEventDedupeStore.clear()
+    initWebhookReplayStore(new InMemoryWebhookReplayStore())
+    process.env.NODE_ENV = originalNodeEnv
     delete process.env.WEBHOOK_SIGNATURE_ENABLED
     delete process.env.WEBHOOK_SECRET
     delete process.env.PAYSTACK_SECRET
@@ -26,6 +35,7 @@ describe('Payments webhook', () => {
   afterEach(async () => {
     await depositStore.clear()
     await outboxStore.clear()
+    process.env.NODE_ENV = originalNodeEnv
   })
 
   it('is idempotent on replay (rail, externalRef) and second delivery is provider-event deduped', async () => {
@@ -148,6 +158,57 @@ describe('Payments webhook', () => {
       .set('x-webhook-timestamp', timestamp)
       .send(payload)
       .expect(200)
+  })
+
+  it('enforces Paystack signature validation in production', async () => {
+    process.env.NODE_ENV = 'production'
+    process.env.PAYSTACK_SECRET = 'prod_secret_paystack'
+
+    const quote = await quoteStore.create({
+      userId: 'prod-user-signature',
+      amountNgn: 220000,
+      paymentRail: 'paystack',
+      fxRateNgnPerUsdc: 1600,
+      feePercent: 0,
+      slippagePercent: 0,
+      expiryMs: 3600000,
+    })
+
+    const init = await request(app)
+      .post('/api/staking/deposit/initiate')
+      .set('x-user-id', 'prod-user-signature')
+      .send({ quoteId: quote.quoteId, paymentRail: 'paystack' })
+      .expect(201)
+
+    await request(app)
+      .post('/api/webhooks/payments/paystack')
+      .send({
+        externalRefSource: 'paystack',
+        externalRef: init.body.externalRef,
+        status: 'confirmed',
+        providerEventId: 'evt-prod-signature-1',
+      })
+      .expect(401)
+  })
+
+  it('persists inbound webhook event before processing and marks failures for replay', async () => {
+    const replayStore = getWebhookReplayStore()
+    const providerEventId = 'evt-missing-deposit-1'
+
+    await request(app)
+      .post('/api/webhooks/payments/paystack')
+      .send({
+        externalRefSource: 'paystack',
+        externalRef: 'missing-external-ref',
+        status: 'confirmed',
+        providerEventId,
+      })
+      .expect(404)
+
+    const stored = await replayStore.getEventByProviderAndExternalId('paystack', providerEventId)
+    expect(stored).not.toBeNull()
+    expect(stored?.processingStatus).toBe(WebhookProcessingStatus.FAILED)
+    expect(stored?.processingError).toContain('Deposit not found')
   })
 
   it('applies concurrent deliveries of one provider event exactly once', async () => {

--- a/backend/src/routes/webhooks.ts
+++ b/backend/src/routes/webhooks.ts
@@ -32,6 +32,17 @@ import {
   webhookSubscriptionStore,
   webhookDeliveryStore
 } from "../models/webhookSubscription.js";
+import { getWebhookReplayStore } from "../webhookReplay/store.js";
+import { WebhookProcessingStatus } from "../webhookReplay/types.js";
+
+function extractWebhookHeaders(req: Request): Record<string, string> {
+  const headers: Record<string, string> = {};
+  for (const [key, value] of Object.entries(req.headers)) {
+    if (typeof value === "string") headers[key] = value;
+    else if (Array.isArray(value)) headers[key] = value.join(",");
+  }
+  return headers;
+}
 
 
 export function createWebhooksRouter(ngnWalletService: NgnWalletService) {
@@ -50,7 +61,8 @@ export function createWebhooksRouter(ngnWalletService: NgnWalletService) {
    * - failed: Marks deposit as failed (no wallet credit)
    * - reversed: Debits NGN wallet and marks deposit as reversed
    *
-   * Signature validation is enforced in production mode when WEBHOOK_SIGNATURE_ENABLED=true
+   * Signature validation is always enforced in production. In non-production,
+   * it can be enabled with WEBHOOK_SIGNATURE_ENABLED=true.
    */
   router.post(
     "/payments/:rail",
@@ -62,6 +74,8 @@ export function createWebhooksRouter(ngnWalletService: NgnWalletService) {
     },
     validate(paymentsWebhookSchema),
     async (req: Request, res: Response, next: NextFunction) => {
+      const replayStore = getWebhookReplayStore();
+      let replayWebhookEventId: string | null = null;
       try {
         const rail = String(req.params.rail);
 
@@ -73,6 +87,22 @@ export function createWebhooksRouter(ngnWalletService: NgnWalletService) {
         // Validate rail matches externalRefSource
         if (externalRefSource !== rail) {
           throw new AppError(ErrorCode.VALIDATION_ERROR, 400, "Rail mismatch");
+        }
+
+        const replayEvent = await replayStore.createEvent({
+          provider: rail,
+          eventType: `payments.${String(rawStatus ?? providerStatus ?? "unknown")}`,
+          externalId: parsed.providerEventId,
+          payload: req.body as Record<string, unknown>,
+          headers: extractWebhookHeaders(req),
+          processingStatus: WebhookProcessingStatus.PENDING,
+        });
+        replayWebhookEventId = replayEvent.id;
+        if (replayEvent.processingStatus === WebhookProcessingStatus.PROCESSED) {
+          recordKPI("webhookEventDeduped");
+          return res
+            .status(200)
+            .json({ success: true, deduped: true, providerEventId: parsed.providerEventId });
         }
 
         // Persisted idempotency on provider event id (after signature validation) — replays short-circuit here.
@@ -134,6 +164,10 @@ export function createWebhooksRouter(ngnWalletService: NgnWalletService) {
             providerStatus,
             requestId: req.requestId,
           });
+          await replayStore.updateEventStatus(
+            replayWebhookEventId!,
+            WebhookProcessingStatus.PROCESSED,
+          );
           return res.status(200).json({ success: true });
         }
 
@@ -171,6 +205,10 @@ export function createWebhooksRouter(ngnWalletService: NgnWalletService) {
             });
           }
 
+          await replayStore.updateEventStatus(
+            replayWebhookEventId!,
+            WebhookProcessingStatus.PROCESSED,
+          );
           return res.status(200).json({ success: true });
         }
 
@@ -287,8 +325,20 @@ export function createWebhooksRouter(ngnWalletService: NgnWalletService) {
           }
         }
 
+        await replayStore.updateEventStatus(
+          replayWebhookEventId!,
+          WebhookProcessingStatus.PROCESSED,
+        );
         res.status(200).json({ success: true });
       } catch (error) {
+        if (replayWebhookEventId) {
+          const message = error instanceof Error ? error.message : String(error);
+          await replayStore.updateEventStatus(
+            replayWebhookEventId,
+            WebhookProcessingStatus.FAILED,
+            message,
+          );
+        }
         next(error);
       }
     },
@@ -303,6 +353,8 @@ export function createWebhooksRouter(ngnWalletService: NgnWalletService) {
     "/reversals/:provider",
     validate(depositReversalWebhookSchema),
     async (req: Request, res: Response, next: NextFunction) => {
+      const replayStore = getWebhookReplayStore();
+      let replayWebhookEventId: string | null = null;
       try {
         const provider = String(req.params.provider);
 
@@ -315,6 +367,22 @@ export function createWebhooksRouter(ngnWalletService: NgnWalletService) {
           reversalRef,
           eventType,
         } = req.body;
+
+        const replayEvent = await replayStore.createEvent({
+          provider,
+          eventType: String(eventType),
+          externalId: String(reversalRef),
+          payload: req.body as Record<string, unknown>,
+          headers: extractWebhookHeaders(req),
+          processingStatus: WebhookProcessingStatus.PENDING,
+        });
+        replayWebhookEventId = replayEvent.id;
+        if (replayEvent.processingStatus === WebhookProcessingStatus.PROCESSED) {
+          recordKPI("webhookEventDeduped");
+          return res
+            .status(200)
+            .json({ success: true, deduped: true, providerEventId: reversalRef });
+        }
 
         if (bodyProvider !== provider) {
           throw new AppError(
@@ -367,9 +435,20 @@ export function createWebhooksRouter(ngnWalletService: NgnWalletService) {
           requestId: req.requestId,
         });
 
+        await replayStore.updateEventStatus(
+          replayWebhookEventId!,
+          WebhookProcessingStatus.PROCESSED,
+        );
         res.status(200).json({ success: true });
       } catch (error) {
         if (error instanceof AppError && error.code === ErrorCode.NOT_FOUND) {
+          if (replayWebhookEventId) {
+            await replayStore.updateEventStatus(
+              replayWebhookEventId,
+              WebhookProcessingStatus.FAILED,
+              error.message,
+            );
+          }
           // If deposit not found, still return 200 to prevent webhook retries
           logger.warn("Deposit not found for reversal webhook", {
             provider: req.params.provider,
@@ -379,6 +458,14 @@ export function createWebhooksRouter(ngnWalletService: NgnWalletService) {
           });
           res.status(200).json({ success: true, message: "Deposit not found" });
           return;
+        }
+        if (replayWebhookEventId) {
+          const message = error instanceof Error ? error.message : String(error);
+          await replayStore.updateEventStatus(
+            replayWebhookEventId,
+            WebhookProcessingStatus.FAILED,
+            message,
+          );
         }
         next(error);
       }

--- a/backend/src/services/webhookDeliveryService.test.ts
+++ b/backend/src/services/webhookDeliveryService.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { initScheduler } from '../jobs/scheduler/worker.js'
+import {
+  WebhookEventType,
+  webhookDeliveryStore,
+  webhookSubscriptionStore,
+} from '../models/webhookSubscription.js'
+import { enqueueDelivery, processWebhookDeliveryJob } from './webhookDeliveryService.js'
+
+describe('webhookDeliveryService', () => {
+  beforeEach(() => {
+    webhookSubscriptionStore.clear()
+    initScheduler({ schedule: vi.fn() } as any)
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  it('schedules retry with backoff and request timeout when delivery fails', async () => {
+    const schedule = vi.fn()
+    initScheduler({ schedule } as any)
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('connection reset')) as any)
+
+    const sub = webhookSubscriptionStore.create({
+      ownerId: 'owner-1',
+      targetUrl: 'https://example.com/hooks/payments',
+      secret: 'hashed_secret',
+      events: [WebhookEventType.PAYMENT_RECEIVED],
+    })
+
+    const startedAt = Date.now()
+    await processWebhookDeliveryJob({
+      subscriptionId: sub.id,
+      event: WebhookEventType.PAYMENT_RECEIVED,
+      payload: { paymentId: 'pay_1' },
+      attemptCount: 0,
+    })
+
+    const [retryJob] = schedule.mock.calls[0]
+    expect(schedule).toHaveBeenCalledTimes(1)
+    expect(retryJob.payload.attemptCount).toBe(1)
+    expect(retryJob.nextRunAt).toBeInstanceOf(Date)
+    const delayMs = retryJob.nextRunAt.getTime() - startedAt
+    expect(delayMs).toBeGreaterThanOrEqual(59_000)
+    expect(delayMs).toBeLessThanOrEqual(61_000)
+
+    const history = webhookDeliveryStore.getHistoryBySubscription(sub.id)
+    expect(history[0]?.status).toBe('failed')
+    expect(vi.mocked(fetch).mock.calls[0]?.[1]).toMatchObject({
+      signal: expect.any(AbortSignal),
+    })
+  })
+
+  it('dead-letters delivery after max attempts without disabling subscription', async () => {
+    const schedule = vi.fn()
+    initScheduler({ schedule } as any)
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('subscriber timeout')) as any)
+
+    const sub = webhookSubscriptionStore.create({
+      ownerId: 'owner-2',
+      targetUrl: 'https://example.com/hooks/status',
+      secret: 'hashed_secret',
+      events: [WebhookEventType.DEAL_ACTIVATED],
+    })
+
+    await processWebhookDeliveryJob({
+      subscriptionId: sub.id,
+      event: WebhookEventType.DEAL_ACTIVATED,
+      payload: { dealId: 'deal_1' },
+      attemptCount: 4,
+    })
+
+    expect(schedule).not.toHaveBeenCalled()
+    const history = webhookDeliveryStore.getHistoryBySubscription(sub.id)
+    expect(history[0]?.status).toBe('permanently_failed')
+    expect(webhookSubscriptionStore.findById(sub.id)?.active).toBe(true)
+  })
+
+  it('enqueues one delivery job per active subscriber', async () => {
+    const schedule = vi.fn()
+    initScheduler({ schedule } as any)
+
+    webhookSubscriptionStore.create({
+      ownerId: 'owner-a',
+      targetUrl: 'https://example.com/hooks/a',
+      secret: 'hashed_secret_a',
+      events: [WebhookEventType.PAYMENT_RECEIVED],
+    })
+    webhookSubscriptionStore.create({
+      ownerId: 'owner-b',
+      targetUrl: 'https://example.com/hooks/b',
+      secret: 'hashed_secret_b',
+      events: [WebhookEventType.PAYMENT_RECEIVED],
+    })
+
+    await enqueueDelivery(WebhookEventType.PAYMENT_RECEIVED, { paymentId: 'pay_2' })
+
+    expect(schedule).toHaveBeenCalledTimes(2)
+    for (const [job] of schedule.mock.calls) {
+      expect(job.handler).toBe('webhook.delivery')
+      expect(job.payload.attemptCount).toBe(0)
+      expect(job.maxRetries).toBe(0)
+    }
+  })
+})

--- a/backend/src/services/webhookDeliveryService.ts
+++ b/backend/src/services/webhookDeliveryService.ts
@@ -5,6 +5,10 @@ import {
   webhookSubscriptionStore,
   webhookDeliveryStore,
 } from '../models/webhookSubscription.js'
+import { logger } from '../utils/logger.js'
+
+const MAX_DELIVERY_ATTEMPTS = 5
+const DELIVERY_TIMEOUT_MS = parseInt(process.env.WEBHOOK_DELIVERY_TIMEOUT_MS ?? '10000', 10)
 
 // Exponential backoff values in milliseconds: 1m, 5m, 30m, 2h, 8h
 const BACKOFF_MS = [
@@ -73,6 +77,7 @@ export async function processWebhookDeliveryJob(jobPayload: {
         'X-Webhook-Signature': signature,
       },
       body: bodyString,
+      signal: AbortSignal.timeout(DELIVERY_TIMEOUT_MS),
     })
 
     responseCode = res.status
@@ -90,7 +95,7 @@ export async function processWebhookDeliveryJob(jobPayload: {
     subscriptionId,
     event,
     payload,
-    status: status === 'delivered' ? 'delivered' : (currentAttempt >= 5 ? 'permanently_failed' : 'failed'),
+    status: status === 'delivered' ? 'delivered' : (currentAttempt >= MAX_DELIVERY_ATTEMPTS ? 'permanently_failed' : 'failed'),
     responseCode,
     responseBody: truncatedBody,
   })
@@ -99,7 +104,7 @@ export async function processWebhookDeliveryJob(jobPayload: {
     return
   }
 
-  if (currentAttempt < 5) {
+  if (currentAttempt < MAX_DELIVERY_ATTEMPTS) {
     const delay = BACKOFF_MS[currentAttempt - 1] || 60 * 1000
     const nextRunAt = new Date(Date.now() + delay)
 
@@ -116,6 +121,11 @@ export async function processWebhookDeliveryJob(jobPayload: {
       maxRetries: 0
     })
   } else {
-    webhookSubscriptionStore.updateActive(subscriptionId, false)
+    logger.warn('webhook.delivery.dead_lettered', {
+      subscriptionId,
+      event,
+      attempts: currentAttempt,
+      targetUrl: sub.targetUrl,
+    })
   }
 }

--- a/backend/src/webhookReplay/store.ts
+++ b/backend/src/webhookReplay/store.ts
@@ -26,24 +26,31 @@ export class PostgresWebhookReplayStore implements IWebhookReplayStore {
   async createEvent(event: Omit<WebhookEvent, 'id' | 'receivedAt'>): Promise<WebhookEvent> {
     const pool = await getPool()
     if (!pool) throw new Error('Database not available')
-    const result = await pool.query(
-      `INSERT INTO webhook_events 
-       (provider, event_type, external_id, payload, headers, processing_status, processing_error)
-       VALUES ($1, $2, $3, $4, $5, $6, $7)
-       RETURNING id, provider, event_type, external_id, payload, headers, 
-                 received_at, processed_at, processing_status, processing_error`,
-      [
-        event.provider,
-        event.eventType,
-        event.externalId,
-        JSON.stringify(event.payload),
-        event.headers ? JSON.stringify(event.headers) : null,
-        event.processingStatus,
-        event.processingError || null,
-      ]
-    )
-
-    return this.mapRowToEvent(result.rows[0])
+    try {
+      const result = await pool.query(
+        `INSERT INTO webhook_events 
+         (provider, event_type, external_id, payload, headers, processing_status, processing_error)
+         VALUES ($1, $2, $3, $4, $5, $6, $7)
+         RETURNING id, provider, event_type, external_id, payload, headers, 
+                   received_at, processed_at, processing_status, processing_error`,
+        [
+          event.provider,
+          event.eventType,
+          event.externalId,
+          JSON.stringify(event.payload),
+          event.headers ? JSON.stringify(event.headers) : null,
+          event.processingStatus,
+          event.processingError || null,
+        ]
+      )
+      return this.mapRowToEvent(result.rows[0])
+    } catch (error) {
+      if ((error as { code?: string }).code === '23505') {
+        const existing = await this.getEventByProviderAndExternalId(event.provider, event.externalId)
+        if (existing) return existing
+      }
+      throw error
+    }
   }
 
   async getEventById(id: string): Promise<WebhookEvent | null> {
@@ -225,6 +232,11 @@ export class InMemoryWebhookReplayStore implements IWebhookReplayStore {
   private idCounter = 1
 
   async createEvent(event: Omit<WebhookEvent, 'id' | 'receivedAt'>): Promise<WebhookEvent> {
+    const existing = await this.getEventByProviderAndExternalId(event.provider, event.externalId)
+    if (existing) {
+      return existing
+    }
+
     const id = `event-${this.idCounter++}`
     const newEvent: WebhookEvent = {
       ...event,


### PR DESCRIPTION
## Summary
Improves webhook reliability for inbound and outbound flows by durably recording inbound events before processing, tracking processed/failed status for replay visibility, enforcing production signature behavior in docs/tests, and hardening outbound delivery with timeout + bounded retry dead-letter behavior.

## Linked issue (recommended)
Closes Shelterflex/monorepo#1354.

## Changes
- Persist inbound payment/reversal webhook events to webhook_events before business processing
- Mark inbound events processed/failed for replay visibility and recovery paths
- Make replay-store event creation idempotent for duplicate provider event IDs
- Add outbound webhook delivery timeout and preserve subscription activity after per-event dead-lettering
- Add failure-path tests for production signature enforcement, inbound failure persistence, and outbound retry/dead-letter behavior
- Update OpenAPI webhook signature enforcement wording

## Contract Upgrade Details (if applicable)
N/A (no contract changes)

### Network
- [ ] Testnet
- [ ] Mainnet

### New Contract
- **Contract ID**: N/A
- **WASM Hash**: N/A
- **Deployer Public Key**: N/A
- **Deploy Transaction**: N/A

### Upgrade Governance
- [ ] Admin/upgrade authority is a multisig requiring maintainer sign-off
- [ ] Maintainer has reviewed and approved the upgrade
- [ ] Upgrade transaction is ready for maintainer signature (provide transaction XDR if applicable)

### Verification Steps
- [ ] New contract deployed successfully
- [x] All existing tests pass against the new contract
- [x] Manual testing checklist completed (describe what you tested)
- [x] No breaking changes for existing integrations (or list them)

## How to test
- [x] All automated tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual testing completed (describe what you tested)

Commands run:
- cd backend && npm ci
- cd backend && npm run test -- src/services/webhookDeliveryService.test.ts src/routes/webhooks.test.ts src/webhookReplay/webhookReplayService.test.ts
- cd backend && npm run lint
- cd backend && npm run test:ci
- cd backend && npm run openapi:validate

## Security Considerations
- [x] No secrets or sensitive data are logged
- [x] No changes to authentication/authorization logic without review
- [x] No changes to admin/upgrade logic without review

## Screenshots (if UI)
N/A

## Checklist
- [x] I linked an issue (or explained why one is not needed)
- [x] I tested locally
- [x] I did not commit secrets
- [x] I updated docs if needed
- [x] Code follows the project's style guidelines
- [x] CI checks pass
- [ ] If UI changes: I included before/after screenshots
- [ ] If images added/changed: I verified they are optimized and accessible
