### PR TITLE
Add tests for frontend lib modules (auth, security, API, payments)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ frontend/.next
 frontend/out
 frontend/.env
 frontend/.env.*
+frontend/coverage
 
 # Backend
 backend/dist

--- a/frontend/lib/__tests__/api-client.test.ts
+++ b/frontend/lib/__tests__/api-client.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { ApiClient } from '@/lib/api-client'
+
+vi.mock('@/lib/wallet-auth', () => ({
+  walletAuthManager: {
+    getAuthToken: vi.fn(),
+  },
+}))
+
+import { walletAuthManager } from '@/lib/wallet-auth'
+
+const mockedGetAuthToken = vi.mocked(walletAuthManager.getAuthToken)
+
+describe('ApiClient', () => {
+  let client: ApiClient
+
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    mockedGetAuthToken.mockReturnValue(null)
+    client = new ApiClient('https://api.test.com')
+  })
+
+  describe('get', () => {
+    it('makes a GET request to the correct URL', async () => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(JSON.stringify({ data: 'ok' }), { status: 200 })
+      )
+
+      const result = await client.get('/api/test')
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        'https://api.test.com/api/test',
+        expect.objectContaining({ method: 'GET' })
+      )
+      expect(result).toEqual({ data: 'ok' })
+    })
+
+    it('attaches Authorization header when token exists', async () => {
+      mockedGetAuthToken.mockReturnValue('my-token')
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(JSON.stringify({ ok: true }), { status: 200 })
+      )
+
+      await client.get('/api/test')
+
+      const headers = fetchSpy.mock.calls[0][1]?.headers as Record<string, string>
+      expect(headers['Authorization']).toBe('Bearer my-token')
+    })
+
+    it('throws on non-ok response', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response('Not Found', { status: 404, statusText: 'Not Found' })
+      )
+
+      await expect(client.get('/api/missing')).rejects.toThrow('API Error: Not Found')
+    })
+  })
+
+  describe('post', () => {
+    it('makes a POST request with JSON body', async () => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(JSON.stringify({ created: true }), { status: 200 })
+      )
+
+      const result = await client.post('/api/create', { name: 'test' })
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        'https://api.test.com/api/create',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ name: 'test' }),
+        })
+      )
+      expect(result).toEqual({ created: true })
+    })
+
+    it('sends POST without body when data is undefined', async () => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(JSON.stringify({ ok: true }), { status: 200 })
+      )
+
+      await client.post('/api/action')
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        'https://api.test.com/api/action',
+        expect.objectContaining({ body: undefined })
+      )
+    })
+
+    it('throws on server error', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response('Server Error', { status: 500, statusText: 'Internal Server Error' })
+      )
+
+      await expect(client.post('/api/fail')).rejects.toThrow('API Error: Internal Server Error')
+    })
+  })
+
+  describe('constructor', () => {
+    it('uses the provided base URL', async () => {
+      const customClient = new ApiClient('https://custom.api.com')
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(JSON.stringify({}), { status: 200 })
+      )
+
+      await customClient.get('/test')
+
+      expect(fetchSpy.mock.calls[0][0]).toBe('https://custom.api.com/test')
+    })
+  })
+})

--- a/frontend/lib/__tests__/api.test.ts
+++ b/frontend/lib/__tests__/api.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { ApiError, isAccountFrozenError, apiFetch, apiPost } from '@/lib/api'
+
+vi.mock('@/lib/offline-queue', () => ({
+  enqueueOfflineRequest: vi.fn(),
+}))
+
+vi.mock('@/lib/csrf-protection', () => ({
+  csrfProtection: {
+    getCurrentToken: vi.fn().mockReturnValue('csrf-token'),
+    initialize: vi.fn().mockReturnValue('csrf-token'),
+  },
+}))
+
+describe('ApiError', () => {
+  it('is an instance of Error', () => {
+    const err = new ApiError({ message: 'test', status: 400 })
+    expect(err).toBeInstanceOf(Error)
+    expect(err).toBeInstanceOf(ApiError)
+  })
+
+  it('has status and code properties', () => {
+    const err = new ApiError({ message: 'forbidden', status: 403, code: 'FORBIDDEN' })
+    expect(err.status).toBe(403)
+    expect(err.code).toBe('FORBIDDEN')
+    expect(err.name).toBe('ApiError')
+  })
+
+  it('stores details', () => {
+    const details = { field: 'email' }
+    const err = new ApiError({ message: 'validation', status: 422, details })
+    expect(err.details).toEqual(details)
+  })
+})
+
+describe('isAccountFrozenError', () => {
+  it('returns true for ACCOUNT_FROZEN ApiError', () => {
+    const err = new ApiError({ message: 'frozen', status: 403, code: 'ACCOUNT_FROZEN' })
+    expect(isAccountFrozenError(err)).toBe(true)
+  })
+
+  it('returns false for other ApiErrors', () => {
+    const err = new ApiError({ message: 'other', status: 500 })
+    expect(isAccountFrozenError(err)).toBe(false)
+  })
+
+  it('returns false for non-ApiError values', () => {
+    expect(isAccountFrozenError(new Error('test'))).toBe(false)
+    expect(isAccountFrozenError(null)).toBe(false)
+    expect(isAccountFrozenError(undefined)).toBe(false)
+  })
+})
+
+describe('apiFetch', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    Object.defineProperty(globalThis, 'navigator', { value: { onLine: true }, writable: true })
+  })
+
+  it('makes a successful request and returns JSON', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    )
+
+    const result = await apiFetch<{ ok: boolean }>('/api/test')
+    expect(result).toEqual({ ok: true })
+  })
+
+  it('attaches Authorization header when token exists', async () => {
+    localStorage.setItem('shelterflex_token', 'auth-token')
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({}), { status: 200 })
+    )
+
+    await apiFetch('/api/test')
+
+    const headers = fetchSpy.mock.calls[0][1]?.headers as Headers
+    expect(headers.get('Authorization')).toBe('Bearer auth-token')
+  })
+
+  it('does not attach Authorization header when no token', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({}), { status: 200 })
+    )
+
+    await apiFetch('/api/test')
+
+    const headers = fetchSpy.mock.calls[0][1]?.headers as Headers
+    expect(headers.get('Authorization')).toBeNull()
+  })
+
+  it('throws ApiError for non-ok responses', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ error: { code: 'NOT_FOUND', message: 'Not found' } }), {
+        status: 404,
+      })
+    )
+
+    await expect(apiFetch('/api/missing')).rejects.toThrow()
+  })
+
+  it('throws connection error for network failure', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new TypeError('Failed to fetch'))
+
+    await expect(apiFetch('/api/test')).rejects.toThrow('Cannot connect to backend')
+  })
+})
+
+describe('apiPost', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('sends a POST request with JSON body', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ created: true }), { status: 200 })
+    )
+
+    const result = await apiPost('/api/create', { name: 'test' })
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      expect.stringContaining('/api/create'),
+      expect.objectContaining({ method: 'POST' })
+    )
+    expect(result).toEqual({ created: true })
+  })
+})

--- a/frontend/lib/__tests__/apiClient.test.ts
+++ b/frontend/lib/__tests__/apiClient.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+vi.mock('@/lib/retryLogic', () => ({
+  retryWithBackoff: vi.fn().mockImplementation(async (fn: () => Promise<unknown>) => fn()),
+}))
+
+vi.mock('@/lib/api', () => ({
+  apiFetch: vi.fn(),
+  ApiError: class ApiError extends Error {
+    status: number
+    code?: string
+    constructor({ message, status, code }: { message: string; status: number; code?: string }) {
+      super(message)
+      this.status = status
+      this.code = code
+    }
+  },
+  isAccountFrozenError: vi.fn(),
+  ACCOUNT_FROZEN_MESSAGE: 'Account frozen',
+}))
+
+import { apiGet, apiPost, apiPut, apiPatch, apiDelete, withQuery } from '@/lib/apiClient'
+import { apiFetch } from '@/lib/api'
+import { retryWithBackoff } from '@/lib/retryLogic'
+
+const mockedApiFetch = vi.mocked(apiFetch)
+const mockedRetry = vi.mocked(retryWithBackoff)
+
+describe('apiClient helpers', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    mockedRetry.mockImplementation(async (fn: () => Promise<unknown>) => fn())
+  })
+
+  describe('apiGet', () => {
+    it('calls retryWithBackoff wrapping apiFetch with GET', async () => {
+      mockedApiFetch.mockResolvedValue({ id: 1 })
+
+      const result = await apiGet('/api/items/1')
+
+      expect(mockedRetry).toHaveBeenCalled()
+      expect(result).toEqual({ id: 1 })
+    })
+  })
+
+  describe('apiPost', () => {
+    it('wraps apiFetch with POST and body in retryWithBackoff', async () => {
+      mockedApiFetch.mockResolvedValue({ created: true })
+
+      await apiPost('/api/items', { name: 'test' })
+
+      expect(mockedRetry).toHaveBeenCalled()
+      expect(mockedApiFetch).toHaveBeenCalledWith('/api/items', {
+        method: 'POST',
+        body: JSON.stringify({ name: 'test' }),
+      })
+    })
+  })
+
+  describe('apiPut', () => {
+    it('wraps apiFetch with PUT and body', async () => {
+      mockedApiFetch.mockResolvedValue({ updated: true })
+
+      await apiPut('/api/items/1', { name: 'updated' })
+
+      expect(mockedApiFetch).toHaveBeenCalledWith('/api/items/1', {
+        method: 'PUT',
+        body: JSON.stringify({ name: 'updated' }),
+      })
+    })
+  })
+
+  describe('apiPatch', () => {
+    it('wraps apiFetch with PATCH and body', async () => {
+      mockedApiFetch.mockResolvedValue({ patched: true })
+
+      await apiPatch('/api/items/1', { name: 'patched' })
+
+      expect(mockedApiFetch).toHaveBeenCalledWith('/api/items/1', {
+        method: 'PATCH',
+        body: JSON.stringify({ name: 'patched' }),
+      })
+    })
+  })
+
+  describe('apiDelete', () => {
+    it('wraps apiFetch with DELETE', async () => {
+      mockedApiFetch.mockResolvedValue({ deleted: true })
+
+      await apiDelete('/api/items/1')
+
+      expect(mockedApiFetch).toHaveBeenCalledWith('/api/items/1', { method: 'DELETE' })
+    })
+  })
+
+  describe('withQuery', () => {
+    it('appends query parameters', () => {
+      const result = withQuery('/api/items', { status: 'active', limit: 10 })
+      expect(result).toBe('/api/items?status=active&limit=10')
+    })
+
+    it('omits null and undefined values', () => {
+      const result = withQuery('/api/items', { status: 'active', page: undefined, limit: null })
+      expect(result).toBe('/api/items?status=active')
+    })
+
+    it('returns path without query string when no params', () => {
+      const result = withQuery('/api/items', {})
+      expect(result).toBe('/api/items')
+    })
+
+    it('handles boolean values', () => {
+      const result = withQuery('/api/items', { active: true })
+      expect(result).toBe('/api/items?active=true')
+    })
+  })
+})

--- a/frontend/lib/__tests__/auth.test.ts
+++ b/frontend/lib/__tests__/auth.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { getToken, setToken, clearToken, isAuthenticated, logout, handleAuthRedirect } from '@/lib/auth'
+
+const TOKEN_KEY = 'shelterflex_token'
+
+describe('auth', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.restoreAllMocks()
+  })
+
+  describe('getToken', () => {
+    it('returns null when no token is stored', () => {
+      expect(getToken()).toBeNull()
+    })
+
+    it('returns the stored token', () => {
+      localStorage.setItem(TOKEN_KEY, 'test-token')
+      expect(getToken()).toBe('test-token')
+    })
+  })
+
+  describe('setToken', () => {
+    it('stores the token in localStorage', () => {
+      setToken('my-token')
+      expect(localStorage.getItem(TOKEN_KEY)).toBe('my-token')
+    })
+
+    it('overwrites an existing token', () => {
+      setToken('first')
+      setToken('second')
+      expect(localStorage.getItem(TOKEN_KEY)).toBe('second')
+    })
+  })
+
+  describe('clearToken', () => {
+    it('removes the token from localStorage', () => {
+      localStorage.setItem(TOKEN_KEY, 'to-clear')
+      clearToken()
+      expect(localStorage.getItem(TOKEN_KEY)).toBeNull()
+    })
+
+    it('does not throw when no token exists', () => {
+      expect(() => clearToken()).not.toThrow()
+    })
+  })
+
+  describe('isAuthenticated', () => {
+    it('returns false when no token exists', () => {
+      expect(isAuthenticated()).toBe(false)
+    })
+
+    it('returns true when a token exists', () => {
+      localStorage.setItem(TOKEN_KEY, 'valid-token')
+      expect(isAuthenticated()).toBe(true)
+    })
+
+    it('returns false after token is cleared', () => {
+      localStorage.setItem(TOKEN_KEY, 'valid-token')
+      clearToken()
+      expect(isAuthenticated()).toBe(false)
+    })
+  })
+
+  describe('logout', () => {
+    it('clears the token', () => {
+      localStorage.setItem(TOKEN_KEY, 'session-token')
+      logout()
+      expect(localStorage.getItem(TOKEN_KEY)).toBeNull()
+    })
+
+    it('redirects to homepage', () => {
+      let capturedHref = ''
+      const locationObj = {
+        get href() { return capturedHref },
+        set href(v: string) { capturedHref = v },
+        pathname: '/',
+      }
+      Object.defineProperty(window, 'location', { value: locationObj, writable: true, configurable: true })
+
+      logout()
+      expect(capturedHref).toBe('/')
+    })
+  })
+
+  describe('handleAuthRedirect', () => {
+    it('redirects to the provided returnTo URL', () => {
+      let capturedHref = ''
+      const locationObj = {
+        get href() { return capturedHref },
+        set href(v: string) { capturedHref = v },
+        pathname: '/',
+      }
+      Object.defineProperty(window, 'location', { value: locationObj, writable: true, configurable: true })
+
+      handleAuthRedirect(encodeURIComponent('/dashboard'))
+      expect(capturedHref).toBe('/dashboard')
+    })
+
+    it('redirects to / when no returnTo is provided and current path differs', () => {
+      let capturedHref = ''
+      const locationObj = {
+        get href() { return capturedHref },
+        set href(v: string) { capturedHref = v },
+        pathname: '/login',
+      }
+      Object.defineProperty(window, 'location', { value: locationObj, writable: true, configurable: true })
+
+      handleAuthRedirect()
+      expect(capturedHref).toBe('/')
+    })
+
+    it('does not redirect when target matches current path', () => {
+      let capturedHref = ''
+      const locationObj = {
+        get href() { return capturedHref },
+        set href(v: string) { capturedHref = v },
+        pathname: '/dashboard',
+      }
+      Object.defineProperty(window, 'location', { value: locationObj, writable: true, configurable: true })
+
+      handleAuthRedirect(encodeURIComponent('/dashboard'))
+      expect(capturedHref).toBe('')
+    })
+  })
+})

--- a/frontend/lib/__tests__/authApi.test.ts
+++ b/frontend/lib/__tests__/authApi.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { requestOtp, verifyOtp, requestWalletChallenge, verifyWalletSignature } from '@/lib/authApi'
+
+vi.mock('@/lib/api', () => ({
+  apiPost: vi.fn(),
+}))
+
+import { apiPost } from '@/lib/api'
+import * as auth from '@/lib/auth'
+
+const mockedApiPost = vi.mocked(apiPost)
+
+describe('authApi', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    localStorage.clear()
+  })
+
+  describe('requestOtp', () => {
+    it('calls apiPost with the correct endpoint and email', async () => {
+      mockedApiPost.mockResolvedValue({ message: 'OTP sent' })
+
+      const result = await requestOtp('user@example.com')
+
+      expect(mockedApiPost).toHaveBeenCalledWith('/api/auth/request-otp', { email: 'user@example.com' })
+      expect(result).toEqual({ message: 'OTP sent' })
+    })
+
+    it('propagates API errors', async () => {
+      mockedApiPost.mockRejectedValue(new Error('Network error'))
+
+      await expect(requestOtp('user@example.com')).rejects.toThrow('Network error')
+    })
+  })
+
+  describe('verifyOtp', () => {
+    it('calls apiPost and stores the returned token', async () => {
+      const response = {
+        token: 'auth-token-123',
+        user: { id: '1', email: 'user@example.com', name: 'Test', role: 'tenant' as const },
+      }
+      mockedApiPost.mockResolvedValue(response)
+
+      const result = await verifyOtp('user@example.com', '123456')
+
+      expect(mockedApiPost).toHaveBeenCalledWith('/api/auth/verify-otp', {
+        email: 'user@example.com',
+        otp: '123456',
+      })
+      expect(result).toEqual(response)
+      expect(localStorage.getItem('shelterflex_token')).toBe('auth-token-123')
+    })
+
+    it('propagates API errors without storing token', async () => {
+      mockedApiPost.mockRejectedValue(new Error('Invalid OTP'))
+
+      await expect(verifyOtp('user@example.com', '000000')).rejects.toThrow('Invalid OTP')
+      expect(localStorage.getItem('shelterflex_token')).toBeNull()
+    })
+  })
+
+  describe('requestWalletChallenge', () => {
+    it('calls apiPost with the correct endpoint and address', async () => {
+      const response = { challengeXdr: 'xdr-data', expiresAt: '2026-01-01T00:00:00Z' }
+      mockedApiPost.mockResolvedValue(response)
+
+      const result = await requestWalletChallenge('GABC123')
+
+      expect(mockedApiPost).toHaveBeenCalledWith('/api/auth/wallet/challenge', { address: 'GABC123' })
+      expect(result).toEqual(response)
+    })
+  })
+
+  describe('verifyWalletSignature', () => {
+    it('calls apiPost and stores the returned token', async () => {
+      const response = {
+        token: 'wallet-token-456',
+        user: { id: '2', email: 'wallet@example.com', name: 'Wallet User', role: 'landlord' as const },
+      }
+      mockedApiPost.mockResolvedValue(response)
+
+      const result = await verifyWalletSignature('GABC123', 'signed-xdr')
+
+      expect(mockedApiPost).toHaveBeenCalledWith('/api/auth/wallet/verify', {
+        address: 'GABC123',
+        signedChallengeXdr: 'signed-xdr',
+      })
+      expect(result).toEqual(response)
+      expect(localStorage.getItem('shelterflex_token')).toBe('wallet-token-456')
+    })
+
+    it('propagates API errors without storing token', async () => {
+      mockedApiPost.mockRejectedValue(new Error('Invalid signature'))
+
+      await expect(verifyWalletSignature('GABC123', 'bad-xdr')).rejects.toThrow('Invalid signature')
+      expect(localStorage.getItem('shelterflex_token')).toBeNull()
+    })
+  })
+})

--- a/frontend/lib/__tests__/consent-manager.test.ts
+++ b/frontend/lib/__tests__/consent-manager.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+
+vi.mock('@/lib/analytics', () => ({
+  analytics: {
+    setConsent: vi.fn(),
+    initialize: vi.fn(),
+    track: vi.fn(),
+    getEvents: vi.fn().mockReturnValue([]),
+    reset: vi.fn(),
+  },
+}))
+
+vi.mock('@/lib/performance-tracking', () => ({
+  performanceTracking: {
+    startTracking: vi.fn(),
+    stopTracking: vi.fn(),
+    getMetrics: vi.fn().mockReturnValue({}),
+    reset: vi.fn(),
+  },
+}))
+
+describe('consentManager', () => {
+  let consentManager: any
+
+  beforeEach(async () => {
+    localStorage.clear()
+    vi.useFakeTimers()
+
+    // Reset singleton by clearing module cache
+    vi.resetModules()
+    const mod = await import('@/lib/consent-manager')
+    consentManager = mod.consentManager
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  describe('consentAll', () => {
+    it('sets all preferences to true', () => {
+      consentManager.consentAll()
+      const prefs = consentManager.getPreferences()
+      expect(prefs.analytics).toBe(true)
+      expect(prefs.performance).toBe(true)
+      expect(prefs.functional).toBe(true)
+      expect(prefs.marketing).toBe(true)
+      expect(prefs.acceptedAll).toBe(true)
+      expect(prefs.rejectedAll).toBe(false)
+    })
+
+    it('persists preferences to localStorage', () => {
+      consentManager.consentAll()
+      const stored = localStorage.getItem('consent_preferences')
+      expect(stored).not.toBeNull()
+      const parsed = JSON.parse(stored!)
+      expect(parsed.analytics).toBe(true)
+    })
+  })
+
+  describe('rejectAll', () => {
+    it('sets all preferences to false', () => {
+      consentManager.rejectAll()
+      const prefs = consentManager.getPreferences()
+      expect(prefs.analytics).toBe(false)
+      expect(prefs.performance).toBe(false)
+      expect(prefs.functional).toBe(false)
+      expect(prefs.marketing).toBe(false)
+      expect(prefs.rejectedAll).toBe(true)
+      expect(prefs.acceptedAll).toBe(false)
+    })
+  })
+
+  describe('updatePreferences', () => {
+    it('partially updates preferences', () => {
+      consentManager.updatePreferences({ analytics: true })
+      expect(consentManager.getPreferences().analytics).toBe(true)
+      expect(consentManager.getPreferences().marketing).toBe(false)
+    })
+  })
+
+  describe('hasConsent', () => {
+    it('returns false by default', () => {
+      expect(consentManager.hasConsent('analytics')).toBe(false)
+    })
+
+    it('returns true after consent is given', () => {
+      consentManager.consentAll()
+      expect(consentManager.hasConsent('analytics')).toBe(true)
+    })
+  })
+
+  describe('hasGivenConsent', () => {
+    it('returns false when no consent exists', () => {
+      expect(consentManager.hasGivenConsent()).toBe(false)
+    })
+
+    it('returns true after consent is given', () => {
+      consentManager.consentAll()
+      expect(consentManager.hasGivenConsent()).toBe(true)
+    })
+  })
+
+  describe('shouldShowBanner', () => {
+    it('returns true when no consent has been given', () => {
+      expect(consentManager.shouldShowBanner()).toBe(true)
+    })
+
+    it('returns false after consent is given', () => {
+      consentManager.consentAll()
+      expect(consentManager.shouldShowBanner()).toBe(false)
+    })
+  })
+
+  describe('getCategories', () => {
+    it('returns all consent categories', () => {
+      const categories = consentManager.getCategories()
+      expect(categories.length).toBe(5)
+      expect(categories.map((c: any) => c.id)).toContain('necessary')
+      expect(categories.map((c: any) => c.id)).toContain('analytics')
+    })
+
+    it('marks necessary cookies as required', () => {
+      const necessary = consentManager.getCategory('necessary')
+      expect(necessary?.required).toBe(true)
+    })
+  })
+
+  describe('getCookieInfo', () => {
+    it('returns only necessary cookies when no consent given', () => {
+      const info = consentManager.getCookieInfo()
+      expect(info.activeCookies).toContain('session')
+      expect(info.activeCookies).not.toContain('analytics_session')
+    })
+
+    it('includes analytics cookies after consent', () => {
+      consentManager.consentAll()
+      const info = consentManager.getCookieInfo()
+      expect(info.activeCookies).toContain('analytics_session')
+    })
+  })
+
+  describe('onConsentChange', () => {
+    it('calls the callback when consent changes', () => {
+      const callback = vi.fn()
+      consentManager.onConsentChange(callback)
+      consentManager.consentAll()
+      expect(callback).toHaveBeenCalled()
+    })
+
+    it('unsubscribes when the returned function is called', () => {
+      const callback = vi.fn()
+      const unsubscribe = consentManager.onConsentChange(callback)
+      unsubscribe()
+      consentManager.consentAll()
+      expect(callback).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('deleteUserData', () => {
+    it('resets all preferences', () => {
+      consentManager.consentAll()
+      consentManager.deleteUserData()
+      const prefs = consentManager.getPreferences()
+      expect(prefs.analytics).toBe(false)
+      expect(prefs.timestamp).toBe(0)
+    })
+  })
+
+  describe('banner config', () => {
+    it('returns default banner config', () => {
+      const config = consentManager.getBannerConfig()
+      expect(config.title).toBe('Privacy & Cookie Consent')
+      expect(config.position).toBe('bottom')
+    })
+
+    it('allows updating banner config', () => {
+      consentManager.updateBannerConfig({ position: 'top' })
+      expect(consentManager.getBannerConfig().position).toBe('top')
+    })
+  })
+
+  describe('privacy rights', () => {
+    it('returns an array of rights', () => {
+      const rights = consentManager.getPrivacyRights()
+      expect(rights.rights.length).toBeGreaterThan(0)
+      expect(rights.contactInfo).toBe('privacy@shelterflex.com')
+    })
+  })
+
+  describe('loading from localStorage', () => {
+    it('loads existing preferences on initialization', async () => {
+      const prefs = {
+        analytics: true,
+        performance: false,
+        functional: true,
+        marketing: false,
+        version: '1.0',
+        timestamp: Date.now(),
+      }
+      localStorage.setItem('consent_preferences', JSON.stringify(prefs))
+
+      vi.resetModules()
+      const mod = await import('@/lib/consent-manager')
+      const manager = mod.consentManager
+      expect(manager.getPreferences().analytics).toBe(true)
+      expect(manager.getPreferences().functional).toBe(true)
+    })
+  })
+})

--- a/frontend/lib/__tests__/csrf-protection.test.ts
+++ b/frontend/lib/__tests__/csrf-protection.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { csrfProtection, addCSRFToFormData, validateCSRFToken } from '@/lib/csrf-protection'
+
+describe('csrfProtection', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.restoreAllMocks()
+  })
+
+  describe('generateNewToken', () => {
+    it('generates a non-empty token', () => {
+      const token = csrfProtection.generateNewToken()
+      expect(token).toBeTruthy()
+      expect(typeof token).toBe('string')
+    })
+
+    it('generates unique tokens on successive calls', () => {
+      const t1 = csrfProtection.generateNewToken()
+      const t2 = csrfProtection.generateNewToken()
+      expect(t1).not.toBe(t2)
+    })
+  })
+
+  describe('getCurrentToken', () => {
+    it('returns null when no token exists', () => {
+      expect(csrfProtection.getCurrentToken()).toBeNull()
+    })
+
+    it('returns the current token after generation', () => {
+      const token = csrfProtection.generateNewToken()
+      expect(csrfProtection.getCurrentToken()).toBe(token)
+    })
+  })
+
+  describe('isTokenValid', () => {
+    it('returns true for a valid token', () => {
+      const token = csrfProtection.generateNewToken()
+      expect(csrfProtection.isTokenValid(token)).toBe(true)
+    })
+
+    it('returns false for an invalid token', () => {
+      csrfProtection.generateNewToken()
+      expect(csrfProtection.isTokenValid('invalid-token')).toBe(false)
+    })
+
+    it('returns false when no token is stored', () => {
+      expect(csrfProtection.isTokenValid('any-token')).toBe(false)
+    })
+
+    it('returns false when called without arguments and no token exists', () => {
+      expect(csrfProtection.isTokenValid()).toBe(false)
+    })
+  })
+
+  describe('refreshToken', () => {
+    it('returns a new token different from the previous', () => {
+      const old = csrfProtection.generateNewToken()
+      const refreshed = csrfProtection.refreshToken()
+      expect(refreshed).not.toBe(old)
+    })
+  })
+
+  describe('addTokenToHeaders', () => {
+    it('adds the CSRF token header', () => {
+      const token = csrfProtection.generateNewToken()
+      const headers = csrfProtection.addTokenToHeaders({})
+      expect(headers['X-CSRF-Token']).toBe(token)
+    })
+
+    it('does not overwrite existing headers', () => {
+      csrfProtection.generateNewToken()
+      const headers = csrfProtection.addTokenToHeaders({ 'Content-Type': 'application/json' })
+      expect(headers['Content-Type']).toBe('application/json')
+      expect(headers['X-CSRF-Token']).toBeTruthy()
+    })
+  })
+
+  describe('validateResponseToken', () => {
+    it('returns true when the response token matches', () => {
+      const token = csrfProtection.generateNewToken()
+      expect(csrfProtection.validateResponseToken({ 'x-csrf-token': token })).toBe(true)
+    })
+
+    it('returns false when the response token does not match', () => {
+      csrfProtection.generateNewToken()
+      expect(csrfProtection.validateResponseToken({ 'x-csrf-token': 'wrong' })).toBe(false)
+    })
+
+    it('returns false when no response token is present', () => {
+      csrfProtection.generateNewToken()
+      expect(csrfProtection.validateResponseToken({})).toBe(false)
+    })
+  })
+
+  describe('initialize', () => {
+    it('generates a new token if none exists', () => {
+      const token = csrfProtection.initialize()
+      expect(token).toBeTruthy()
+    })
+
+    it('returns existing token if one is already stored', () => {
+      const first = csrfProtection.initialize()
+      const second = csrfProtection.initialize()
+      expect(first).toBe(second)
+    })
+  })
+
+  describe('clear', () => {
+    it('removes the token', () => {
+      csrfProtection.generateNewToken()
+      csrfProtection.clear()
+      expect(csrfProtection.getCurrentToken()).toBeNull()
+    })
+  })
+
+  describe('token expiration', () => {
+    it('returns null for an expired token', () => {
+      vi.useFakeTimers()
+      csrfProtection.generateNewToken()
+
+      vi.advanceTimersByTime(61 * 60 * 1000)
+
+      expect(csrfProtection.getCurrentToken()).toBeNull()
+      vi.useRealTimers()
+    })
+  })
+
+  describe('fetchWithCSRF', () => {
+    it('attaches the CSRF token to the request', async () => {
+      const token = csrfProtection.generateNewToken()
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(JSON.stringify({ ok: true }), { status: 200 })
+      )
+
+      await csrfProtection.fetchWithCSRF('https://api.example.com/test')
+
+      const calledHeaders = fetchSpy.mock.calls[0][1]?.headers as Headers
+      expect(calledHeaders.get('X-CSRF-Token')).toBe(token)
+    })
+  })
+})
+
+describe('addCSRFToFormData', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('adds the CSRF token to FormData', () => {
+    const token = csrfProtection.generateNewToken()
+    const fd = new FormData()
+    addCSRFToFormData(fd)
+    expect(fd.get('csrf_token')).toBe(token)
+  })
+
+  it('does not set token when none exists', () => {
+    const fd = new FormData()
+    addCSRFToFormData(fd)
+    expect(fd.get('csrf_token')).toBeNull()
+  })
+})
+
+describe('validateCSRFToken', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('validates a request with a correct CSRF token', () => {
+    const token = csrfProtection.generateNewToken()
+    const request = new Request('https://api.example.com', {
+      headers: { 'X-CSRF-Token': token },
+    })
+    expect(validateCSRFToken(request)).toBe(true)
+  })
+
+  it('rejects a request with an incorrect CSRF token', () => {
+    csrfProtection.generateNewToken()
+    const request = new Request('https://api.example.com', {
+      headers: { 'X-CSRF-Token': 'wrong-token' },
+    })
+    expect(validateCSRFToken(request)).toBe(false)
+  })
+
+  it('validates request when no header but stored token exists (falls back to stored token)', () => {
+    csrfProtection.generateNewToken()
+    const request = new Request('https://api.example.com')
+    expect(validateCSRFToken(request)).toBe(true)
+  })
+})

--- a/frontend/lib/__tests__/errors.test.ts
+++ b/frontend/lib/__tests__/errors.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { parseBackendError, isNetworkError, getUserFriendlyError } from '@/lib/errors'
+
+describe('parseBackendError', () => {
+  it('parses BackendErrorResponse format', () => {
+    const error = {
+      error: { code: 'UNAUTHORIZED', message: 'auth required' },
+    }
+    const result = parseBackendError(error)
+    expect(result.code).toBe('UNAUTHORIZED')
+    expect(result.userMessage).toBe('Please sign in to continue')
+  })
+
+  it('uses backend message for unknown codes', () => {
+    const error = {
+      error: { code: 'CUSTOM_ERROR', message: 'Something custom' },
+    }
+    const result = parseBackendError(error)
+    expect(result.code).toBe('CUSTOM_ERROR')
+    expect(result.userMessage).toBe('Something custom')
+  })
+
+  it('handles ACCOUNT_FROZEN code', () => {
+    const error = {
+      error: { code: 'ACCOUNT_FROZEN', message: 'frozen' },
+    }
+    const result = parseBackendError(error)
+    expect(result.code).toBe('ACCOUNT_FROZEN')
+    expect(result.message).toBe('frozen')
+  })
+
+  it('parses Error objects', () => {
+    const error = new Error('network issue')
+    const result = parseBackendError(error)
+    expect(result.code).toBe('UNKNOWN_ERROR')
+    expect(result.userMessage).toBe('network issue')
+  })
+
+  it('parses string errors', () => {
+    const result = parseBackendError('simple error')
+    expect(result.code).toBe('UNKNOWN_ERROR')
+    expect(result.userMessage).toBe('simple error')
+  })
+
+  it('returns default message for unknown types', () => {
+    const result = parseBackendError(42)
+    expect(result.code).toBe('UNKNOWN_ERROR')
+    expect(result.userMessage).toBe('Something went wrong. Please try again')
+  })
+
+  it('uses custom defaultMessage', () => {
+    const result = parseBackendError(null, 'Custom default')
+    expect(result.userMessage).toBe('Custom default')
+  })
+
+  it('includes details when present', () => {
+    const error = {
+      error: { code: 'VALIDATION_ERROR', message: 'bad input', details: { field: 'email' } },
+    }
+    const result = parseBackendError(error)
+    expect(result.details).toEqual({ field: 'email' })
+  })
+})
+
+describe('isNetworkError', () => {
+  it('returns true for Failed to fetch errors', () => {
+    expect(isNetworkError(new Error('Failed to fetch'))).toBe(true)
+  })
+
+  it('returns true for NetworkError', () => {
+    expect(isNetworkError(new Error('NetworkError occurred'))).toBe(true)
+  })
+
+  it('returns true for connection errors', () => {
+    expect(isNetworkError(new Error('Cannot connect to backend'))).toBe(true)
+  })
+
+  it('returns false for other errors', () => {
+    expect(isNetworkError(new Error('Something else'))).toBe(false)
+  })
+
+  it('returns false for non-Error values', () => {
+    expect(isNetworkError(null)).toBe(false)
+    expect(isNetworkError('string')).toBe(false)
+  })
+})
+
+describe('getUserFriendlyError', () => {
+  it('returns mapped message for known error codes', () => {
+    const error = {
+      error: { code: 'FORBIDDEN', message: 'no access' },
+    }
+    expect(getUserFriendlyError(error)).toBe('You do not have permission to perform this action')
+  })
+
+  it('appends "Try again." for unknown error codes', () => {
+    const error = {
+      error: { code: 'UNKNOWN_CODE', message: 'something happened' },
+    }
+    expect(getUserFriendlyError(error)).toBe('something happened Try again.')
+  })
+
+  it('appends "Try again." for generic Error objects', () => {
+    expect(getUserFriendlyError(new Error('timeout'))).toBe('timeout Try again.')
+  })
+
+  it('uses custom defaultMessage', () => {
+    expect(getUserFriendlyError(null, 'Custom msg')).toBe('Custom msg Try again.')
+  })
+})

--- a/frontend/lib/__tests__/ngnStakingApi.test.ts
+++ b/frontend/lib/__tests__/ngnStakingApi.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { getQuote, initiateDeposit, getTransactionStatus, NgnStakingApiError } from '@/lib/ngnStakingApi'
+
+vi.mock('@/lib/api', () => ({
+  apiFetch: vi.fn(),
+}))
+
+import { apiFetch } from '@/lib/api'
+
+const mockedApiFetch = vi.mocked(apiFetch)
+
+describe('ngnStakingApi', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('NgnStakingApiError', () => {
+    it('is an instance of Error', () => {
+      const err = new NgnStakingApiError('test error')
+      expect(err).toBeInstanceOf(Error)
+      expect(err.name).toBe('NgnStakingApiError')
+    })
+
+    it('stores statusCode and originalError', () => {
+      const original = new Error('orig')
+      const err = new NgnStakingApiError('msg', 500, original)
+      expect(err.statusCode).toBe(500)
+      expect(err.originalError).toBe(original)
+    })
+  })
+
+  describe('getQuote', () => {
+    it('returns quote on success', async () => {
+      const quote = {
+        id: 'q_1',
+        ngnAmount: 100000,
+        usdcAmount: 60,
+        fxRate: 1666.67,
+        fees: { conversionFee: 100, platformFee: 200, total: 300 },
+        expiresAt: '2026-01-01T00:05:00Z',
+        createdAt: '2026-01-01T00:00:00Z',
+      }
+      mockedApiFetch.mockResolvedValue({ success: true, quote })
+
+      const result = await getQuote(100000)
+
+      expect(mockedApiFetch).toHaveBeenCalledWith('/api/staking/ngn/quote', {
+        method: 'POST',
+        body: JSON.stringify({ ngnAmount: 100000 }),
+      })
+      expect(result).toEqual(quote)
+    })
+
+    it('throws NgnStakingApiError when success is false', async () => {
+      mockedApiFetch.mockResolvedValue({ success: false, quote: null })
+
+      await expect(getQuote(100000)).rejects.toThrow(NgnStakingApiError)
+    })
+
+    it('wraps non-NgnStakingApiError errors', async () => {
+      mockedApiFetch.mockRejectedValue(new Error('Network error'))
+
+      await expect(getQuote(100000)).rejects.toThrow(NgnStakingApiError)
+    })
+  })
+
+  describe('initiateDeposit', () => {
+    it('returns deposit initiation response on success', async () => {
+      const response = {
+        success: true,
+        transactionId: 'txn_1',
+        paymentInstructions: { paystackUrl: 'https://paystack.com/xyz' },
+      }
+      mockedApiFetch.mockResolvedValue(response)
+
+      const result = await initiateDeposit('q_1', 'paystack')
+
+      expect(result).toEqual(response)
+    })
+
+    it('defaults to paystack payment method', async () => {
+      mockedApiFetch.mockResolvedValue({
+        success: true,
+        transactionId: 'txn_1',
+        paymentInstructions: {},
+      })
+
+      await initiateDeposit('q_1')
+
+      const calledBody = JSON.parse(mockedApiFetch.mock.calls[0][1]?.body as string)
+      expect(calledBody.paymentMethod).toBe('paystack')
+    })
+
+    it('throws on invalid response', async () => {
+      mockedApiFetch.mockResolvedValue({ success: false })
+
+      await expect(initiateDeposit('q_1')).rejects.toThrow(NgnStakingApiError)
+    })
+  })
+
+  describe('getTransactionStatus', () => {
+    it('returns transaction status on success', async () => {
+      const status = {
+        transactionId: 'txn_1',
+        status: 'confirmed' as const,
+        ngnAmount: 100000,
+        usdcAmount: 60,
+        updatedAt: '2026-01-01T00:10:00Z',
+      }
+      mockedApiFetch.mockResolvedValue({ success: true, status })
+
+      const result = await getTransactionStatus('txn_1')
+
+      expect(mockedApiFetch).toHaveBeenCalledWith('/api/staking/ngn/status/txn_1')
+      expect(result).toEqual(status)
+    })
+
+    it('throws on invalid response', async () => {
+      mockedApiFetch.mockResolvedValue({ success: false, status: null })
+
+      await expect(getTransactionStatus('txn_1')).rejects.toThrow(NgnStakingApiError)
+    })
+
+    it('wraps network errors', async () => {
+      mockedApiFetch.mockRejectedValue(new TypeError('Failed to fetch'))
+
+      await expect(getTransactionStatus('txn_1')).rejects.toThrow(NgnStakingApiError)
+    })
+  })
+})

--- a/frontend/lib/__tests__/paymentApi.test.ts
+++ b/frontend/lib/__tests__/paymentApi.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { getFullPaymentPreview, confirmFullPayment } from '@/lib/paymentApi'
+
+vi.mock('@/lib/api', () => ({
+  apiFetch: vi.fn(),
+}))
+
+import { apiFetch } from '@/lib/api'
+
+const mockedApiFetch = vi.mocked(apiFetch)
+
+describe('paymentApi', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('getFullPaymentPreview', () => {
+    it('calls apiFetch with the correct endpoint', async () => {
+      const response = {
+        paymentId: 'pay_123',
+        breakdown: {
+          totalAmount: 100000,
+          platformShare: 5000,
+          reporterShare: 2000,
+          landlordAmount: 93000,
+          currency: 'NGN',
+        },
+        expiresAt: '2026-01-01T00:00:00Z',
+      }
+      mockedApiFetch.mockResolvedValue(response)
+
+      const result = await getFullPaymentPreview('pay_123')
+
+      expect(mockedApiFetch).toHaveBeenCalledWith('/api/payments/pay_123/full-payment/preview')
+      expect(result).toEqual(response)
+    })
+
+    it('propagates API errors', async () => {
+      mockedApiFetch.mockRejectedValue(new Error('Not found'))
+
+      await expect(getFullPaymentPreview('missing')).rejects.toThrow('Not found')
+    })
+  })
+
+  describe('confirmFullPayment', () => {
+    it('calls apiFetch with POST method', async () => {
+      const response = {
+        paymentId: 'pay_123',
+        reference: 'ref_abc',
+        breakdown: {
+          totalAmount: 100000,
+          platformShare: 5000,
+          reporterShare: null,
+          landlordAmount: 95000,
+          currency: 'NGN',
+        },
+        paidAt: '2026-01-01T00:00:00Z',
+        status: 'confirmed' as const,
+      }
+      mockedApiFetch.mockResolvedValue(response)
+
+      const result = await confirmFullPayment('pay_123')
+
+      expect(mockedApiFetch).toHaveBeenCalledWith('/api/payments/pay_123/full-payment/confirm', {
+        method: 'POST',
+      })
+      expect(result).toEqual(response)
+    })
+
+    it('propagates API errors', async () => {
+      mockedApiFetch.mockRejectedValue(new Error('Payment failed'))
+
+      await expect(confirmFullPayment('pay_fail')).rejects.toThrow('Payment failed')
+    })
+  })
+})

--- a/frontend/lib/__tests__/paymentOffline.test.ts
+++ b/frontend/lib/__tests__/paymentOffline.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { paymentActionFingerprint, newIdempotencyKey, flushPaymentQueue } from '@/lib/paymentOffline'
+
+vi.mock('@/lib/offline-queue', () => ({
+  enqueueOfflineRequest: vi.fn(),
+  flushOfflineQueue: vi.fn().mockResolvedValue(0),
+}))
+
+import { flushOfflineQueue } from '@/lib/offline-queue'
+
+const mockedFlush = vi.mocked(flushOfflineQueue)
+
+describe('paymentOffline', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('paymentActionFingerprint', () => {
+    it('generates a fingerprint from operation and body', () => {
+      const fp = paymentActionFingerprint('tenant-quick-pay', { amount: 1000 })
+      expect(fp).toBe('tenant-quick-pay:{"amount":1000}')
+    })
+
+    it('produces consistent fingerprints for same input', () => {
+      const fp1 = paymentActionFingerprint('tenant-topup', { amount: 500 })
+      const fp2 = paymentActionFingerprint('tenant-topup', { amount: 500 })
+      expect(fp1).toBe(fp2)
+    })
+
+    it('produces different fingerprints for different inputs', () => {
+      const fp1 = paymentActionFingerprint('tenant-quick-pay', { amount: 100 })
+      const fp2 = paymentActionFingerprint('tenant-quick-pay', { amount: 200 })
+      expect(fp1).not.toBe(fp2)
+    })
+
+    it('handles ngn-topup operation', () => {
+      const fp = paymentActionFingerprint('ngn-topup', { amount: 5000 })
+      expect(fp).toContain('ngn-topup')
+    })
+  })
+
+  describe('newIdempotencyKey', () => {
+    it('generates a unique key', () => {
+      const key1 = newIdempotencyKey()
+      const key2 = newIdempotencyKey()
+      expect(key1).not.toBe(key2)
+    })
+
+    it('generates a UUID when crypto.randomUUID is available', () => {
+      const key = newIdempotencyKey()
+      expect(typeof key).toBe('string')
+      expect(key.length).toBeGreaterThan(0)
+    })
+  })
+
+  describe('flushPaymentQueue', () => {
+    it('calls flushOfflineQueue with the base URL', async () => {
+      mockedFlush.mockResolvedValue(2)
+
+      const count = await flushPaymentQueue()
+
+      expect(mockedFlush).toHaveBeenCalledWith(expect.any(String))
+      expect(count).toBe(2)
+    })
+  })
+})

--- a/frontend/lib/__tests__/retryLogic.test.ts
+++ b/frontend/lib/__tests__/retryLogic.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { retryWithBackoff, withRetry } from '@/lib/retryLogic'
+
+describe('retryWithBackoff', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns result on first success', async () => {
+    const fn = vi.fn().mockResolvedValue('ok')
+    const result = await retryWithBackoff(fn)
+    expect(result).toBe('ok')
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries on retryable status code errors', async () => {
+    const fn = vi.fn()
+      .mockRejectedValueOnce({ status: 500 })
+      .mockResolvedValue('ok')
+
+    const result = await retryWithBackoff(fn, { maxRetries: 2, initialDelayMs: 1 })
+    expect(result).toBe('ok')
+    expect(fn).toHaveBeenCalledTimes(2)
+  }, 15000)
+
+  it('retries on network errors (TypeError with fetch)', async () => {
+    const fn = vi.fn()
+      .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+      .mockResolvedValue('ok')
+
+    const result = await retryWithBackoff(fn, { maxRetries: 2, initialDelayMs: 1 })
+    expect(result).toBe('ok')
+    expect(fn).toHaveBeenCalledTimes(2)
+  }, 15000)
+
+  it('does not retry on non-retryable errors', async () => {
+    const fn = vi.fn().mockRejectedValue({ status: 400 })
+
+    await expect(retryWithBackoff(fn, { maxRetries: 3, initialDelayMs: 1 })).rejects.toThrow()
+    expect(fn).toHaveBeenCalledTimes(1)
+  }, 10000)
+
+  it('does not retry on 401', async () => {
+    const fn = vi.fn().mockRejectedValue({ status: 401 })
+
+    await expect(retryWithBackoff(fn, { maxRetries: 3, initialDelayMs: 1 })).rejects.toThrow()
+    expect(fn).toHaveBeenCalledTimes(1)
+  }, 10000)
+
+  it('throws after exhausting all retries', async () => {
+    const fn = vi.fn().mockRejectedValue({ status: 503 })
+
+    await expect(retryWithBackoff(fn, { maxRetries: 2, initialDelayMs: 1 })).rejects.toThrow()
+    expect(fn).toHaveBeenCalledTimes(3)
+  }, 15000)
+
+  it('calls onRetry callback', async () => {
+    const fn = vi.fn()
+      .mockRejectedValueOnce({ status: 500 })
+      .mockResolvedValue('ok')
+    const onRetry = vi.fn()
+
+    const result = await retryWithBackoff(fn, { maxRetries: 2, initialDelayMs: 1, onRetry })
+
+    expect(onRetry).toHaveBeenCalledWith(1, expect.any(Error))
+    expect(result).toBe('ok')
+  }, 15000)
+
+  it('uses default options when none provided', async () => {
+    const fn = vi.fn().mockRejectedValue({ status: 500 })
+
+    await expect(retryWithBackoff(fn)).rejects.toThrow()
+    expect(fn).toHaveBeenCalledTimes(4)
+  }, 30000)
+
+  it('does not sleep on success', async () => {
+    const fn = vi.fn().mockResolvedValue('ok')
+    const sleepSpy = vi.spyOn(globalThis, 'setTimeout')
+
+    await retryWithBackoff(fn)
+
+    expect(sleepSpy).not.toHaveBeenCalled()
+  })
+})
+
+describe('withRetry', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns a function that retries on failure', async () => {
+    const fn = vi.fn()
+      .mockRejectedValueOnce({ status: 500 })
+      .mockResolvedValue('result')
+
+    const retried = withRetry(fn, { maxRetries: 2, initialDelayMs: 1 })
+    const result = await retried('arg1')
+
+    expect(result).toBe('result')
+    expect(fn).toHaveBeenCalledWith('arg1')
+    expect(fn).toHaveBeenCalledTimes(2)
+  }, 15000)
+
+  it('passes arguments through to the original function', async () => {
+    const fn = vi.fn().mockResolvedValue('ok')
+    const retried = withRetry(fn)
+
+    await retried('a', 'b', 'c')
+
+    expect(fn).toHaveBeenCalledWith('a', 'b', 'c')
+  })
+})

--- a/frontend/lib/__tests__/secure-storage.test.ts
+++ b/frontend/lib/__tests__/secure-storage.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import { secureStorage } from '@/lib/secure-storage'
+
+describe('secureStorage', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    sessionStorage.clear()
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  describe('setItem / getItem', () => {
+    it('stores and retrieves a value', async () => {
+      await secureStorage.setItem('test-key', 'test-value')
+      const result = await secureStorage.getItem('test-key')
+      expect(result).toBe('test-value')
+    })
+
+    it('returns null for a nonexistent key', async () => {
+      const result = await secureStorage.getItem('nonexistent')
+      expect(result).toBeNull()
+    })
+
+    it('stores values under a secure_ prefix', async () => {
+      await secureStorage.setItem('prefixed', 'val')
+      const keys = Object.keys(localStorage)
+      expect(keys.some(k => k.startsWith('secure_'))).toBe(true)
+    })
+
+    it('overwrites an existing value', async () => {
+      await secureStorage.setItem('key', 'first')
+      await secureStorage.setItem('key', 'second')
+      const result = await secureStorage.getItem('key')
+      expect(result).toBe('second')
+    })
+  })
+
+  describe('removeItem', () => {
+    it('removes the item', async () => {
+      await secureStorage.setItem('to-remove', 'value')
+      secureStorage.removeItem('to-remove')
+      const result = await secureStorage.getItem('to-remove')
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('clear', () => {
+    it('removes only secure_ prefixed items', async () => {
+      await secureStorage.setItem('s1', 'v1')
+      await secureStorage.setItem('s2', 'v2')
+      localStorage.setItem('other_key', 'other_value')
+
+      secureStorage.clear()
+
+      expect(localStorage.getItem('other_key')).toBe('other_value')
+      expect(await secureStorage.getItem('s1')).toBeNull()
+      expect(await secureStorage.getItem('s2')).toBeNull()
+    })
+  })
+
+  describe('TTL / expiration', () => {
+    it('returns null when the item has expired', async () => {
+      await secureStorage.setItem('ttl-key', 'value', 5000)
+
+      vi.advanceTimersByTime(6000)
+
+      const result = await secureStorage.getItem('ttl-key')
+      expect(result).toBeNull()
+    })
+
+    it('returns the value before expiration', async () => {
+      await secureStorage.setItem('ttl-key', 'value', 10000)
+
+      vi.advanceTimersByTime(5000)
+
+      const result = await secureStorage.getItem('ttl-key')
+      expect(result).toBe('value')
+    })
+  })
+
+  describe('setSessionItem / getSessionItem', () => {
+    it('stores and retrieves from sessionStorage', async () => {
+      await secureStorage.setSessionItem('session-key', 'session-value')
+      const result = await secureStorage.getSessionItem('session-key')
+      expect(result).toBe('session-value')
+    })
+
+    it('returns null for nonexistent session item', async () => {
+      const result = await secureStorage.getSessionItem('nonexistent')
+      expect(result).toBeNull()
+    })
+
+    it('session items use sessionStorage, not localStorage', async () => {
+      await secureStorage.setSessionItem('s-key', 's-val')
+      expect(localStorage.getItem('secure_s-key')).toBeNull()
+      expect(sessionStorage.getItem('secure_s-key')).not.toBeNull()
+    })
+  })
+
+  describe('removeSessionItem', () => {
+    it('removes the session item', async () => {
+      await secureStorage.setSessionItem('to-remove', 'val')
+      secureStorage.removeSessionItem('to-remove')
+      const result = await secureStorage.getSessionItem('to-remove')
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('session TTL', () => {
+    it('returns null for expired session items', async () => {
+      await secureStorage.setSessionItem('expiring', 'value', 1000)
+
+      vi.advanceTimersByTime(2000)
+
+      const result = await secureStorage.getSessionItem('expiring')
+      expect(result).toBeNull()
+    })
+  })
+})

--- a/frontend/lib/__tests__/security-tests.test.ts
+++ b/frontend/lib/__tests__/security-tests.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { SecurityTests } from '@/lib/security-tests'
+
+vi.mock('@/lib/secure-storage', () => ({
+  secureStorage: {
+    setItem: vi.fn().mockResolvedValue(undefined),
+    getItem: vi.fn(),
+    removeItem: vi.fn(),
+    clear: vi.fn(),
+  },
+}))
+
+vi.mock('@/lib/csrf-protection', () => ({
+  csrfProtection: {
+    generateNewToken: vi.fn().mockReturnValue('test-csrf-token'),
+    getCurrentToken: vi.fn().mockReturnValue('test-csrf-token'),
+    isTokenValid: vi.fn().mockReturnValue(true),
+    refreshToken: vi.fn().mockReturnValue('new-csrf-token'),
+    addTokenToHeaders: vi.fn().mockReturnValue({ 'X-CSRF-Token': 'test-csrf-token' }),
+  },
+}))
+
+vi.mock('@/lib/rate-limiter', () => {
+  return {
+    default: class MockRateLimiter {
+      private remaining: number
+      constructor(private opts: { maxRequests: number; windowMs: number }) {
+        this.remaining = opts.maxRequests
+      }
+      checkLimit(_key: string) {
+        if (this.remaining > 0) {
+          this.remaining--
+          return { allowed: true, remaining: this.remaining }
+        }
+        return { allowed: false, remaining: 0 }
+      }
+      reset(_key: string) {
+        this.remaining = this.opts.maxRequests
+      }
+    },
+  }
+})
+
+describe('SecurityTests', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('testXSSProtection', () => {
+    it('runs XSS sanitization tests and returns results', () => {
+      const result = SecurityTests.testXSSProtection()
+      expect(result).toHaveProperty('passed')
+      expect(result).toHaveProperty('details')
+      expect(Array.isArray(result.details)).toBe(true)
+    })
+  })
+
+  describe('testCSRFProtection', () => {
+    it('runs CSRF tests and returns results', async () => {
+      const result = await SecurityTests.testCSRFProtection()
+      expect(result).toHaveProperty('passed')
+      expect(result).toHaveProperty('details')
+      expect(Array.isArray(result.details)).toBe(true)
+    })
+  })
+
+  describe('testRateLimiting', () => {
+    it('validates normal operation, limit exceeded, and reset', async () => {
+      const result = await SecurityTests.testRateLimiting()
+      expect(result.passed).toBe(true)
+      expect(result.details.every((d: string) => d.startsWith('✅'))).toBe(true)
+    })
+  })
+
+  describe('testSecureStorage', () => {
+    it('validates set, get, expiration, and removal', async () => {
+      const { secureStorage } = await import('@/lib/secure-storage')
+      vi.mocked(secureStorage.getItem)
+        .mockResolvedValueOnce('test_sensitive_data')
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(null)
+
+      const result = await SecurityTests.testSecureStorage()
+      expect(result.passed).toBe(true)
+    })
+  })
+
+  describe('testCSPHeaders', () => {
+    it('handles fetch failure gracefully', async () => {
+      vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('Network error'))
+
+      const result = await SecurityTests.testCSPHeaders()
+      expect(result.passed).toBe(false)
+      expect(result.details.some((d: string) => d.includes('Error testing CSP headers'))).toBe(true)
+    })
+  })
+
+  describe('runAllTests', () => {
+    it('returns overall result with all sub-results', async () => {
+      vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('No server'))
+
+      const result = await SecurityTests.runAllTests()
+
+      expect(result).toHaveProperty('overall')
+      expect(result).toHaveProperty('results')
+      expect(result.results).toHaveProperty('csp')
+      expect(result.results).toHaveProperty('storage')
+      expect(result.results).toHaveProperty('rateLimit')
+      expect(result.results).toHaveProperty('csrf')
+      expect(result.results).toHaveProperty('xss')
+    })
+  })
+
+  describe('generateReport', () => {
+    it('generates a markdown report', async () => {
+      vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('No server'))
+
+      const results = await SecurityTests.runAllTests()
+      const report = SecurityTests.generateReport(results)
+
+      expect(report).toContain('# Security Test Report')
+      expect(report).toContain('Overall Status:')
+      expect(report).toContain('## CSP Headers')
+      expect(report).toContain('## CSRF Protection')
+    })
+  })
+})

--- a/frontend/lib/__tests__/stellar-wallet.test.ts
+++ b/frontend/lib/__tests__/stellar-wallet.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+vi.mock('@stellar/freighter-api', () => ({
+  default: {
+    isConnected: vi.fn(),
+    getAddress: vi.fn(),
+    getNetwork: vi.fn(),
+    signTransaction: vi.fn(),
+  },
+}))
+
+import freighterApi from '@stellar/freighter-api'
+import { StellarWalletConnection } from '@/lib/stellar-wallet'
+
+const mockedIsConnected = vi.mocked(freighterApi.isConnected)
+const mockedGetAddress = vi.mocked(freighterApi.getAddress)
+const mockedGetNetwork = vi.mocked(freighterApi.getNetwork)
+const mockedSignTransaction = vi.mocked(freighterApi.signTransaction)
+
+describe('StellarWalletConnection', () => {
+  let wallet: StellarWalletConnection
+
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    wallet = new StellarWalletConnection()
+  })
+
+  describe('connect', () => {
+    it('returns wallet info on successful connection', async () => {
+      mockedIsConnected.mockReturnValue(true)
+      mockedGetAddress.mockResolvedValue({ address: 'GABC123' })
+      mockedGetNetwork.mockResolvedValue({ network: 'testnet', networkPassphrase: 'Test SDF Network ; September 2015' })
+
+      const info = await wallet.connect()
+
+      expect(info.publicKey).toBe('GABC123')
+      expect(info.network).toBe('testnet')
+    })
+
+    it('throws when Freighter is not connected', async () => {
+      mockedIsConnected.mockReturnValue(false)
+
+      await expect(wallet.connect()).rejects.toThrow()
+    })
+
+    it('defaults to testnet when network cannot be determined', async () => {
+      mockedIsConnected.mockReturnValue(true)
+      mockedGetAddress.mockResolvedValue({ address: 'GABC123' })
+      mockedGetNetwork.mockRejectedValue(new Error('no network'))
+
+      const info = await wallet.connect()
+
+      expect(info.network).toBe('testnet')
+    })
+
+    it('throws when public key is empty', async () => {
+      mockedIsConnected.mockReturnValue(true)
+      mockedGetAddress.mockResolvedValue({ address: '' })
+
+      await expect(wallet.connect()).rejects.toThrow()
+    })
+  })
+
+  describe('signTransaction', () => {
+    it('signs a transaction with the correct passphrase', async () => {
+      mockedIsConnected.mockReturnValue(true)
+      mockedGetAddress.mockResolvedValue({ address: 'GABC123' })
+      mockedGetNetwork.mockResolvedValue({ network: 'testnet', networkPassphrase: 'Test SDF Network ; September 2015' })
+      await wallet.connect()
+
+      mockedSignTransaction.mockResolvedValue({ signedTxXdr: 'signed_xdr_123' })
+
+      const result = await wallet.signTransaction('unsigned_xdr')
+
+      expect(result).toBe('signed_xdr_123')
+      expect(mockedSignTransaction).toHaveBeenCalledWith('unsigned_xdr', {
+        networkPassphrase: 'Test SDF Network ; September 2015',
+        address: 'GABC123',
+      })
+    })
+
+    it('throws when wallet is not connected', async () => {
+      await expect(wallet.signTransaction('xdr')).rejects.toThrow('Wallet not connected')
+    })
+
+    it('throws when signing fails', async () => {
+      mockedIsConnected.mockReturnValue(true)
+      mockedGetAddress.mockResolvedValue({ address: 'GABC123' })
+      mockedGetNetwork.mockResolvedValue({ network: 'testnet', networkPassphrase: 'Test SDF Network ; September 2015' })
+      await wallet.connect()
+
+      mockedSignTransaction.mockResolvedValue({ error: 'user rejected' })
+
+      await expect(wallet.signTransaction('xdr')).rejects.toThrow()
+    })
+  })
+
+  describe('disconnect', () => {
+    it('clears the public key and network', async () => {
+      mockedIsConnected.mockReturnValue(true)
+      mockedGetAddress.mockResolvedValue({ address: 'GABC123' })
+      mockedGetNetwork.mockResolvedValue({ network: 'testnet', networkPassphrase: 'Test' })
+      await wallet.connect()
+
+      expect(wallet.isConnected()).toBe(true)
+
+      await wallet.disconnect()
+
+      expect(wallet.isConnected()).toBe(false)
+      expect(wallet.getPublicKey()).toBeNull()
+      expect(wallet.getNetwork()).toBeNull()
+    })
+  })
+
+  describe('isConnected', () => {
+    it('returns false initially', () => {
+      expect(wallet.isConnected()).toBe(false)
+    })
+
+    it('returns true after connection', async () => {
+      mockedIsConnected.mockReturnValue(true)
+      mockedGetAddress.mockResolvedValue({ address: 'GABC123' })
+      mockedGetNetwork.mockResolvedValue({ network: 'testnet', networkPassphrase: 'Test' })
+      await wallet.connect()
+
+      expect(wallet.isConnected()).toBe(true)
+    })
+  })
+
+  describe('getPublicKey / getNetwork', () => {
+    it('returns null before connection', () => {
+      expect(wallet.getPublicKey()).toBeNull()
+      expect(wallet.getNetwork()).toBeNull()
+    })
+
+    it('returns values after connection', async () => {
+      mockedIsConnected.mockReturnValue(true)
+      mockedGetAddress.mockResolvedValue({ address: 'GDEF456' })
+      mockedGetNetwork.mockResolvedValue({ network: 'public', networkPassphrase: 'Public Global Stellar Network ; September 2015' })
+      await wallet.connect()
+
+      expect(wallet.getPublicKey()).toBe('GDEF456')
+      expect(wallet.getNetwork()).toBe('public')
+    })
+  })
+})

--- a/frontend/lib/__tests__/wallet-auth.test.ts
+++ b/frontend/lib/__tests__/wallet-auth.test.ts
@@ -1,0 +1,280 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { WalletAuthManager } from '@/lib/wallet-auth'
+
+vi.mock('@/lib/stellar-wallet', () => ({
+  stellarWallet: {
+    connect: vi.fn(),
+    signTransaction: vi.fn(),
+    disconnect: vi.fn(),
+    isConnected: vi.fn(),
+    getPublicKey: vi.fn(),
+    getNetwork: vi.fn(),
+  },
+}))
+
+vi.mock('@/lib/authApi', () => ({
+  requestWalletChallenge: vi.fn(),
+  verifyWalletSignature: vi.fn(),
+}))
+
+import { stellarWallet } from '@/lib/stellar-wallet'
+import { requestWalletChallenge, verifyWalletSignature } from '@/lib/authApi'
+
+const mockedConnect = vi.mocked(stellarWallet.connect)
+const mockedSign = vi.mocked(stellarWallet.signTransaction)
+const mockedDisconnect = vi.mocked(stellarWallet.disconnect)
+const mockedChallenge = vi.mocked(requestWalletChallenge)
+const mockedVerify = vi.mocked(verifyWalletSignature)
+
+function resetSingleton() {
+  ;(WalletAuthManager as any).instance = undefined
+}
+
+describe('WalletAuthManager', () => {
+  let manager: WalletAuthManager
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.restoreAllMocks()
+    localStorage.clear()
+    resetSingleton()
+    manager = WalletAuthManager.getInstance()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  describe('getInstance', () => {
+    it('returns the same instance on repeated calls', () => {
+      const a = WalletAuthManager.getInstance()
+      const b = WalletAuthManager.getInstance()
+      expect(a).toBe(b)
+    })
+  })
+
+  describe('connectAndAuthenticate', () => {
+    it('connects wallet, requests challenge, signs, verifies, and returns a session', async () => {
+      mockedConnect.mockResolvedValue({ publicKey: 'GABC123', network: 'testnet' })
+      mockedChallenge.mockResolvedValue({ challengeXdr: 'xdr-123', expiresAt: '2026-01-01T00:00:00Z' })
+      mockedSign.mockResolvedValue('signed-xdr')
+      mockedVerify.mockResolvedValue({
+        token: 'session-token',
+        user: { id: '1', email: 'a@b.com', name: 'A', role: 'tenant' },
+      })
+
+      const session = await manager.connectAndAuthenticate()
+
+      expect(session.publicKey).toBe('GABC123')
+      expect(session.network).toBe('testnet')
+      expect(session.token).toBe('session-token')
+      expect(session.expiresAt).toBeGreaterThan(Date.now())
+      expect(mockedConnect).toHaveBeenCalledOnce()
+      expect(mockedChallenge).toHaveBeenCalledWith('GABC123')
+      expect(mockedSign).toHaveBeenCalledWith('xdr-123')
+      expect(mockedVerify).toHaveBeenCalledWith('GABC123', 'signed-xdr')
+    })
+
+    it('persists session to localStorage', async () => {
+      mockedConnect.mockResolvedValue({ publicKey: 'GDEF456', network: 'testnet' })
+      mockedChallenge.mockResolvedValue({ challengeXdr: 'xdr-456', expiresAt: '2026-01-01T00:00:00Z' })
+      mockedSign.mockResolvedValue('signed-xdr-456')
+      mockedVerify.mockResolvedValue({
+        token: 'persist-token',
+        user: { id: '2', email: 'b@b.com', name: 'B', role: 'landlord' },
+      })
+
+      await manager.connectAndAuthenticate()
+
+      const stored = localStorage.getItem('wallet_auth_session')
+      expect(stored).not.toBeNull()
+      const parsed = JSON.parse(stored!)
+      expect(parsed.token).toBe('persist-token')
+    })
+
+    it('throws and does not save session on failure', async () => {
+      mockedConnect.mockRejectedValue(new Error('Wallet not found'))
+
+      await expect(manager.connectAndAuthenticate()).rejects.toThrow('Wallet not found')
+      expect(localStorage.getItem('wallet_auth_session')).toBeNull()
+    })
+  })
+
+  describe('disconnect', () => {
+    it('clears the session and calls wallet disconnect', async () => {
+      mockedConnect.mockResolvedValue({ publicKey: 'GABC', network: 'testnet' })
+      mockedChallenge.mockResolvedValue({ challengeXdr: 'x', expiresAt: '2026-01-01T00:00:00Z' })
+      mockedSign.mockResolvedValue('signed')
+      mockedVerify.mockResolvedValue({
+        token: 'tok',
+        user: { id: '1', email: 'a@b.com', name: 'A', role: 'tenant' },
+      })
+
+      await manager.connectAndAuthenticate()
+      expect(manager.isAuthenticated()).toBe(true)
+
+      await manager.disconnect()
+
+      expect(manager.isAuthenticated()).toBe(false)
+      expect(mockedDisconnect).toHaveBeenCalledOnce()
+      expect(localStorage.getItem('wallet_auth_session')).toBeNull()
+    })
+  })
+
+  describe('getSession', () => {
+    it('returns null when no session exists', () => {
+      expect(manager.getSession()).toBeNull()
+    })
+
+    it('returns the session when it is valid', async () => {
+      mockedConnect.mockResolvedValue({ publicKey: 'GABC', network: 'testnet' })
+      mockedChallenge.mockResolvedValue({ challengeXdr: 'x', expiresAt: '2026-01-01T00:00:00Z' })
+      mockedSign.mockResolvedValue('signed')
+      mockedVerify.mockResolvedValue({
+        token: 'tok',
+        user: { id: '1', email: 'a@b.com', name: 'A', role: 'tenant' },
+      })
+
+      await manager.connectAndAuthenticate()
+      const session = manager.getSession()
+      expect(session).not.toBeNull()
+      expect(session!.token).toBe('tok')
+    })
+
+    it('returns null and clears storage when session is expired', async () => {
+      mockedConnect.mockResolvedValue({ publicKey: 'GABC', network: 'testnet' })
+      mockedChallenge.mockResolvedValue({ challengeXdr: 'x', expiresAt: '2026-01-01T00:00:00Z' })
+      mockedSign.mockResolvedValue('signed')
+      mockedVerify.mockResolvedValue({
+        token: 'tok',
+        user: { id: '1', email: 'a@b.com', name: 'A', role: 'tenant' },
+      })
+
+      await manager.connectAndAuthenticate()
+
+      vi.advanceTimersByTime(25 * 60 * 60 * 1000)
+
+      expect(manager.getSession()).toBeNull()
+      expect(localStorage.getItem('wallet_auth_session')).toBeNull()
+    })
+  })
+
+  describe('isAuthenticated', () => {
+    it('returns false when no session', () => {
+      expect(manager.isAuthenticated()).toBe(false)
+    })
+
+    it('returns true after successful authentication', async () => {
+      mockedConnect.mockResolvedValue({ publicKey: 'GABC', network: 'testnet' })
+      mockedChallenge.mockResolvedValue({ challengeXdr: 'x', expiresAt: '2026-01-01T00:00:00Z' })
+      mockedSign.mockResolvedValue('signed')
+      mockedVerify.mockResolvedValue({
+        token: 'tok',
+        user: { id: '1', email: 'a@b.com', name: 'A', role: 'tenant' },
+      })
+
+      await manager.connectAndAuthenticate()
+      expect(manager.isAuthenticated()).toBe(true)
+    })
+  })
+
+  describe('getAuthToken', () => {
+    it('returns null when not authenticated', () => {
+      expect(manager.getAuthToken()).toBeNull()
+    })
+
+    it('returns the token when authenticated', async () => {
+      mockedConnect.mockResolvedValue({ publicKey: 'GABC', network: 'testnet' })
+      mockedChallenge.mockResolvedValue({ challengeXdr: 'x', expiresAt: '2026-01-01T00:00:00Z' })
+      mockedSign.mockResolvedValue('signed')
+      mockedVerify.mockResolvedValue({
+        token: 'my-token',
+        user: { id: '1', email: 'a@b.com', name: 'A', role: 'tenant' },
+      })
+
+      await manager.connectAndAuthenticate()
+      expect(manager.getAuthToken()).toBe('my-token')
+    })
+  })
+
+  describe('refreshIfNeeded', () => {
+    it('does nothing when not authenticated', async () => {
+      await manager.refreshIfNeeded()
+      expect(mockedConnect).not.toHaveBeenCalled()
+    })
+
+    it('refreshes when session is within 1 hour of expiry', async () => {
+      mockedConnect.mockResolvedValue({ publicKey: 'GABC', network: 'testnet' })
+      mockedChallenge.mockResolvedValue({ challengeXdr: 'x', expiresAt: '2026-01-01T00:00:00Z' })
+      mockedSign.mockResolvedValue('signed')
+      mockedVerify.mockResolvedValue({
+        token: 'tok',
+        user: { id: '1', email: 'a@b.com', name: 'A', role: 'tenant' },
+      })
+
+      await manager.connectAndAuthenticate()
+
+      vi.advanceTimersByTime(23.5 * 60 * 60 * 1000)
+
+      await manager.refreshIfNeeded()
+
+      expect(mockedConnect).toHaveBeenCalledTimes(2)
+    })
+
+    it('does not refresh when session has more than 1 hour left', async () => {
+      mockedConnect.mockResolvedValue({ publicKey: 'GABC', network: 'testnet' })
+      mockedChallenge.mockResolvedValue({ challengeXdr: 'x', expiresAt: '2026-01-01T00:00:00Z' })
+      mockedSign.mockResolvedValue('signed')
+      mockedVerify.mockResolvedValue({
+        token: 'tok',
+        user: { id: '1', email: 'a@b.com', name: 'A', role: 'tenant' },
+      })
+
+      await manager.connectAndAuthenticate()
+
+      vi.advanceTimersByTime(1 * 60 * 60 * 1000)
+
+      await manager.refreshIfNeeded()
+
+      expect(mockedConnect).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('session restoration from localStorage', () => {
+    it('restores a valid session on initialization', () => {
+      const futureTime = Date.now() + 3600000
+      localStorage.setItem('wallet_auth_session', JSON.stringify({
+        publicKey: 'GSTORED',
+        network: 'testnet',
+        token: 'stored-token',
+        expiresAt: futureTime,
+      }))
+
+      resetSingleton()
+      const newManager = WalletAuthManager.getInstance()
+      expect(newManager.isAuthenticated()).toBe(true)
+      expect(newManager.getAuthToken()).toBe('stored-token')
+    })
+
+    it('does not restore an expired session', () => {
+      localStorage.setItem('wallet_auth_session', JSON.stringify({
+        publicKey: 'GSTORED',
+        network: 'testnet',
+        token: 'expired-token',
+        expiresAt: Date.now() - 1000,
+      }))
+
+      resetSingleton()
+      const newManager = WalletAuthManager.getInstance()
+      expect(newManager.isAuthenticated()).toBe(false)
+    })
+
+    it('handles corrupted localStorage data gracefully', () => {
+      localStorage.setItem('wallet_auth_session', 'not-json')
+
+      resetSingleton()
+      const newManager = WalletAuthManager.getInstance()
+      expect(newManager.isAuthenticated()).toBe(false)
+    })
+  })
+})

--- a/frontend/lib/__tests__/walletApi.test.ts
+++ b/frontend/lib/__tests__/walletApi.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import {
+  getNgnBalance,
+  getNgnLedger,
+  initiateTopUp,
+  initiateWithdrawal,
+  getWithdrawalHistory,
+  getMultiCurrencyBalance,
+  getConversionQuote,
+} from '@/lib/walletApi'
+
+vi.mock('@/lib/api', () => ({
+  apiFetch: vi.fn(),
+}))
+
+import { apiFetch } from '@/lib/api'
+
+const mockedApiFetch = vi.mocked(apiFetch)
+
+describe('walletApi', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('getNgnBalance', () => {
+    it('fetches NGN balance from the correct endpoint', async () => {
+      const response = { availableNgn: 50000, heldNgn: 10000, totalNgn: 60000 }
+      mockedApiFetch.mockResolvedValue(response)
+
+      const result = await getNgnBalance()
+
+      expect(mockedApiFetch).toHaveBeenCalledWith('/api/wallet/ngn/balance')
+      expect(result).toEqual(response)
+    })
+  })
+
+  describe('getNgnLedger', () => {
+    it('fetches ledger with default params', async () => {
+      const response = { entries: [], nextCursor: null }
+      mockedApiFetch.mockResolvedValue(response)
+
+      await getNgnLedger()
+
+      expect(mockedApiFetch).toHaveBeenCalledWith(expect.stringContaining('/api/wallet/ngn/ledger?'))
+    })
+
+    it('includes cursor, limit, and type in query string', async () => {
+      mockedApiFetch.mockResolvedValue({ entries: [], nextCursor: null })
+
+      await getNgnLedger({
+        cursor: 'cur_123',
+        limit: 10,
+        type: ['top_up', 'withdrawal'],
+      })
+
+      const calledUrl = mockedApiFetch.mock.calls[0][0] as string
+      expect(calledUrl).toContain('cursor=cur_123')
+      expect(calledUrl).toContain('limit=10')
+      expect(calledUrl).toContain('type=top_up')
+      expect(calledUrl).toContain('type=withdrawal')
+    })
+  })
+
+  describe('initiateTopUp', () => {
+    it('sends POST request with payload', async () => {
+      const response = {
+        id: 'top_1',
+        amountNgn: 10000,
+        rail: 'paystack' as const,
+        status: 'pending' as const,
+        reference: 'ref_1',
+        createdAt: '2026-01-01T00:00:00Z',
+      }
+      mockedApiFetch.mockResolvedValue(response)
+
+      const result = await initiateTopUp({ amountNgn: 10000, rail: 'paystack' })
+
+      expect(mockedApiFetch).toHaveBeenCalledWith('/api/wallet/ngn/topup/initiate', {
+        method: 'POST',
+        body: JSON.stringify({ amountNgn: 10000, rail: 'paystack' }),
+      })
+      expect(result).toEqual(response)
+    })
+  })
+
+  describe('initiateWithdrawal', () => {
+    it('sends POST request with bank account details', async () => {
+      const response = {
+        id: 'wd_1',
+        amountNgn: 5000,
+        status: 'pending' as const,
+        bankAccount: { accountNumber: '1234567890', accountName: 'Test User', bankName: 'GTBank' },
+        reference: 'ref_wd',
+        createdAt: '2026-01-01T00:00:00Z',
+      }
+      mockedApiFetch.mockResolvedValue(response)
+
+      const result = await initiateWithdrawal({
+        amountNgn: 5000,
+        bankAccount: { accountNumber: '1234567890', accountName: 'Test User', bankName: 'GTBank' },
+      })
+
+      expect(result).toEqual(response)
+    })
+  })
+
+  describe('getWithdrawalHistory', () => {
+    it('fetches withdrawal history', async () => {
+      const response = { entries: [], nextCursor: null }
+      mockedApiFetch.mockResolvedValue(response)
+
+      const result = await getWithdrawalHistory()
+
+      expect(result).toEqual(response)
+    })
+
+    it('includes pagination params', async () => {
+      mockedApiFetch.mockResolvedValue({ entries: [], nextCursor: null })
+
+      await getWithdrawalHistory({ cursor: 'cur_abc', limit: 5 })
+
+      const calledUrl = mockedApiFetch.mock.calls[0][0] as string
+      expect(calledUrl).toContain('cursor=cur_abc')
+      expect(calledUrl).toContain('limit=5')
+    })
+  })
+
+  describe('getMultiCurrencyBalance', () => {
+    it('fetches multi-currency balance', async () => {
+      const response = {
+        balances: [
+          { currency: 'NGN', available: 10000, held: 0, total: 10000 },
+          { currency: 'USDC', available: 50, held: 10, total: 60 },
+        ],
+      }
+      mockedApiFetch.mockResolvedValue(response)
+
+      const result = await getMultiCurrencyBalance()
+
+      expect(mockedApiFetch).toHaveBeenCalledWith('/api/wallet/balance')
+      expect(result).toEqual(response)
+    })
+  })
+
+  describe('getConversionQuote', () => {
+    it('sends conversion quote request with query params', async () => {
+      const response = {
+        quoteId: 'q_1',
+        fromCurrency: 'NGN' as const,
+        toCurrency: 'USDC' as const,
+        fromAmount: 100000,
+        estimatedToAmount: 60,
+        rate: 1666.67,
+        fees: 500,
+        expiresAt: '2026-01-01T00:05:00Z',
+      }
+      mockedApiFetch.mockResolvedValue(response)
+
+      const result = await getConversionQuote({
+        fromCurrency: 'NGN',
+        toCurrency: 'USDC',
+        amount: 100000,
+      })
+
+      const calledUrl = mockedApiFetch.mock.calls[0][0] as string
+      expect(calledUrl).toContain('fromCurrency=NGN')
+      expect(calledUrl).toContain('toCurrency=USDC')
+      expect(calledUrl).toContain('amount=100000')
+      expect(result).toEqual(response)
+    })
+  })
+})


### PR DESCRIPTION
Closes #1415, Closes #1416, Closes #1417, Closes #1418

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional or behavioral changes)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Build / CI configuration change
- [ ] Dependency update
- [ ] Other: <!-- describe -->

---

## Summary

Added comprehensive unit tests for 17 previously untested `frontend/lib/` modules across four categories: auth/wallet-auth/secure-storage, CSRF/PII/security utilities, API client/error normalization/retry logic, and payment/wallet/staking clients. All 208 tests pass, and lint and build remain green.

**Note:** `lib/pii-scrubber.ts` referenced in #1416 does not exist in the codebase. This was reported separately.

## Motivation / Context

These modules handle authentication, security, network communication, and payment flows — all critical paths that were entirely untested. The tests cover both success and failure paths, use deterministic mocking (no live backend), and verify that errors surface distinct, actionable states.

Closes #1415, Closes #1416, Closes #1417, Closes #1418