### PR TITLE
feat: real homepage stats, financial rate limits, correlation IDs, idempotency

### DIFF
--- a/backend/migrations/045_correlation_ids.sql
+++ b/backend/migrations/045_correlation_ids.sql
@@ -1,0 +1,9 @@
+-- Correlation ID support for request tracing across subsystems
+-- Links outbox items, jobs, and webhook deliveries to their originating request
+
+-- Add request_id to outbox_items for tracing chain writes back to the originating HTTP request
+ALTER TABLE outbox_items ADD COLUMN IF NOT EXISTS request_id TEXT;
+
+-- Index for tracing: find all outbox items from a single request
+CREATE INDEX IF NOT EXISTS outbox_items_request_id_idx ON outbox_items (request_id)
+  WHERE request_id IS NOT NULL;

--- a/backend/migrations/migration-order.manifest.json
+++ b/backend/migrations/migration-order.manifest.json
@@ -268,6 +268,10 @@
     {
       "position": 67,
       "filename": "044_signing_key_rotation.sql"
+    },
+    {
+      "position": 68,
+      "filename": "045_correlation_ids.sql"
     }
   ]
 }

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -581,6 +581,18 @@ export function createApp() {
   app.use(requestIdMiddleware);
   app.use(traceResponseMiddleware);
 
+  // Attach requestId to Sentry scope for error correlation
+  if (env.NODE_ENV !== "test" && process.env.SENTRY_DSN_BACKEND) {
+    app.use((req: import('express').Request, _res: import('express').Response, next: import('express').NextFunction) => {
+      Sentry.withScope((scope) => {
+        scope.setTag("requestId", req.requestId || "unknown");
+        scope.setExtra("method", req.method);
+        scope.setExtra("path", req.originalUrl);
+      });
+      next();
+    });
+  }
+
   // Sentry request handler (must be before routes)
   if (env.NODE_ENV !== "test" && process.env.SENTRY_DSN_BACKEND) {
     app.use((Sentry as any).Handlers.requestHandler());

--- a/backend/src/config/rateLimits.ts
+++ b/backend/src/config/rateLimits.ts
@@ -25,6 +25,26 @@ export const RateLimitTiers = {
     limit: 20,
     keyPrefix: 'payment_initiate',
   },
+  staking: {
+    windowMs: 60 * 60 * 1000, // 1 hour
+    limit: 20,
+    keyPrefix: 'staking',
+  },
+  deposit: {
+    windowMs: 60 * 60 * 1000, // 1 hour
+    limit: 10,
+    keyPrefix: 'deposit',
+  },
+  wallet_withdrawal: {
+    windowMs: 60 * 60 * 1000, // 1 hour
+    limit: 5,
+    keyPrefix: 'wallet_withdrawal',
+  },
+  wallet_topup: {
+    windowMs: 60 * 60 * 1000, // 1 hour
+    limit: 10,
+    keyPrefix: 'wallet_topup',
+  },
   search: {
     windowMs: 60 * 1000, // 1 minute
     limit: 60,

--- a/backend/src/middleware/comprehensiveRateLimit.ts
+++ b/backend/src/middleware/comprehensiveRateLimit.ts
@@ -77,6 +77,22 @@ function getEndpointConfig(method: string, path: string): RateLimitConfig & { ma
     return { ...RateLimitTiers.payment_initiate, matchedKey: 'payment_initiate' }
   }
 
+  if (method === 'POST' && (path.startsWith('/api/staking') || path.startsWith('/staking'))) {
+    return { ...RateLimitTiers.staking, matchedKey: 'staking' }
+  }
+
+  if (method === 'POST' && (path.startsWith('/api/deposits') || path.startsWith('/deposits'))) {
+    return { ...RateLimitTiers.deposit, matchedKey: 'deposit' }
+  }
+
+  if (method === 'POST' && (path.startsWith('/api/wallet/ngn/withdraw') || path.startsWith('/wallet/ngn/withdraw'))) {
+    return { ...RateLimitTiers.wallet_withdrawal, matchedKey: 'wallet_withdrawal' }
+  }
+
+  if (method === 'POST' && (path.startsWith('/api/wallet/ngn/topup') || path.startsWith('/wallet/ngn/topup'))) {
+    return { ...RateLimitTiers.wallet_topup, matchedKey: 'wallet_topup' }
+  }
+
   if (path.startsWith('/api/properties') || path.startsWith('/properties')) {
     return { ...RateLimitTiers.search, matchedKey: 'search' }
   }

--- a/backend/src/middleware/concurrentIdempotency.test.ts
+++ b/backend/src/middleware/concurrentIdempotency.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import express, { type Request, type Response } from 'express'
+import supertest from 'supertest'
+import { idempotency, InMemoryIdempotencyStore } from './idempotency.js'
+
+const KEY = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee'
+
+function buildConcurrentApp(store: InMemoryIdempotencyStore) {
+  const app = express()
+  app.use(express.json())
+
+  let effectCount = 0
+
+  app.post(
+    '/pay',
+    idempotency(store),
+    async (_req: Request, res: Response) => {
+      effectCount++
+      // Simulate async work (e.g. DB write)
+      await new Promise((r) => setTimeout(r, 50))
+      res.status(201).json({ id: `txn-${effectCount}`, effectCount })
+    }
+  )
+
+  return { app, getEffectCount: () => effectCount }
+}
+
+describe('Concurrent idempotency', () => {
+  let store: InMemoryIdempotencyStore
+
+  beforeEach(() => {
+    store = new InMemoryIdempotencyStore(60_000)
+  })
+
+  afterEach(() => {
+    store.stop()
+  })
+
+  it('two simultaneous requests with the same key produce exactly one effect', async () => {
+    const { app, getEffectCount } = buildConcurrentApp(store)
+    const agent = supertest(app)
+
+    const [res1, res2] = await Promise.all([
+      agent
+        .post('/pay')
+        .set('Idempotency-Key', KEY)
+        .send({ amount: 100 }),
+      agent
+        .post('/pay')
+        .set('Idempotency-Key', KEY)
+        .send({ amount: 100 }),
+    ])
+
+    const statuses = [res1.status, res2.status].sort()
+    const bodies = [res1.body, res2.body]
+
+    // Exactly one succeeds with 201, the other is 409 in-flight
+    expect(statuses).toEqual([201, 409])
+
+    // Only one effect occurred
+    expect(getEffectCount()).toBe(1)
+
+    // The successful response has a real transaction id
+    const successBody = bodies.find((b) => b.id)
+    expect(successBody).toBeDefined()
+    expect(successBody.id).toMatch(/^txn-/)
+  })
+
+  it('ten concurrent requests produce exactly one effect', async () => {
+    const { app, getEffectCount } = buildConcurrentApp(store)
+    const agent = supertest(app)
+
+    const results = await Promise.all(
+      Array(10)
+        .fill(null)
+        .map(() =>
+          agent
+            .post('/pay')
+            .set('Idempotency-Key', KEY)
+            .send({ amount: 50 })
+        )
+    )
+
+    const successCount = results.filter((r) => r.status === 201).length
+    const conflictCount = results.filter((r) => r.status === 409).length
+
+    expect(successCount).toBe(1)
+    expect(conflictCount).toBe(9)
+    expect(getEffectCount()).toBe(1)
+  })
+
+  it('after first request completes, replay returns cached response', async () => {
+    const { app } = buildConcurrentApp(store)
+    const agent = supertest(app)
+
+    const first = await agent
+      .post('/pay')
+      .set('Idempotency-Key', KEY)
+      .send({ amount: 100 })
+
+    expect(first.status).toBe(201)
+
+    const second = await agent
+      .post('/pay')
+      .set('Idempotency-Key', KEY)
+      .send({ amount: 100 })
+
+    expect(second.status).toBe(201)
+    expect(second.headers['x-idempotent-replay']).toBe('true')
+    expect(second.body).toEqual(first.body)
+  })
+
+  it('different keys run concurrently without interference', async () => {
+    const { app, getEffectCount } = buildConcurrentApp(store)
+    const agent = supertest(app)
+
+    const [res1, res2] = await Promise.all([
+      agent
+        .post('/pay')
+        .set('Idempotency-Key', '11111111-1111-4111-8111-111111111111')
+        .send({ amount: 100 }),
+      agent
+        .post('/pay')
+        .set('Idempotency-Key', '22222222-2222-4222-8222-222222222222')
+        .send({ amount: 200 }),
+    ])
+
+    expect(res1.status).toBe(201)
+    expect(res2.status).toBe(201)
+    expect(getEffectCount()).toBe(2)
+  })
+})

--- a/backend/src/middleware/correlationId.test.ts
+++ b/backend/src/middleware/correlationId.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest'
+import express, { type Request, type Response, type NextFunction } from 'express'
+import supertest from 'supertest'
+import { requestIdMiddleware } from './requestId.js'
+import { requestContext, getRequestContext } from '../request-context.js'
+
+function buildApp() {
+  const app = express()
+  app.use(requestIdMiddleware)
+  app.use(express.json())
+
+  app.get('/ping', (req: Request, res: Response) => {
+    res.json({
+      requestId: req.requestId,
+      contextRequestId: getRequestContext()?.requestId,
+    })
+  })
+
+  app.post('/echo', (req: Request, res: Response) => {
+    res.json({
+      requestId: req.requestId,
+      contextRequestId: getRequestContext()?.requestId,
+      body: req.body,
+    })
+  })
+
+  app.get('/error', (_req: Request, res: Response) => {
+    res.status(500).json({
+      error: { code: 'INTERNAL_ERROR', message: 'test' },
+    })
+  })
+
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({
+      error: { code: 'INTERNAL_ERROR', message: err.message },
+    })
+  })
+
+  return app
+}
+
+describe('Correlation ID propagation', () => {
+  it('generates x-request-id and attaches to req.requestId', async () => {
+    const app = buildApp()
+    const res = await supertest(app).get('/ping')
+
+    expect(res.status).toBe(200)
+    expect(typeof res.headers['x-request-id']).toBe('string')
+    expect(res.headers['x-request-id'].length).toBeGreaterThan(0)
+    expect(res.body.requestId).toBe(res.headers['x-request-id'])
+  })
+
+  it('propagates incoming x-request-id', async () => {
+    const app = buildApp()
+    const incoming = 'trace-xyz-789'
+
+    const res = await supertest(app)
+      .get('/ping')
+      .set('x-request-id', incoming)
+
+    expect(res.headers['x-request-id']).toBe(incoming)
+    expect(res.body.requestId).toBe(incoming)
+  })
+
+  it('requestId is available via AsyncLocalStorage in handlers', async () => {
+    const app = buildApp()
+    const incoming = 'ctx-test-456'
+
+    const res = await supertest(app)
+      .get('/ping')
+      .set('x-request-id', incoming)
+
+    expect(res.body.contextRequestId).toBe(incoming)
+  })
+
+  it('requestId propagates to POST handlers', async () => {
+    const app = buildApp()
+    const incoming = 'post-propagate-111'
+
+    const res = await supertest(app)
+      .post('/echo')
+      .set('x-request-id', incoming)
+      .send({ data: 'hello' })
+
+    expect(res.body.requestId).toBe(incoming)
+    expect(res.body.contextRequestId).toBe(incoming)
+    expect(res.body.body.data).toBe('hello')
+  })
+
+  it('different requests get different IDs when no header is provided', async () => {
+    const app = buildApp()
+
+    const res1 = await supertest(app).get('/ping')
+    const res2 = await supertest(app).get('/ping')
+
+    expect(res1.body.requestId).not.toBe(res2.body.requestId)
+  })
+
+  it('x-request-id header is present on error responses', async () => {
+    const app = buildApp()
+    const incoming = 'error-propagate-999'
+
+    const res = await supertest(app)
+      .get('/error')
+      .set('x-request-id', incoming)
+
+    expect(res.headers['x-request-id']).toBe(incoming)
+  })
+})

--- a/backend/src/middleware/errorHandler.ts
+++ b/backend/src/middleware/errorHandler.ts
@@ -5,6 +5,7 @@ import { ErrorCode, classifyError, type ErrorResponse } from '../errors/errorCod
 import { chainUnavailable } from '../errors/factories.js'
 import { isChainUnavailableError } from '../errors/chainUnavailable.js'
 import { formatZodIssues } from '../errors/utils.js'
+import { logger } from '../utils/logger.js'
 
 const isProduction = process.env.NODE_ENV === 'production'
 
@@ -33,6 +34,7 @@ export function errorHandler(
       .setHeader('x-request-id', requestId)
       .json({
         ...body,
+        requestId,
         error: {
           ...body.error,
           classification,
@@ -59,18 +61,13 @@ export function errorHandler(
    * 2️⃣ Chain / Soroban RPC unavailable (circuit open or timeout)
    */
   if (isChainUnavailableError(err)) {
-    console.warn(
-      JSON.stringify({
-        level: 'warn',
-        requestId,
-        message: 'Chain unavailable',
-        errorName: err instanceof Error ? err.name : 'Unknown',
-        errorMessage: err instanceof Error ? err.message : String(err),
-        path: req.originalUrl,
-        method: req.method,
-        timestamp: new Date().toISOString(),
-      }),
-    )
+    logger.warn('Chain unavailable', {
+      requestId,
+      errorName: err instanceof Error ? err.name : 'Unknown',
+      errorMessage: err instanceof Error ? err.message : String(err),
+      path: req.originalUrl,
+      method: req.method,
+    })
 
     const appErr = chainUnavailable()
     send(appErr.status, {
@@ -115,19 +112,14 @@ export function errorHandler(
   const safeMessage = 'An unexpected error occurred'
 
   // Structured logging (never log secrets)
-  console.error(
-    JSON.stringify({
-      level: 'error',
-      requestId,
-      message: 'Unhandled error',
-      errorName: err instanceof Error ? err.name : 'Unknown',
-      errorMessage: err instanceof Error ? err.message : String(err),
-      stack: !isProduction && err instanceof Error ? err.stack : undefined,
-      path: req.originalUrl,
-      method: req.method,
-      timestamp: new Date().toISOString(),
-    }),
-  )
+  logger.error('Unhandled error', {
+    requestId,
+    errorName: err instanceof Error ? err.name : 'Unknown',
+    errorMessage: err instanceof Error ? err.message : String(err),
+    stack: !isProduction && err instanceof Error ? err.stack : undefined,
+    path: req.originalUrl,
+    method: req.method,
+  })
 
   send(500, {
     error: {

--- a/backend/src/middleware/financialRateLimit.test.ts
+++ b/backend/src/middleware/financialRateLimit.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import express, { type Request, type Response } from 'express'
+import supertest from 'supertest'
+import {
+  createComprehensiveRateLimiter,
+  resetRateLimitStore,
+} from './comprehensiveRateLimit.js'
+import { RateLimitTiers } from '../config/rateLimits.js'
+import { quotaService } from '../services/QuotaService.js'
+import { vi } from 'vitest'
+
+vi.mock('../services/QuotaService.js', () => ({
+  quotaService: {
+    getUserLimits: vi.fn(),
+  },
+}))
+
+describe('Financial endpoint rate limiting', () => {
+  let app: express.Application
+
+  beforeEach(() => {
+    resetRateLimitStore()
+    vi.mocked(quotaService.getUserLimits).mockResolvedValue({
+      requestsPerMinute: 100,
+      requestsPerDay: 10000,
+    })
+
+    app = express()
+    app.use((req: Request, _res: Response, next) => {
+      ;(req as any).id = 'test-' + Math.random().toString(36).substr(2, 9)
+      ;(req as any).user = { id: 'user-1', tier: 'pro' }
+      next()
+    })
+    app.use(createComprehensiveRateLimiter())
+
+    app.post('/staking/deposit/initiate', (_req: Request, res: Response) => {
+      res.json({ ok: true, route: 'staking-deposit-initiate' })
+    })
+    app.post('/staking/stake', (_req: Request, res: Response) => {
+      res.json({ ok: true, route: 'staking-stake' })
+    })
+    app.post('/staking/unstake', (_req: Request, res: Response) => {
+      res.json({ ok: true, route: 'staking-unstake' })
+    })
+    app.post('/deposits/initiate', (_req: Request, res: Response) => {
+      res.json({ ok: true, route: 'deposit-initiate' })
+    })
+    app.post('/wallet/ngn/withdraw/initiate', (_req: Request, res: Response) => {
+      res.json({ ok: true, route: 'wallet-withdraw' })
+    })
+    app.post('/wallet/ngn/topup/initiate', (_req: Request, res: Response) => {
+      res.json({ ok: true, route: 'wallet-topup' })
+    })
+
+    app.use((err: any, _req: Request, res: Response, _next: any) => {
+      if (err.status === 429) {
+        return res.status(429).json({
+          error: { code: 'TOO_MANY_REQUESTS', message: err.message },
+        })
+      }
+      res.status(500).json({ error: 'Internal error' })
+    })
+  })
+
+  it('staking endpoints should use staking tier (limit 20, doubled for auth)', async () => {
+    const agent = supertest(app)
+    const res = await agent.post('/staking/stake')
+    const limitHeader = parseInt(res.headers['x-ratelimit-limit'] as string)
+    expect(limitHeader).toBe(RateLimitTiers.staking.limit * 2)
+  })
+
+  it('deposit endpoints should use deposit tier (limit 10, doubled for auth)', async () => {
+    const agent = supertest(app)
+    const res = await agent.post('/deposits/initiate')
+    const limitHeader = parseInt(res.headers['x-ratelimit-limit'] as string)
+    expect(limitHeader).toBe(RateLimitTiers.deposit.limit * 2)
+  })
+
+  it('wallet withdrawal should use wallet_withdrawal tier (limit 5, doubled for auth)', async () => {
+    const agent = supertest(app)
+    const res = await agent.post('/wallet/ngn/withdraw/initiate')
+    const limitHeader = parseInt(res.headers['x-ratelimit-limit'] as string)
+    expect(limitHeader).toBe(RateLimitTiers.wallet_withdrawal.limit * 2)
+  })
+
+  it('wallet topup should use wallet_topup tier (limit 10, doubled for auth)', async () => {
+    const agent = supertest(app)
+    const res = await agent.post('/wallet/ngn/topup/initiate')
+    const limitHeader = parseInt(res.headers['x-ratelimit-limit'] as string)
+    expect(limitHeader).toBe(RateLimitTiers.wallet_topup.limit * 2)
+  })
+
+  it('staking deposit/initiate should use staking tier (not deposit)', async () => {
+    const agent = supertest(app)
+    const res = await agent.post('/staking/deposit/initiate')
+    const limitHeader = parseInt(res.headers['x-ratelimit-limit'] as string)
+    expect(limitHeader).toBe(RateLimitTiers.staking.limit * 2)
+  })
+
+  it('should block wallet withdrawal after limit is exhausted', async () => {
+    resetRateLimitStore()
+    const strictApp = express()
+    strictApp.use((req: Request, _res: Response, next) => {
+      ;(req as any).id = 'test-' + Math.random().toString(36).substr(2, 9)
+      ;(req as any).user = { id: 'user-w', tier: 'pro' }
+      next()
+    })
+    strictApp.use(createComprehensiveRateLimiter())
+    strictApp.post('/wallet/ngn/withdraw/initiate', (_req: Request, res: Response) => {
+      res.json({ ok: true })
+    })
+    strictApp.use((err: any, _req: Request, res: Response, _next: any) => {
+      if (err.status === 429) {
+        return res.status(429).json({
+          error: { code: 'TOO_MANY_REQUESTS', message: err.message },
+        })
+      }
+      res.status(500).json({ error: 'Internal error' })
+    })
+
+    const agent = supertest(strictApp)
+    const limit = RateLimitTiers.wallet_withdrawal.limit * 2
+
+    for (let i = 0; i < limit; i++) {
+      const res = await agent.post('/wallet/ngn/withdraw/initiate')
+      expect(res.status).toBe(200)
+    }
+
+    const blocked = await agent.post('/wallet/ngn/withdraw/initiate')
+    expect(blocked.status).toBe(429)
+  })
+})

--- a/backend/src/middleware/requestId.ts
+++ b/backend/src/middleware/requestId.ts
@@ -1,6 +1,7 @@
 import { Request, Response, NextFunction } from "express"
 import { randomUUID } from "crypto"
 import { requestContext } from "../request-context.js"
+import { logger } from "../utils/logger.js"
 
 export function requestIdMiddleware(
   req: Request,
@@ -21,18 +22,13 @@ export function requestIdMiddleware(
   requestContext.run(store, () => {
     res.on("finish", () => {
       if (process.env.NODE_ENV === "test") return
-      console.log(
-        JSON.stringify({
-          level: "info",
-          message: "Request database queries",
-          requestId,
-          queryCount: store.queryCount,
-          method: req.method,
-          path: req.originalUrl,
-          statusCode: res.statusCode,
-          timestamp: new Date().toISOString(),
-        }),
-      )
+      logger.info("Request database queries", {
+        requestId,
+        queryCount: store.queryCount,
+        method: req.method,
+        path: req.originalUrl,
+        statusCode: res.statusCode,
+      })
     })
     next()
   })

--- a/backend/src/outbox/store.ts
+++ b/backend/src/outbox/store.ts
@@ -90,6 +90,7 @@ function mapRow(row: Record<string, unknown>): OutboxItem {
     submittedLedger: row.submitted_ledger != null ? Number(row.submitted_ledger) : undefined,
     confirmationDepth: row.confirmation_depth != null ? Number(row.confirmation_depth) : 3,
     claimedBy: (row.claimed_by as string) ?? undefined,
+    requestId: (row.request_id as string) ?? undefined,
     createdAt: new Date(row.created_at as string),
     updatedAt: new Date(row.updated_at as string),
   }
@@ -129,6 +130,7 @@ class InMemoryOutboxStore implements IOutboxStore {
       processedAt: null,
       retryCount: 0,
       confirmationDepth: 3,
+      requestId: input.requestId,
       createdAt: now,
       updatedAt: now,
     }
@@ -306,14 +308,15 @@ export class PostgresOutboxStore implements IOutboxStore {
     const { rows } = await pool.query(
       `INSERT INTO outbox_items (
          id, tx_id, tx_type, canonical_external_ref_v1,
-         aggregate_id, aggregate_type, event_type, payload
-       ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+         aggregate_id, aggregate_type, event_type, payload, request_id
+       ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
        ON CONFLICT (canonical_external_ref_v1) DO NOTHING
        RETURNING *`,
       [
         id, txId, input.txType, canonicalExternalRefV1,
         input.aggregateId ?? '', input.aggregateType ?? '', input.eventType ?? '',
         JSON.stringify(input.payload),
+        input.requestId ?? null,
       ],
     )
 

--- a/backend/src/outbox/types.ts
+++ b/backend/src/outbox/types.ts
@@ -64,6 +64,9 @@ export interface OutboxItem {
   /** Worker instance UUID holding an advisory claim on this row. */
   claimedBy?: string
 
+  /** Correlation ID linking this item to the originating HTTP request. */
+  requestId?: string
+
   createdAt: Date
   updatedAt: Date
 }
@@ -74,10 +77,12 @@ export interface CreateOutboxItemInput {
   ref: string     // External payment reference ID
   payload: Record<string, unknown>
 
-
   aggregateId?: string
   aggregateType?: string
   eventType?: string
+
+  /** Correlation ID from the originating HTTP request. */
+  requestId?: string
 }
 
 

--- a/backend/src/routes/deals.ts
+++ b/backend/src/routes/deals.ts
@@ -305,7 +305,7 @@ router.patch('/:dealId/status', async (req: Request, res: Response, next) => {
           tenantId: deal.tenantId,
           landlordId: deal.landlordId,
           totalFinancedAmount: deal.financedAmountNgn
-        }).catch(err => logger.error('Failed to enqueue deal webhook:', err))
+        }, { requestId: req.requestId }).catch(err => logger.error('Failed to enqueue deal webhook:', err))
       }
     }
 

--- a/backend/src/routes/ngnWallet.ts
+++ b/backend/src/routes/ngnWallet.ts
@@ -87,6 +87,7 @@ export function createNgnWalletRouter(ngnWalletService: NgnWalletService): Route
     '/withdraw/initiate',
     authenticateToken,
     requireNotFrozen,
+    durableIdempotency((req) => `withdrawal:${(req as AuthenticatedRequest).user!.id}`),
     validate(withdrawalRequestSchema, 'body'),
     async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
       try {

--- a/backend/src/routes/payments.ts
+++ b/backend/src/routes/payments.ts
@@ -70,6 +70,7 @@ export function createPaymentsRouter(adapter: SorobanAdapter) {
             ...(fxRateNgnPerUsdc != null && { fxRateNgnPerUsdc }),
             ...(fxProvider != null && { fxProvider }),
           },
+          requestId: req.requestId,
         })
 
         logger.info('Outbox item created or retrieved', {
@@ -119,14 +120,14 @@ export function createPaymentsRouter(adapter: SorobanAdapter) {
             externalRef,
             amountNgn,
             fxRateNgnPerUsdc
-          }).catch(err => logger.error('Failed to enqueue payment.received webhook:', err))
+          }, { requestId: req.requestId }).catch(err => logger.error('Failed to enqueue payment.received webhook:', err))
         } else if (txType === TxType.LANDLORD_PAYOUT) {
           await enqueueDelivery(WebhookEventType.PAYOUT_DISBURSED, {
             dealId,
             amountUsdc,
             externalRef,
             amountNgn
-          }).catch(err => logger.error('Failed to enqueue payout.disbursed webhook:', err))
+          }, { requestId: req.requestId }).catch(err => logger.error('Failed to enqueue payout.disbursed webhook:', err))
         }
 
         res.status(sent ? 200 : 202).json({

--- a/backend/src/routes/publicRoutes.ts
+++ b/backend/src/routes/publicRoutes.ts
@@ -44,7 +44,10 @@ publicRouter.get(
     }
 
     let landlordCount = 0
+    let tenantCount = 0
     let totalPaidNgn = 0
+    let totalFinancedNgn = 0
+    let citiesCount = 0
     let defaultRate = 0
 
     try {
@@ -55,12 +58,30 @@ publicRouter.get(
         )
         landlordCount = Number(landlordRows[0]?.count || 0)
 
+        const { rows: tenantRows } = await pool.query(
+          "SELECT COUNT(*) as count FROM users WHERE role = 'tenant' AND deleted_at IS NULL"
+        )
+        tenantCount = Number(tenantRows[0]?.count || 0)
+
         const { rows: paidRows } = await pool.query(
           `SELECT COALESCE(SUM(amount_ngn), 0) as total
            FROM settlement_ledger_entries
            WHERE beneficiary_type = 'landlord'`
         )
         totalPaidNgn = Number(paidRows[0]?.total || 0)
+
+        const { rows: financedRows } = await pool.query(
+          `SELECT COALESCE(SUM(financed_amount_ngn), 0) as total
+           FROM tenant_deals WHERE deleted_at IS NULL`
+        )
+        totalFinancedNgn = Number(financedRows[0]?.total || 0)
+
+        const { rows: citiesRows } = await pool.query(
+          `SELECT COUNT(DISTINCT city) as count
+           FROM landlord_properties
+           WHERE city IS NOT NULL AND city != ''`
+        )
+        citiesCount = Number(citiesRows[0]?.count || 0)
 
         const { rows: defRows } = await pool.query(
           `SELECT
@@ -91,8 +112,13 @@ publicRouter.get(
     const payload = {
       success: true,
       data: {
-        totalPaidToLandlords: formatNgnAmount(totalPaidNgn),
+        // Homepage stats
+        happyTenants: tenantCount > 0 ? `${tenantCount.toLocaleString()}+` : "0",
+        rentFinanced: formatNgnAmount(totalFinancedNgn),
         partnerLandlords: landlordCount > 0 ? `${landlordCount}+` : "0",
+        citiesCovered: citiesCount > 0 ? `${citiesCount}` : "0",
+        // Landlords page stats
+        totalPaidToLandlords: formatNgnAmount(totalPaidNgn),
         avgPaymentTime: "48hrs",
         landlordDefaultRate: `${defaultRate}%`,
       },

--- a/backend/src/routes/staking.ts
+++ b/backend/src/routes/staking.ts
@@ -6,6 +6,7 @@ import { AppError } from '../errors/AppError.js'
 import { ErrorCode } from '../errors/errorCodes.js'
 import { getPaymentProvider } from '../payments/index.js'
 import { validate } from '../middleware/validate.js'
+import { idempotency } from '../middleware/idempotency.js'
 import { authenticateToken, type AuthenticatedRequest } from '../middleware/auth.js'
 import { depositStore } from '../models/depositStore.js'
 import { LinkedAddressStore } from '../models/linkedAddressStore.js'
@@ -119,6 +120,7 @@ export function createStakingRouter(
 
   router.post(
     '/deposit/initiate',
+    idempotency(),
     validate(depositInitiateSchema),
     async (req: Request, res: Response, next: NextFunction) => {
       try {
@@ -211,6 +213,7 @@ export function createStakingRouter(
    */
   router.post(
     '/finalize',
+    idempotency(),
     validate(stakeFinalizeSchema),
     async (req: Request, res: Response, next: NextFunction) => {
       try {
@@ -252,6 +255,7 @@ export function createStakingRouter(
    */
   router.post(
     '/stake_from_deposit',
+    idempotency(),
     validate(stakeFromDepositSchema),
     async (req: Request, res: Response, next: NextFunction) => {
       try {
@@ -329,6 +333,7 @@ export function createStakingRouter(
    */
   router.post(
     '/stake',
+    idempotency(),
     validate(stakeSchema),
     async (req: Request, res: Response, next: NextFunction) => {
       try {
@@ -403,6 +408,7 @@ export function createStakingRouter(
   router.post(
     '/stake-ngn',
     authenticateToken,
+    idempotency(),
     validate(stakeNgnSchema),
     async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
       try {
@@ -580,6 +586,7 @@ export function createStakingRouter(
    */
   router.post(
     '/unstake',
+    idempotency(),
     validate(unstakeSchema),
     async (req: Request, res: Response, next: NextFunction) => {
       try {
@@ -647,6 +654,7 @@ export function createStakingRouter(
    */
   router.post(
     '/claim',
+    idempotency(),
     validate(claimStakeRewardSchema),
     async (req: Request, res: Response, next: NextFunction) => {
       try {

--- a/backend/src/services/webhookDeliveryService.ts
+++ b/backend/src/services/webhookDeliveryService.ts
@@ -25,7 +25,8 @@ export function computeHmacSignature(payload: string, secret: string): string {
 
 export async function enqueueDelivery(
   event: WebhookEventType,
-  payload: Record<string, unknown>
+  payload: Record<string, unknown>,
+  options?: { requestId?: string }
 ): Promise<void> {
   const activeSubs = webhookSubscriptionStore.listActiveByEvent(event)
   const scheduler = getScheduler()
@@ -35,7 +36,8 @@ export async function enqueueDelivery(
       subscriptionId: sub.id,
       event,
       payload,
-      attemptCount: 0
+      attemptCount: 0,
+      requestId: options?.requestId,
     }
 
     await scheduler.schedule({
@@ -52,8 +54,9 @@ export async function processWebhookDeliveryJob(jobPayload: {
   event: WebhookEventType
   payload: Record<string, unknown>
   attemptCount: number
+  requestId?: string
 }): Promise<void> {
-  const { subscriptionId, event, payload, attemptCount } = jobPayload
+  const { subscriptionId, event, payload, attemptCount, requestId } = jobPayload
   const sub = webhookSubscriptionStore.findById(subscriptionId)
   if (!sub || !sub.active) {
     return
@@ -98,6 +101,7 @@ export async function processWebhookDeliveryJob(jobPayload: {
     status: status === 'delivered' ? 'delivered' : (currentAttempt >= MAX_DELIVERY_ATTEMPTS ? 'permanently_failed' : 'failed'),
     responseCode,
     responseBody: truncatedBody,
+    requestId,
   })
 
   if (status === 'delivered') {
@@ -115,7 +119,8 @@ export async function processWebhookDeliveryJob(jobPayload: {
         subscriptionId,
         event,
         payload,
-        attemptCount: currentAttempt
+        attemptCount: currentAttempt,
+        requestId,
       },
       nextRunAt,
       maxRetries: 0

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState, useEffect } from "react";
 import Link from "next/link";
 import {
   ArrowRight,
@@ -11,7 +12,8 @@ import {
   Wallet,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { homePageStats, homePageBenefits } from "@/lib/mockData";
+import { homePageBenefits } from "@/lib/content/homepage";
+import { getHomePageStats, type HomePageStats } from "@/lib/publicStatsApi";
 
 const iconMap = {
   Wallet,
@@ -21,6 +23,23 @@ const iconMap = {
 };
 
 export default function HomePage() {
+  const [stats, setStats] = useState<HomePageStats | null>(null);
+
+  useEffect(() => {
+    getHomePageStats()
+      .then(setStats)
+      .catch(() => setStats(null));
+  }, []);
+
+  const homePageStats = stats
+    ? [
+        { value: stats.happyTenants, label: "Happy Tenants" },
+        { value: stats.rentFinanced, label: "Rent Financed" },
+        { value: stats.partnerLandlords, label: "Partner Landlords" },
+        { value: stats.citiesCovered, label: "Cities Covered" },
+      ]
+    : [];
+
   return (
     <main>
       {/* Hero Section */}
@@ -120,20 +139,22 @@ export default function HomePage() {
       </section>
 
       {/* Stats Bar */}
-      <section className="border-y-3 border-foreground bg-foreground py-6">
-        <div className="container mx-auto px-4">
-          <div className="grid grid-cols-2 gap-8 md:grid-cols-4">
-            {homePageStats.map((stat) => (
-              <div key={stat.label} className="text-center">
-                <p className="font-mono text-2xl font-black text-background md:text-3xl">
-                  {stat.value}
-                </p>
-                <p className="text-sm text-background/70">{stat.label}</p>
-              </div>
-            ))}
+      {homePageStats.length > 0 && (
+        <section className="border-y-3 border-foreground bg-foreground py-6">
+          <div className="container mx-auto px-4">
+            <div className="grid grid-cols-2 gap-8 md:grid-cols-4">
+              {homePageStats.map((stat) => (
+                <div key={stat.label} className="text-center">
+                  <p className="font-mono text-2xl font-black text-background md:text-3xl">
+                    {stat.value}
+                  </p>
+                  <p className="text-sm text-background/70">{stat.label}</p>
+                </div>
+              ))}
+            </div>
           </div>
-        </div>
-      </section>
+        </section>
+      )}
 
       {/* How It Works */}
       <section className="bg-muted py-16 md:py-24">

--- a/frontend/lib/content/homepage.ts
+++ b/frontend/lib/content/homepage.ts
@@ -1,0 +1,22 @@
+export const homePageBenefits = [
+  {
+    title: "Split Your Rent",
+    description:
+      "Pay your annual rent in comfortable monthly installments instead of one lump sum.",
+  },
+  {
+    title: "Quick Approval",
+    description:
+      "Get approved in under 24 hours with minimal documentation required.",
+  },
+  {
+    title: "No Hidden Fees",
+    description:
+      "Transparent pricing with no surprises. What you see is what you pay.",
+  },
+  {
+    title: "Verified Properties",
+    description:
+      "All listed properties are verified and inspected by our team.",
+  },
+];

--- a/frontend/lib/mockData/index.ts
+++ b/frontend/lib/mockData/index.ts
@@ -1,8 +1,5 @@
 // Re-export all mock data from this file for easy imports
 
-// Homepage
-export { homePageStats, homePageBenefits } from "./homepage";
-
 // Properties
 export { allProperties, propertyFilters } from "./properties";
 

--- a/frontend/lib/publicStatsApi.ts
+++ b/frontend/lib/publicStatsApi.ts
@@ -1,14 +1,36 @@
 import { apiFetch } from "./api";
 
-export interface LandlordPublicStats {
-  totalPaidToLandlords: string;
+export interface PlatformStatsResponse {
+  // Homepage stats
+  happyTenants: string;
+  rentFinanced: string;
   partnerLandlords: string;
+  citiesCovered: string;
+  // Landlords page stats
+  totalPaidToLandlords: string;
   avgPaymentTime: string;
   landlordDefaultRate: string;
 }
 
+export type LandlordPublicStats = Pick<
+  PlatformStatsResponse,
+  "totalPaidToLandlords" | "partnerLandlords" | "avgPaymentTime" | "landlordDefaultRate"
+>;
+
+export type HomePageStats = Pick<
+  PlatformStatsResponse,
+  "happyTenants" | "rentFinanced" | "partnerLandlords" | "citiesCovered"
+>;
+
 export async function getPublicLandlordStats(): Promise<LandlordPublicStats> {
-  const result = await apiFetch<{ success: boolean; data: LandlordPublicStats }>(
+  const result = await apiFetch<{ success: boolean; data: PlatformStatsResponse }>(
+    "/public/stats",
+  );
+  return result.data;
+}
+
+export async function getHomePageStats(): Promise<HomePageStats> {
+  const result = await apiFetch<{ success: boolean; data: PlatformStatsResponse }>(
     "/public/stats",
   );
   return result.data;


### PR DESCRIPTION
Replaces fabricated homepage stats with live database queries, adds rate limiting tiers for staking/deposit/wallet endpoints, propagates correlation IDs through Sentry, outbox, and webhook delivery, and adds idempotency middleware to all money-moving POST endpoints.

## Changes

### #1331 — Fix fabricated homepage stats
- Extended `GET /api/public/stats` with `happyTenants`, `rentFinanced`, `citiesCovered` from live DB queries
- Updated frontend to fetch real stats via `useEffect`, with graceful fallback when unavailable
- Extracted homepage benefits to `frontend/lib/content/homepage.ts`

### #1345 — Add rate limiting to financial endpoints
- Added `staking`, `deposit`, `wallet_withdrawal`, `wallet_topup` tiers to `config/rateLimits.ts`
- Added path-matching rules in `comprehensiveRateLimit.ts` for staking, deposit, wallet withdrawal, and wallet topup routes
- Added tests in `financialRateLimit.test.ts` verifying correct tier engagement

### #1346 — Add correlation IDs across services
- Added Sentry scope integration tagging `requestId` on every request
- Added optional `requestId` to outbox items (`types.ts`, `store.ts`)
- Propagated `requestId` through webhook delivery service and retry scheduling
- Added `requestId` to JSON error response body in `errorHandler.ts`
- Created migration `045_correlation_ids.sql` adding `request_id` column to `outbox_items`
- Added tests in `correlationId.test.ts`

### #1347 — Verify idempotency on money-moving endpoints
- Added `idempotency()` middleware to all staking POST routes: `/deposit/initiate`, `/finalize`, `/stake_from_deposit`, `/stake`, `/stake-ngn`, `/unstake`, `/claim`
- Added durable idempotency to NGN wallet withdrawal `/withdraw/initiate`
- Added tests in `concurrentIdempotency.test.ts` verifying single-effect guarantee

## CI Results
- Frontend lint: 0 errors, build passes
- Backend lint: 0 errors, OpenAPI valid
- 192 tests passing across 18 test files

Closes #1331
Closes #1345
Closes #1346
Closes #1347