### PR TITLE
Backend: route tests for account and balance endpoints (#1266)

### DIFF
--- a/backend/src/routes/account.test.ts
+++ b/backend/src/routes/account.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import request from 'supertest'
+import express from 'express'
+import { createAccountRouter } from './account.js'
+import { errorHandler } from '../middleware/errorHandler.js'
+import { requestIdMiddleware } from '../middleware/requestId.js'
+import { sessionStore, userStore } from '../models/authStore.js'
+import { softDeleteUser } from '../services/dataRetentionService.js'
+
+vi.mock('../services/dataRetentionService.js', () => ({
+  softDeleteUser: vi.fn(),
+}))
+
+// Deliberately not importing from '../test-helpers.js' here: it imports the full
+// app (createApp from '../app.js') at module scope, which pulls in
+// @sentry/profiling-node's native binding — unrelated to what this suite tests
+// and best avoided in a focused route-level test.
+function expectErrorShape(
+  res: request.Response,
+  expectedCode: string,
+  expectedStatus: number,
+): void {
+  expect(res.status).toBe(expectedStatus)
+  expect(res.body).toHaveProperty('error')
+  expect(res.body.error).toHaveProperty('code', expectedCode)
+  expect(res.body.error).toHaveProperty('message')
+  expect(typeof res.body.error.message).toBe('string')
+}
+
+/**
+ * Route-level tests only. This intentionally mounts createAccountRouter() directly
+ * (not the full app via createApp()) so the real authenticateToken middleware and
+ * real in-memory session/user stores are exercised without pulling in unrelated
+ * app-wide wiring.
+ */
+function buildApp(): express.Express {
+  const app = express()
+  app.use(requestIdMiddleware)
+  app.use(express.json())
+  app.use('/api/v1', createAccountRouter())
+  app.use(errorHandler)
+  return app
+}
+
+describe('Account Routes', () => {
+  let app: express.Express
+  let userAId: string
+  let userAToken: string
+  let userBId: string
+  let userBToken: string
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    sessionStore.clear()
+    userStore.clear()
+    app = buildApp()
+
+    const userA = await userStore.getOrCreateByEmail('account-owner-a@example.com')
+    userAId = userA.id
+    userAToken = 'test-token-account-owner-a'
+    await sessionStore.create(userA.email, userAToken)
+
+    const userB = await userStore.getOrCreateByEmail('account-owner-b@example.com')
+    userBId = userB.id
+    userBToken = 'test-token-account-owner-b'
+    await sessionStore.create(userB.email, userBToken)
+
+    vi.mocked(softDeleteUser).mockResolvedValue({ success: true, userId: userAId })
+  })
+
+  describe('DELETE /api/v1/account', () => {
+    it('rejects unauthenticated requests', async () => {
+      const res = await request(app).delete('/api/v1/account')
+      expectErrorShape(res, 'UNAUTHORIZED', 401)
+      expect(softDeleteUser).not.toHaveBeenCalled()
+    })
+
+    it('rejects requests bearing an invalid/unknown token', async () => {
+      const res = await request(app)
+        .delete('/api/v1/account')
+        .set('Authorization', 'Bearer not-a-real-session-token')
+
+      expect(res.status).toBe(401)
+      expect(softDeleteUser).not.toHaveBeenCalled()
+    })
+
+    it("deletes only the authenticated caller's own account", async () => {
+      await request(app)
+        .delete('/api/v1/account')
+        .set('Authorization', `Bearer ${userAToken}`)
+        .expect(204)
+
+      expect(softDeleteUser).toHaveBeenCalledTimes(1)
+      expect(softDeleteUser).toHaveBeenCalledWith(
+        userAId,
+        userAId,
+        expect.any(String),
+        expect.anything(),
+      )
+    })
+
+    it('scopes the delete to the session owner even if another user id is supplied in the body/query (no IDOR)', async () => {
+      await request(app)
+        .delete('/api/v1/account')
+        .set('Authorization', `Bearer ${userAToken}`)
+        .query({ userId: userBId })
+        .send({ userId: userBId, id: userBId, accountId: userBId })
+        .expect(204)
+
+      // Only the caller's own id is ever passed to the delete service — the
+      // supplied userB id in the body/query has no effect on which account is targeted.
+      expect(softDeleteUser).toHaveBeenCalledWith(
+        userAId,
+        userAId,
+        expect.any(String),
+        expect.anything(),
+      )
+      expect(softDeleteUser).not.toHaveBeenCalledWith(
+        userBId,
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+      )
+    })
+
+    it("does not touch another user's account or session", async () => {
+      await request(app)
+        .delete('/api/v1/account')
+        .set('Authorization', `Bearer ${userAToken}`)
+        .expect(204)
+
+      expect(softDeleteUser).not.toHaveBeenCalledWith(
+        userBId,
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+      )
+
+      // User B's own session is unaffected by A's deletion.
+      const userBSession = await sessionStore.getByToken(userBToken)
+      expect(userBSession).toBeDefined()
+      expect(userBSession?.email).toBe('account-owner-b@example.com')
+    })
+
+    it('returns a consistent error shape when the underlying delete fails', async () => {
+      vi.mocked(softDeleteUser).mockResolvedValueOnce({ success: false, error: 'database unavailable' })
+
+      const res = await request(app)
+        .delete('/api/v1/account')
+        .set('Authorization', `Bearer ${userAToken}`)
+
+      expectErrorShape(res, 'INTERNAL_ERROR', 500)
+    })
+  })
+})

--- a/backend/src/routes/balance.test.ts
+++ b/backend/src/routes/balance.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import request from 'supertest'
+import express from 'express'
+import { createBalanceRouter } from './balance.js'
+import { StubSorobanAdapter } from '../soroban/stub-adapter.js'
+import { errorHandler } from '../middleware/errorHandler.js'
+import { requestIdMiddleware } from '../middleware/requestId.js'
+
+/**
+ * NOTE ON SCOPE: createBalanceRouter() applies no auth middleware at all — every
+ * route here (get balance, credit, debit) accepts an arbitrary `:account` path
+ * param with no session/ownership check. This is a genuine gap (see PR
+ * description), not something this test suite can paper over: the
+ * "current behavior" tests below intentionally document that any caller can
+ * read or mutate any account's balance today, rather than asserting a denial
+ * that the code does not implement.
+ */
+function buildApp(): express.Express {
+  const adapter = new StubSorobanAdapter({ rpcUrl: '', networkPassphrase: '' })
+  const app = express()
+  app.use(requestIdMiddleware)
+  app.use(express.json())
+  app.use('/api/v1', createBalanceRouter(adapter))
+  app.use(errorHandler)
+  return app
+}
+
+describe('Balance Routes', () => {
+  let app: express.Express
+
+  beforeEach(() => {
+    StubSorobanAdapter._testOnlyReset()
+    app = buildApp()
+  })
+
+  describe('GET /api/v1/balance/:account', () => {
+    it('returns a balance for an arbitrary account with no Authorization header at all', async () => {
+      // Documents the current gap: there is no authenticateToken (or any auth) on this route.
+      const res = await request(app).get('/api/v1/balance/GACCOUNT_NO_AUTH_TEST')
+      expect(res.status).toBe(200)
+      expect(res.body.account).toBe('GACCOUNT_NO_AUTH_TEST')
+      expect(typeof res.body.balance).toBe('string')
+    })
+
+    it('rejects a blank account param', async () => {
+      const res = await request(app).get('/api/v1/balance/%20')
+      expect(res.status).toBe(400)
+      expect(res.body.error).toBeDefined()
+    })
+
+    it('returns a stable, deterministic non-negative balance on repeated reads with no intervening mutation', async () => {
+      const first = await request(app).get('/api/v1/balance/GACCOUNT_STABLE').expect(200)
+      const second = await request(app).get('/api/v1/balance/GACCOUNT_STABLE').expect(200)
+
+      expect(second.body.balance).toBe(first.body.balance)
+      expect(BigInt(second.body.balance)).toBeGreaterThanOrEqual(0n)
+    })
+
+    it('tracks balances independently per account (no cross-account bleed)', async () => {
+      const accountA = await request(app).get('/api/v1/balance/GACCOUNT_ISO_A').expect(200)
+      const accountB = await request(app).get('/api/v1/balance/GACCOUNT_ISO_B').expect(200)
+
+      await request(app)
+        .post('/api/v1/balance/GACCOUNT_ISO_A/credit')
+        .send({ amount: '500' })
+        .expect(200)
+
+      const accountAAfter = await request(app).get('/api/v1/balance/GACCOUNT_ISO_A').expect(200)
+      const accountBAfter = await request(app).get('/api/v1/balance/GACCOUNT_ISO_B').expect(200)
+
+      expect(BigInt(accountAAfter.body.balance)).toBe(BigInt(accountA.body.balance) + 500n)
+      // Crediting A must never change B's balance.
+      expect(accountBAfter.body.balance).toBe(accountB.body.balance)
+    })
+  })
+
+  describe('POST /api/v1/balance/:account/credit', () => {
+    it('increases the balance by the credited amount', async () => {
+      const before = await request(app).get('/api/v1/balance/GACCOUNT_CREDIT').expect(200)
+
+      const res = await request(app)
+        .post('/api/v1/balance/GACCOUNT_CREDIT/credit')
+        .send({ amount: '250' })
+        .expect(200)
+
+      expect(BigInt(res.body.newBalance)).toBe(BigInt(before.body.balance) + 250n)
+    })
+
+    it('requires an amount string in the body', async () => {
+      const res = await request(app)
+        .post('/api/v1/balance/GACCOUNT_CREDIT_BAD/credit')
+        .send({})
+      expect(res.status).toBe(400)
+      expect(res.body.error).toBeDefined()
+    })
+
+    it('can be called with no Authorization header at all (current gap — see PR description)', async () => {
+      const res = await request(app)
+        .post('/api/v1/balance/GACCOUNT_CREDIT_NO_AUTH/credit')
+        .send({ amount: '100' })
+      expect(res.status).toBe(200)
+    })
+  })
+
+  describe('POST /api/v1/balance/:account/debit', () => {
+    it('decreases the balance by the debited amount, including down to exactly zero', async () => {
+      const before = await request(app).get('/api/v1/balance/GACCOUNT_DEBIT').expect(200)
+      const fullBalance = before.body.balance as string
+
+      const res = await request(app)
+        .post('/api/v1/balance/GACCOUNT_DEBIT/debit')
+        .send({ amount: fullBalance })
+        .expect(200)
+
+      expect(res.body.newBalance).toBe('0')
+
+      const after = await request(app).get('/api/v1/balance/GACCOUNT_DEBIT').expect(200)
+      expect(after.body.balance).toBe('0')
+    })
+
+    it('rejects debiting more than the current balance', async () => {
+      const before = await request(app).get('/api/v1/balance/GACCOUNT_OVERDRAW').expect(200)
+      const tooMuch = (BigInt(before.body.balance) + 1_000_000n).toString()
+
+      const res = await request(app)
+        .post('/api/v1/balance/GACCOUNT_OVERDRAW/debit')
+        .send({ amount: tooMuch })
+
+      expect(res.status).toBeGreaterThanOrEqual(400)
+
+      // Balance must be unchanged after a rejected debit.
+      const after = await request(app).get('/api/v1/balance/GACCOUNT_OVERDRAW').expect(200)
+      expect(after.body.balance).toBe(before.body.balance)
+    })
+
+    it('requires an amount string in the body', async () => {
+      const res = await request(app)
+        .post('/api/v1/balance/GACCOUNT_DEBIT_BAD/debit')
+        .send({})
+      expect(res.status).toBe(400)
+      expect(res.body.error).toBeDefined()
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Adds `backend/src/routes/account.test.ts` (6 tests) and `backend/src/routes/balance.test.ts` (10 tests).
- Both suites mount only the router under test (not the full `createApp()`) — this sidesteps a pre-existing environment issue where importing the full app pulls in `@sentry/profiling-node`'s native binding, which is absent on this dev machine (that's also why `session.test.ts`, `wallet.test.ts`, etc. are excluded from `test:ci`). The route logic and real `authenticateToken` middleware are still exercised directly.

### account.test.ts
`account.ts` turned out to have no GET/profile endpoint — only `DELETE /api/account` (soft-delete), which is `authenticateToken`-guarded and always scoped to `req.user.id` (there's no id parameter, so no IDOR surface exists). Covers: unauthenticated/invalid-token rejection, self-only delete, that a spoofed `userId` in body/query has no effect, that another user's session/account is untouched, and consistent error shape on failure.

### balance.test.ts — finding
`balance.ts` (`GET /balance/:account`, `POST /balance/:account/credit`, `POST /balance/:account/debit`) has **no auth middleware on any route** — `account` is just a path param, and any caller can read or mutate any account's balance today. This is mounted unconditionally at `/api/v1` with no feature flag. Per direction from the repo owner, the tests document this actual (unauthenticated) behavior rather than asserting a denial the code doesn't implement, and cover the legitimate balance-accuracy cases: zero-after-full-debit, overdraw rejection, per-account isolation, and credit/debit arithmetic.

Route auth behavior was not changed — this is test-only, flagging the gap for a follow-up.

## Test plan
- [x] Both new suites pass in isolation and together
- [x] `npm run lint` — clean
- [x] `npm run test:ci` — same 22 pre-existing failures as `main` (missing native Sentry binary, confirmed identical before this change), plus 16 new passing tests; no regressions
- [x] `npm run openapi:validate` — unchanged baseline (this PR doesn't touch the spec)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>