### PR TITLE
test(frontend): add component coverage for shared and role-based UI

### DIFF
--- a/frontend/components/admin/AuditLogFilters.test.tsx
+++ b/frontend/components/admin/AuditLogFilters.test.tsx
@@ -1,0 +1,26 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { AuditLogFilters } from './AuditLogFilters'
+
+describe('AuditLogFilters', () => {
+  it('submits the actor id filter and clears active filters when requested', () => {
+    const onFiltersChange = vi.fn()
+
+    render(
+      <AuditLogFilters
+        filters={{ page: 1, limit: 20 }}
+        onFiltersChange={onFiltersChange}
+      />,
+    )
+
+    const actorInput = screen.getByLabelText(/actor id/i)
+    fireEvent.change(actorInput, { target: { value: 'actor-42' } })
+    fireEvent.keyDown(actorInput, { key: 'Enter' })
+
+    expect(onFiltersChange).toHaveBeenCalledWith(expect.objectContaining({ actorId: 'actor-42', page: 1 }))
+
+    fireEvent.click(screen.getByRole('button', { name: /clear filters/i }))
+    expect(onFiltersChange).toHaveBeenCalledWith(expect.objectContaining({ page: 1, limit: 20 }))
+  })
+})

--- a/frontend/components/inspector/InspectionChecklist.test.tsx
+++ b/frontend/components/inspector/InspectionChecklist.test.tsx
@@ -1,0 +1,19 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { InspectionChecklist } from './InspectionChecklist'
+
+describe('InspectionChecklist', () => {
+  it('tracks progress and notes when checklist items are updated', () => {
+    render(<InspectionChecklist />)
+
+    expect(screen.getByText(/0 of 17 required items completed/i)).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /building exterior condition/i }))
+    expect(screen.getByText(/1 of 17 required items completed/i)).toBeInTheDocument()
+
+    const notesField = screen.getAllByPlaceholderText(/Add notes/i)[0]
+    fireEvent.change(notesField, { target: { value: 'Needs touch-up' } })
+    expect(notesField).toHaveValue('Needs touch-up')
+  })
+})

--- a/frontend/components/inspector/ReportSubmitForm.test.tsx
+++ b/frontend/components/inspector/ReportSubmitForm.test.tsx
@@ -1,0 +1,52 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ReportSubmitForm } from './ReportSubmitForm'
+import { propertyInspectionApi } from '@/lib/propertyInspectionApi'
+
+vi.mock('@/lib/propertyInspectionApi', () => ({
+  propertyInspectionApi: {
+    submitReport: vi.fn(),
+  },
+}))
+
+describe('ReportSubmitForm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.stubGlobal('URL', {
+      ...URL,
+      createObjectURL: vi.fn(() => 'blob:inspection-photo'),
+    })
+  })
+
+  it('submits the inspection report after the required fields are completed', async () => {
+    const onSubmitted = vi.fn()
+    const submitReportMock = vi.mocked(propertyInspectionApi.submitReport)
+    submitReportMock.mockResolvedValue(undefined as never)
+
+    render(<ReportSubmitForm jobId="job-42" propertyTitle="Sunny Villa" onSubmitted={onSubmitted} />)
+
+    fireEvent.change(screen.getByLabelText(/summary of findings/i), {
+      target: { value: 'All systems are in good order.' },
+    })
+
+    const fileInput = screen.getByLabelText(/upload inspection photos/i)
+    fireEvent.change(fileInput, {
+      target: { files: [new File(['photo'], 'photo.png', { type: 'image/png' })] },
+    })
+
+    screen.getAllByRole('checkbox').forEach((checkbox) => {
+      fireEvent.click(checkbox)
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /submit inspection report/i }))
+
+    expect(submitReportMock).toHaveBeenCalledWith(
+      'job-42',
+      expect.objectContaining({
+        inspectorNotes: 'All systems are in good order.',
+      }),
+    )
+    expect(onSubmitted).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/components/landlord/ApplicantCard.test.tsx
+++ b/frontend/components/landlord/ApplicantCard.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+
+import { ApplicantCard } from './ApplicantCard'
+
+const applicant = {
+  id: 'app-1',
+  listingId: 'listing-1',
+  tenantId: 'tenant-12345678',
+  landlordId: 'landlord-1',
+  status: 'approved' as const,
+  preferredStartDate: '2025-01-01',
+  paymentPlan: 'monthly',
+  appliedAt: '2025-01-03T08:00:00.000Z',
+  name: 'Jane Doe',
+  email: 'jane@example.com',
+  phone: '+2348000000000',
+  employmentStatus: 'Full-time',
+  incomeBand: '$5k-$10k',
+  ratingCardScore: 87,
+}
+
+describe('ApplicantCard', () => {
+  it('renders applicant details and calls the view handler', async () => {
+    const user = userEvent.setup()
+    const onViewDetails = vi.fn()
+
+    render(<ApplicantCard applicant={applicant} onViewDetails={onViewDetails} />)
+
+    expect(screen.getByText('Jane Doe')).toBeInTheDocument()
+    expect(screen.getByText('Approved')).toBeInTheDocument()
+    expect(screen.getByText(/Rating Card Score/i)).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /view details/i }))
+
+    expect(onViewDetails).toHaveBeenCalledWith(applicant)
+  })
+})

--- a/frontend/components/layout/NotificationBell.test.tsx
+++ b/frontend/components/layout/NotificationBell.test.tsx
@@ -1,0 +1,66 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { NotificationBell } from './NotificationBell'
+
+const mockUseNotifications = vi.fn()
+const mockUseUnreadMessageCount = vi.fn()
+const mockMarkAllNotificationsRead = vi.fn()
+const mockIsAuthenticated = vi.fn()
+
+vi.mock('next/link', () => ({
+  default: ({ children, href, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string; children: React.ReactNode }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}))
+
+vi.mock('@/hooks/useNotifications', () => ({
+  useNotifications: () => mockUseNotifications(),
+}))
+
+vi.mock('@/hooks/useUnreadMessageCount', () => ({
+  useUnreadMessageCount: () => mockUseUnreadMessageCount(),
+}))
+
+vi.mock('@/lib/notificationsApi', () => ({
+  markAllNotificationsRead: () => mockMarkAllNotificationsRead(),
+}))
+
+vi.mock('@/lib/auth', () => ({
+  isAuthenticated: () => mockIsAuthenticated(),
+}))
+
+describe('NotificationBell', () => {
+  beforeEach(() => {
+    mockIsAuthenticated.mockReturnValue(true)
+    mockUseNotifications.mockReturnValue({
+      unreadCount: 2,
+      notifications: [{ id: 'n1', category: 'payment_due', title: 'Payment due', body: 'Your rent is due', createdAt: new Date().toISOString(), read: false }],
+      isConnected: true,
+    })
+    mockUseUnreadMessageCount.mockReturnValue({ unreadCount: 1, isConnected: true })
+    mockMarkAllNotificationsRead.mockResolvedValue(undefined)
+  })
+
+  it('renders nothing for unauthenticated users', () => {
+    mockIsAuthenticated.mockReturnValue(false)
+
+    const { container } = render(<NotificationBell />)
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('shows the combined unread count and opens the notification menu', () => {
+    render(<NotificationBell />)
+
+    const trigger = screen.getByRole('button', { name: /Notifications, 2 unread notifications and 1 unread messages/i })
+    expect(trigger).toHaveTextContent('3')
+
+    fireEvent.click(trigger)
+
+    expect(screen.getByText('Messages')).toBeInTheDocument()
+    expect(screen.getByText('Payment due')).toBeInTheDocument()
+  })
+})

--- a/frontend/components/tenant/document-preview-dialog.test.tsx
+++ b/frontend/components/tenant/document-preview-dialog.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { DocumentPreviewDialog } from './document-preview-dialog'
+
+describe('DocumentPreviewDialog', () => {
+  it('shows the loading state while a preview is pending', () => {
+    render(
+      <DocumentPreviewDialog
+        preview={null}
+        loading={true}
+        error={null}
+        onClose={() => undefined}
+      />,
+    )
+
+    expect(screen.getByRole('status')).toHaveTextContent(/loading document/i)
+  })
+
+  it('renders an informative error state when the preview fails', () => {
+    render(
+      <DocumentPreviewDialog
+        preview={{
+          fileName: 'lease.pdf',
+          fileFormat: 'pdf',
+          storageKey: 'https://example.com/lease.pdf',
+          previewAvailable: false,
+          message: 'Preview not available',
+          fileSizeBytes: 1024,
+        } as any}
+        loading={false}
+        error={null}
+        onClose={() => undefined}
+      />,
+    )
+
+    expect(screen.getByText(/preview not available/i)).toBeInTheDocument()
+  })
+})

--- a/frontend/components/ui/primitives.test.tsx
+++ b/frontend/components/ui/primitives.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { Badge } from './badge'
+import { Button } from './button'
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from './card'
+
+describe('shared UI primitives', () => {
+  it('renders a button with the requested variant and size classes', () => {
+    render(
+      <Button variant="destructive" size="sm" data-testid="action-button">
+        Delete
+      </Button>,
+    )
+
+    const button = screen.getByTestId('action-button')
+
+    expect(button).toHaveTextContent('Delete')
+    expect(button).toHaveClass('bg-destructive')
+    expect(button).toHaveClass('h-8')
+  })
+
+  it('renders a badge with the outline variant styling', () => {
+    render(<Badge variant="outline">New</Badge>)
+
+    const badge = screen.getByText('New')
+
+    expect(badge).toHaveClass('border')
+    expect(badge).toHaveClass('text-foreground')
+  })
+
+  it('renders card subcomponents with the expected data slots', () => {
+    render(
+      <Card>
+        <CardHeader>
+          <CardTitle>Card title</CardTitle>
+          <CardDescription>Helpful summary</CardDescription>
+        </CardHeader>
+        <CardContent>Body copy</CardContent>
+        <CardFooter>Footer action</CardFooter>
+      </Card>,
+    )
+
+    expect(screen.getByText('Card title')).toBeInTheDocument()
+    expect(screen.getByText('Helpful summary')).toBeInTheDocument()
+    expect(screen.getByText('Body copy')).toBeInTheDocument()
+    expect(screen.getByText('Footer action')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary

Add frontend component test coverage for the shared UI primitives and the admin, landlord, inspector, layout, and tenant-facing components covered by issues #1411-#1414.

## Changes

- Added focused Vitest + Testing Library coverage for shared UI primitives in the shared component library.
- Added component tests for layout and notification behavior.
- Added landlord component tests for application card rendering and interaction.
- Added inspector component tests for checklist progress tracking and report submission flow.
- Added tenant document preview dialog tests for loading and error states.
- Added admin audit log filter tests for actor ID submission and filter clearing behavior.

## Checklist

- [x] I have added or updated tests for the affected frontend components.
- [x] I have followed the repository’s frontend testing conventions.
- [x] I have kept the change focused on the assigned issues.

Closes #1411
Closes #1412
Closes #1413
Closes #1414