### PR TITLE
Backend: declare accurate security schemes across OpenAPI spec (#1332)

### DIFF
--- a/backend/docs/openapi.yml
+++ b/backend/docs/openapi.yml
@@ -7,6 +7,7 @@ info:
     name: ShelterFlex Team
   license:
     name: MIT
+    url: https://opensource.org/licenses/MIT
 
 servers:
   - url: http://localhost:4000
@@ -22,6 +23,7 @@ paths:
       operationId: getHealth
       tags:
         - Health
+      security: []
       responses:
         "200":
           description: Service is healthy
@@ -57,6 +59,7 @@ paths:
       operationId: requestOtp
       tags:
         - Auth
+      security: []
       requestBody:
         required: true
         content:
@@ -94,6 +97,7 @@ paths:
       operationId: verifyOtp
       tags:
         - Auth
+      security: []
       requestBody:
         required: true
         content:
@@ -127,6 +131,8 @@ paths:
                     description: "Session token to be used as Authorization: Bearer <token>"
                   user:
                     $ref: "#/components/schemas/User"
+        "400":
+          $ref: "#/components/responses/ValidationError"
         default:
           $ref: "#/components/responses/Error"
 
@@ -152,6 +158,8 @@ paths:
                   message:
                     type: string
                     example: Logged out
+        "401":
+          $ref: "#/components/responses/Unauthorized"
         default:
           $ref: "#/components/responses/Error"
 
@@ -176,6 +184,8 @@ paths:
                 properties:
                   user:
                     $ref: "#/components/schemas/User"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
         default:
           $ref: "#/components/responses/Error"
 
@@ -211,6 +221,8 @@ paths:
                 properties:
                   messageEmailsEnabled:
                     type: boolean
+        "401":
+          $ref: "#/components/responses/Unauthorized"
         default:
           $ref: "#/components/responses/Error"
 
@@ -221,6 +233,7 @@ paths:
       operationId: walletChallenge
       tags:
         - Auth
+      security: []
       requestBody:
         required: true
         content:
@@ -234,6 +247,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/WalletChallengeResponse'
+        "400":
+          $ref: "#/components/responses/ValidationError"
         default:
           $ref: "#/components/responses/Error"
 
@@ -244,6 +259,7 @@ paths:
       operationId: walletVerify
       tags:
         - Auth
+      security: []
       requestBody:
         required: true
         content:
@@ -257,6 +273,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AuthTokenResponse'
+        "400":
+          $ref: "#/components/responses/ValidationError"
         default:
           $ref: "#/components/responses/Error"
 
@@ -276,13 +294,19 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RiskStateResponse'
+        "401":
+          $ref: "#/components/responses/Unauthorized"
         default:
           $ref: "#/components/responses/Error"
 
   /api/admin/receipts:
     get:
       summary: Query indexed receipts
-      description: Query receipts indexed off-chain (no Soroban call).
+      description: >-
+        Query receipts indexed off-chain (no Soroban call). Note: despite the
+        /admin path prefix, this endpoint only requires an authenticated
+        session (authenticateToken) — the route handler does not check for an
+        admin role.
       operationId: queryReceipts
       tags:
         - Admin
@@ -321,16 +345,21 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PagedReceipts'
+        "401":
+          $ref: "#/components/responses/Unauthorized"
         default:
           $ref: "#/components/responses/Error"
 
   /api/deals/{dealId}/receipts:
     get:
       summary: List receipts for a deal
-      description: Returns all receipts for a deal.
+      description: >-
+        Returns all receipts for a deal. Note: the route has no auth
+        middleware today (see PR description — code/spec mismatch finding).
       operationId: listDealReceipts
       tags:
         - Deals
+      security: []
       parameters:
         - name: dealId
           in: path
@@ -344,6 +373,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DealReceiptsResponse'
+        "404":
+          description: Deal not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
         default:
           $ref: "#/components/responses/Error"
 
@@ -354,6 +389,7 @@ paths:
       operationId: createSupportMessage
       tags:
         - Support
+      security: []
       requestBody:
         required: true
         content:
@@ -408,6 +444,7 @@ paths:
       operationId: listWhistleblowerRatings
       tags:
         - Whistleblower
+      security: []
       parameters:
         - name: id
           in: path
@@ -448,6 +485,7 @@ paths:
       operationId: getWhistleblowerRatingAggregate
       tags:
         - Whistleblower
+      security: []
       parameters:
         - name: id
           in: path
@@ -479,6 +517,7 @@ paths:
       operationId: createPropertyIssueReport
       tags:
         - Risk
+      security: []
       requestBody:
         required: true
         content:
@@ -504,6 +543,7 @@ paths:
       operationId: getSorobanConfig
       tags:
         - Soroban
+      security: []
       responses:
         "200":
           description: Soroban configuration retrieved successfully
@@ -539,6 +579,7 @@ paths:
       operationId: getWhistleblowerEarnings
       tags:
         - Whistleblower
+      security: []
       parameters:
         - name: id
           in: path
@@ -665,6 +706,7 @@ paths:
       operationId: createListing
       tags:
         - Whistleblower
+      security: []
       requestBody:
         required: true
         content:
@@ -737,6 +779,7 @@ paths:
       operationId: listListings
       tags:
         - Whistleblower
+      security: []
       parameters:
         - name: status
           in: query
@@ -856,6 +899,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/WithdrawalHistoryResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
         default:
           $ref: '#/components/responses/Error'
 
@@ -931,6 +976,7 @@ paths:
       operationId: getListingById
       tags:
         - Whistleblower
+      security: []
       parameters:
         - name: id
           in: path
@@ -1057,6 +1103,9 @@ paths:
       operationId: confirmPayment
       tags:
         - Payments
+      # NOTE: createPaymentsRouter() applies no auth middleware to this route today (see PR
+      # description — code/spec mismatch finding). security:[] reflects the current code.
+      security: []
       requestBody:
         required: true
         content:
@@ -1124,6 +1173,9 @@ paths:
       operationId: createDeal
       tags:
         - Deals
+      # NOTE: createDealsRouter() applies no auth middleware to any /api/deals route today
+      # (see PR description — code/spec mismatch finding). security:[] reflects current code.
+      security: []
       requestBody:
         required: true
         content:
@@ -1205,6 +1257,7 @@ paths:
       operationId: getDeals
       tags:
         - Deals
+      security: []
       parameters:
         - name: tenantId
           in: query
@@ -1266,6 +1319,7 @@ paths:
       operationId: getDealById
       tags:
         - Deals
+      security: []
       parameters:
         - name: dealId
           in: path
@@ -1304,6 +1358,7 @@ paths:
       operationId: updateDealStatus
       tags:
         - Deals
+      security: []
       parameters:
         - name: dealId
           in: path
@@ -1350,6 +1405,7 @@ paths:
       operationId: updateScheduleItemStatus
       tags:
         - Deals
+      security: []
       parameters:
         - name: dealId
           in: path
@@ -1408,6 +1464,7 @@ paths:
       operationId: getDealProgress
       tags:
         - Deals
+      security: []
       parameters:
         - name: dealId
           in: path
@@ -1472,6 +1529,10 @@ paths:
       operationId: markRewardPaid
       tags:
         - Admin
+      # NOTE: this handler calls neither requireAdminSecret nor authenticateToken — it is
+      # unauthenticated in code today despite being an admin payout action (see PR
+      # description — code/spec mismatch finding). security:[] reflects current code.
+      security: []
       parameters:
         - name: rewardId
           in: path
@@ -1603,6 +1664,10 @@ paths:
       operationId: adminListWhistleblowerListings
       tags:
         - Admin
+      # NOTE: this handler calls neither requireAdminSecret nor authenticateToken — it is
+      # unauthenticated in code today (see PR description — code/spec mismatch finding).
+      # security:[] reflects current code.
+      security: []
       parameters:
         - name: status
           in: query
@@ -1658,6 +1723,10 @@ paths:
       operationId: approveWhistleblowerListing
       tags:
         - Admin
+      # NOTE: this handler calls neither requireAdminSecret nor authenticateToken — it is
+      # unauthenticated in code today (see PR description — code/spec mismatch finding).
+      # security:[] reflects current code.
+      security: []
       parameters:
         - name: id
           in: path
@@ -1730,6 +1799,10 @@ paths:
       operationId: rejectWhistleblowerListing
       tags:
         - Admin
+      # NOTE: this handler calls neither requireAdminSecret nor authenticateToken — it is
+      # unauthenticated in code today (see PR description — code/spec mismatch finding).
+      # security:[] reflects current code.
+      security: []
       parameters:
         - name: id
           in: path
@@ -1815,6 +1888,9 @@ paths:
       operationId: stakeTokens
       tags:
         - Staking
+      # NOTE: createStakingRouter() applies no auth middleware to this route today (see PR
+      # description — code/spec mismatch finding). security:[] reflects current code.
+      security: []
       requestBody:
         required: true
         content:
@@ -1870,6 +1946,9 @@ paths:
       operationId: unstakeTokens
       tags:
         - Staking
+      # NOTE: createStakingRouter() applies no auth middleware to this route today (see PR
+      # description — code/spec mismatch finding). security:[] reflects current code.
+      security: []
       requestBody:
         required: true
         content:
@@ -1925,6 +2004,9 @@ paths:
       operationId: claimStakingRewards
       tags:
         - Staking
+      # NOTE: createStakingRouter() applies no auth middleware to this route today (see PR
+      # description — code/spec mismatch finding). security:[] reflects current code.
+      security: []
       requestBody:
         required: true
         content:
@@ -1975,6 +2057,8 @@ paths:
       operationId: getStakingPosition
       tags:
         - Staking
+      security:
+        - bearerAuth: []
       responses:
         '200':
           description: Staking position retrieved successfully
@@ -1987,6 +2071,8 @@ paths:
                 position:
                   staked: "1000.000000"
                   claimable: "50.250000"
+        '401':
+          $ref: '#/components/responses/Unauthorized'
         default:
           $ref: '#/components/responses/Error'
 
@@ -2091,6 +2177,10 @@ paths:
       operationId: initiateStakingDeposit
       tags:
         - Staking
+      # NOTE: identity here comes from the trusted x-user-id header (see description), not a
+      # bearer token — the route has no authenticateToken/bearerAuth check (see PR
+      # description — code/spec mismatch finding). security:[] reflects current code.
+      security: []
       parameters:
         - in: header
           name: x-user-id
@@ -2170,6 +2260,8 @@ paths:
       operationId: paymentsWebhook
       tags:
         - Webhooks
+      security:
+        - webhookSignature: []
       parameters:
         - name: rail
           in: path
@@ -3570,6 +3662,14 @@ components:
       type: http
       scheme: bearer
       bearerFormat: token
+    webhookSignature:
+      type: apiKey
+      in: header
+      name: X-Webhook-Signature
+      description: >-
+        Provider-specific HMAC signature header verified server-side instead of a bearer
+        token (e.g. x-paystack-signature for Paystack, verif-hash for Flutterwave). The
+        header name varies by payment rail; see the payments webhook handler.
 
 tags:
   - name: Health


### PR DESCRIPTION
## Summary
- Fixes all 32 `security-defined` warnings from `npm run openapi:validate` — every operation now explicitly declares `security: [bearerAuth: []]`, `security: [webhookSignature: []]`, or `security: []` (public), matching what the route middleware actually enforces.
- Adds a `webhookSignature` security scheme (HMAC, verified server-side) for the payments webhook, alongside the existing `bearerAuth`.
- Resolves 13 of the other 15 pre-existing lint warnings (missing license URL, an unused response component, 11 missing 4xx responses).
- No route/middleware behavior was changed — this PR is spec-only (`backend/docs/openapi.yml`).

## Critical finding — please read before merging
While verifying each operation against its actual middleware (per the issue's instructions), I found the issue's own premise — "the routes are protected in code today" — is **false** for a large subset of endpoints. These currently have **zero** auth middleware in the code, so I documented them as `security: []` to match reality rather than inventing auth that doesn't exist:

- `/api/staking/stake`, `/unstake`, `/claim`, `/deposit/initiate`
- `/api/payments/confirm`
- All of `/api/deals` (create, list, get, status patch, schedule patch, progress, receipts)
- `/api/admin/rewards/{rewardId}/mark-paid`
- `/api/admin/whistleblower/listings` (list, approve, reject) — not even the existing `requireAdminSecret` header check is applied here

Also noted: `/api/admin/receipts` only requires *any* authenticated session (no admin-role check) despite the `/admin` path.

These are money-moving and admin endpoints with no access control today. Fixing the actual auth behavior is explicitly out of scope for this ticket ("Changing route authentication behaviour... raise it separately"), so I'm flagging it here for a follow-up security-fix issue rather than bundling a behavior change into a docs PR.

## Remaining non-security warnings (2, explained rather than fixed)
- `no-server-example.com` on the `http://localhost:4000` dev server entry — intentional local-dev server, not a defect.
- `no-ambiguous-paths` between `/api/whistleblower/{id}/ratings` and `/api/whistleblower/listings/{id}` — a genuine structural ambiguity, but fixing it means renaming/restructuring paths, which is explicitly out of scope ("Restructuring the spec").

## Test plan
- [x] `npm run openapi:validate` — 0 security-defined warnings (was 32), 2 warnings remain (documented above)
- [x] `npm run lint` — clean
- [x] `npm run test:ci` — same pre-existing failures as `main` (all one root cause: a missing native Sentry profiler binary on this dev machine, unrelated to this change — verified by stashing the diff and re-running); no regressions

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>