### PR TITLE
feat: job/worker observability, admin capability map, and e2e coverag…

### DIFF
--- a/backend/docs/jobs-and-workers.md
+++ b/backend/docs/jobs-and-workers.md
@@ -1,0 +1,75 @@
+# Scheduled jobs and workers
+
+Inventory of the platform's background work, what healthy behaviour looks like, and
+how to tell a job has stopped running. Source of truth for the table is
+`JOB_INVENTORY` in [`src/jobs/jobObservability.ts`](../src/jobs/jobObservability.ts) —
+the two are kept in step by `jobObservability.test.ts`.
+
+## Inventory
+
+| Job | Module | What it does | Expected interval | If it does not run | Healthy looks like |
+| --- | --- | --- | --- | --- | --- |
+| `late-payment-escalation` | `src/jobs/latePaymentJob.ts` | Walks active deals and applies the late-payment escalation matrix. | 6h (`LATE_PAYMENT_JOB_POLL_MS`) | Late tenants are never escalated; arrears accrue with no notice sent. | Completes in seconds. `recordsProcessed` is 0 on a day with no late deals — a *rising* count is the abnormal case. |
+| `staking-finalizer` | `src/jobs/stakingFinalizer.ts` | Finalises staking for completed conversions (idempotent per conversion). | 10s | Completed conversions never finalise; staked balances stay invisible to the tenant. | Usually 0 processed. Sustained non-zero means conversions are backing up. |
+| `data-retention` | `src/jobs/dataRetentionJob.ts` | Deletes stale onboarding drafts, anonymises KYC rejections, expires erasure requests. | 24h (`DATA_RETENTION_JOB_POLL_MS`) | Personal data retained past its policy window — a compliance breach, not a bug. | One run/day. Small non-zero counts are normal; a spike means a retention window changed. |
+| `monthly-deduction-reminder` | `src/jobs/monthlyDeductionReminderJob.ts` | Sends advance salary-deduction notices to employer webhooks. | 24h (`MONTHLY_DEDUCTION_REMINDER_POLL_MS`) | Employers deduct without notice, or not at all — a missed rent cycle. | One run/day, non-zero only in the days before a pay cycle. |
+| `scheduler` | `src/jobs/scheduler/worker.ts` | Leases and executes due rows in the job table (notifications, webhook delivery, purges). | 5s (`JOB_SCHEDULER_POLL_MS`) | Nothing queued ever executes: notifications, webhook deliveries and purges stall silently. | A tick every 5s; `recordsProcessed` = due rows claimed. Per-run detail: `GET /api/admin/jobs/{id}/history`. |
+
+Other background loops not yet on the observed path (deliberately out of scope for
+this change, listed so the gap is visible): `src/workers/dealStatusSyncWorker.ts`,
+`src/workers/sorobanEventIndexer.ts`, the settlement outbox worker, and the
+reconciliation pass. They keep their existing logging.
+
+## What is recorded per run
+
+`observeJobRun(name, fn)` wraps each run and records:
+
+- **start** — `Job run started` log line with `job`, `startedAt`, `correlationId`
+- **completion and duration** — `Job run completed` with `durationMs`
+- **records processed** — `recordsProcessed`, returned by the job itself. This is the
+  point of the whole exercise: a run that completed having processed zero records
+  because of a query defect is indistinguishable from a healthy run in any log that
+  only records completion.
+- **failures** — `Job run failed` with the error message, `consecutiveFailures`, and
+  the correlation id of the originating request when the run was triggered inside one
+  (from `request-context.ts`, the same id used for HTTP request tracing).
+
+## Detecting a job that stopped running
+
+A missing run produces no error, so it has to be detected as an *absence*:
+
+| Metric | Use |
+| --- | --- |
+| `job_seconds_since_last_run{job}` | Grows without bound once a job stops. `-1` = never ran this process. |
+| `job_overdue{job}` | `1` when a job has not run within **twice** its expected interval, including never having run. This is the alerting signal. |
+| `job_last_success_timestamp_seconds{job}` | Last *successful* run, for alerting on "runs but always fails". |
+| `job_runs_total{job,status}` | `status` is `completed`, `failed`, or `skipped_overrun`. |
+| `job_records_processed_total{job}` | Work actually done. Flat while `job_runs_total` climbs = running but doing nothing. |
+| `job_run_duration_ms{job}` | Runs creeping toward the interval length predict overruns. |
+
+Both gauges are computed at scrape time, so a stalled job keeps drifting instead of
+freezing at its last reported value.
+
+Suggested alert: `job_overdue == 1 for 10m`.
+
+## Overrun behaviour
+
+Deliberate, and enforced at two layers:
+
+1. **In-process** — `observeJobRun` refuses to start a second run of the same job
+   while one is still in flight and counts it as `job_runs_total{status="skipped_overrun"}`.
+   Runs are skipped, never queued: these jobs are all "process whatever is due now",
+   so a skipped run is fully recovered by the next one.
+2. **Across processes** — scheduler-driven jobs are additionally serialised by the
+   lease plus monotonic fencing token in `src/jobs/scheduler/store.ts`, so two
+   instances cannot execute the same job row even mid-deploy.
+
+A rising `skipped_overrun` count means a job is consistently overrunning its
+interval and the interval (or the job) needs attention.
+
+## Operator surface
+
+- `GET /api/admin/jobs/health` — the full report above as JSON (`x-admin-secret`
+  when `MANUAL_ADMIN_SECRET` is set).
+- Admin UI: the **Background jobs** panel on `/admin/health`.
+- `GET /metrics` — Prometheus, for alerting.

--- a/backend/docs/openapi.yml
+++ b/backend/docs/openapi.yml
@@ -299,6 +299,96 @@ paths:
         default:
           $ref: "#/components/responses/Error"
 
+  /api/admin/jobs/health:
+    get:
+      summary: Scheduled job and worker health
+      description: >-
+        Health of every scheduled job and background worker: what it does, when
+        it last ran, how long that run took, how many records it processed, and
+        whether it is overdue. A job that has stopped being scheduled reports
+        state "overdue" (or "never_ran") so a missing run is detectable as an
+        absence rather than only as an error. Requires the x-admin-secret header
+        when MANUAL_ADMIN_SECRET is configured.
+      operationId: getJobHealth
+      tags:
+        - Admin
+      security:
+        - adminSecret: []
+      responses:
+        "200":
+          description: Job health report
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [capturedAt, overdueCount, failingCount, jobs]
+                properties:
+                  capturedAt:
+                    type: string
+                    format: date-time
+                  overdueCount:
+                    type: integer
+                  failingCount:
+                    type: integer
+                  jobs:
+                    type: array
+                    items:
+                      type: object
+                      required: [name, module, does, expectedIntervalMs, state, overdue]
+                      properties:
+                        name:
+                          type: string
+                        module:
+                          type: string
+                        does:
+                          type: string
+                        expectedIntervalMs:
+                          type: integer
+                        ifItDoesNotRun:
+                          type: string
+                        healthy:
+                          type: string
+                        state:
+                          type: string
+                          enum: [healthy, failing, overdue, never_ran]
+                        overdue:
+                          type: boolean
+                        secondsSinceLastRun:
+                          type: integer
+                          nullable: true
+                        lastSuccessAt:
+                          type: string
+                          format: date-time
+                          nullable: true
+                        consecutiveFailures:
+                          type: integer
+                        lastRun:
+                          type: object
+                          nullable: true
+                          properties:
+                            startedAt:
+                              type: string
+                              format: date-time
+                            finishedAt:
+                              type: string
+                              format: date-time
+                            durationMs:
+                              type: integer
+                            outcome:
+                              type: string
+                              enum: [completed, failed, skipped_overrun]
+                            recordsProcessed:
+                              type: integer
+                            correlationId:
+                              type: string
+                              nullable: true
+                            error:
+                              type: string
+        "403":
+          description: Invalid admin secret
+        default:
+          $ref: "#/components/responses/Error"
+
   /api/admin/receipts:
     get:
       summary: Query indexed receipts
@@ -3695,6 +3785,13 @@ components:
         in middleware/rbac.ts, e.g. payouts:trigger) or an explicit admin/super_admin role
         check. Kept as a distinct scheme name so admin-gated operations are visibly
         distinguishable from ordinary authenticated ones in this document.
+    adminSecret:
+      type: apiKey
+      in: header
+      name: x-admin-secret
+      description: >-
+        Shared operator secret checked against MANUAL_ADMIN_SECRET. Used by the
+        job-scheduler admin routes, which are reachable without a user session.
     webhookSignature:
       type: apiKey
       in: header

--- a/backend/src/jobs/dataRetentionJob.ts
+++ b/backend/src/jobs/dataRetentionJob.ts
@@ -1,6 +1,7 @@
 import { getPool } from '../db.js'
 import { logger } from '../utils/logger.js'
 import { erasureService } from '../services/erasureService.js'
+import { observeJobRun, sumCounts } from './jobObservability.js'
 
 export interface DataRetentionResult {
   onboardingDraftsDeleted: number
@@ -48,7 +49,10 @@ export class DataRetentionJob {
   }
 
   async poll(now = new Date()): Promise<void> {
-    await this.runRetention(now)
+    await observeJobRun('data-retention', async () => {
+      const result = await this.runRetention(now)
+      return { recordsProcessed: sumCounts(result) }
+    })
   }
 
   async runRetention(now = new Date()): Promise<DataRetentionResult> {

--- a/backend/src/jobs/jobObservability.test.ts
+++ b/backend/src/jobs/jobObservability.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+import {
+  JOB_INVENTORY,
+  observeJobRun,
+  getJobHealthReport,
+  resetJobObservability,
+  sumCounts,
+} from './jobObservability.js'
+import { requestContext } from '../request-context.js'
+
+describe('job observability', () => {
+  beforeEach(() => {
+    resetJobObservability()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('records start, completion, duration and records processed', async () => {
+    const record = await observeJobRun('data-retention', async () => ({ recordsProcessed: 7 }))
+
+    expect(record.outcome).toBe('completed')
+    expect(record.recordsProcessed).toBe(7)
+    expect(record.durationMs).toBeGreaterThanOrEqual(0)
+    expect(Date.parse(record.startedAt)).not.toBeNaN()
+    expect(Date.parse(record.finishedAt)).not.toBeNaN()
+  })
+
+  it('distinguishes a run that did no work from a run that never happened', async () => {
+    await observeJobRun('data-retention', async () => ({ recordsProcessed: 0 }))
+    const report = getJobHealthReport()
+
+    const ran = report.jobs.find(j => j.name === 'data-retention')!
+    const neverRan = report.jobs.find(j => j.name === 'staking-finalizer')!
+
+    expect(ran.state).toBe('healthy')
+    expect(ran.lastRun?.recordsProcessed).toBe(0)
+    expect(neverRan.state).toBe('never_ran')
+    expect(neverRan.lastRun).toBeNull()
+    expect(neverRan.secondsSinceLastRun).toBeNull()
+  })
+
+  it('reports a job that has stopped running as overdue — an absence, not an error', () => {
+    // Nothing has run at all: every inventoried job is overdue.
+    const report = getJobHealthReport()
+    expect(report.overdueCount).toBe(JOB_INVENTORY.length)
+    expect(report.failingCount).toBe(0)
+  })
+
+  it('clears overdue once a run lands, and re-raises it after the expected interval lapses', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'))
+
+    await observeJobRun('staking-finalizer', async () => ({ recordsProcessed: 1 }))
+    expect(getJobHealthReport().jobs.find(j => j.name === 'staking-finalizer')!.overdue).toBe(false)
+
+    // staking-finalizer is expected every 10s; two intervals is the grace window.
+    vi.setSystemTime(new Date('2026-01-01T00:01:00Z'))
+    const stale = getJobHealthReport().jobs.find(j => j.name === 'staking-finalizer')!
+    expect(stale.overdue).toBe(true)
+    expect(stale.secondsSinceLastRun).toBe(60)
+  })
+
+  it('records a failure with its correlation id instead of throwing', async () => {
+    const record = await requestContext.run({ requestId: 'req-abc', queryCount: 0 }, () =>
+      observeJobRun('late-payment-escalation', async () => {
+        throw new Error('database unavailable')
+      }),
+    )
+
+    expect(record.outcome).toBe('failed')
+    expect(record.error).toBe('database unavailable')
+    expect(record.correlationId).toBe('req-abc')
+
+    const health = getJobHealthReport().jobs.find(j => j.name === 'late-payment-escalation')!
+    expect(health.state).toBe('failing')
+    expect(health.consecutiveFailures).toBe(1)
+  })
+
+  it('skips rather than stacking a second run while one is in flight', async () => {
+    let release: (() => void) | undefined
+    const gate = new Promise<void>(resolve => {
+      release = resolve
+    })
+
+    const first = observeJobRun('scheduler', async () => {
+      await gate
+      return { recordsProcessed: 3 }
+    })
+    const second = await observeJobRun('scheduler', async () => ({ recordsProcessed: 99 }))
+
+    expect(second.outcome).toBe('skipped_overrun')
+    expect(second.recordsProcessed).toBe(0)
+
+    release!()
+    expect((await first).recordsProcessed).toBe(3)
+  })
+
+  it('sums the numeric fields of a job result into a records-processed count', () => {
+    expect(sumCounts({ dealsProcessed: 2, installmentsProcessed: 5, note: 'x' })).toBe(7)
+    expect(sumCounts({})).toBe(0)
+  })
+
+  it('documents every inventoried job well enough to operate it', () => {
+    for (const entry of JOB_INVENTORY) {
+      expect(entry.expectedIntervalMs).toBeGreaterThan(0)
+      expect(entry.does.length).toBeGreaterThan(10)
+      expect(entry.ifItDoesNotRun.length).toBeGreaterThan(10)
+      expect(entry.healthy.length).toBeGreaterThan(10)
+    }
+  })
+})

--- a/backend/src/jobs/jobObservability.ts
+++ b/backend/src/jobs/jobObservability.ts
@@ -1,0 +1,362 @@
+/**
+ * Job & worker observability (#1449)
+ *
+ * The characteristic failure of background work is silence: a job that stops
+ * being scheduled produces no error and no user-visible symptom until something
+ * downstream is found to be stale. This module makes two things detectable:
+ *
+ *  1. A run that happened but did no work — every run records its
+ *     `recordsProcessed`, not merely that it completed.
+ *  2. A run that never happened — every job declares an expected interval, and
+ *     `job_overdue` / `job_seconds_since_last_run` turn an *absence* into a
+ *     positive signal an operator can alert on.
+ *
+ * Overrun policy: `observeJobRun` refuses to start a second in-process run of
+ * the same job while one is still in flight (counted as `skipped_overrun`).
+ * Scheduler-driven jobs are additionally serialised across processes by the
+ * lease + fencing token in `scheduler/store.ts`.
+ */
+
+import client from 'prom-client'
+import { metricsRegister } from '../metrics.js'
+import { getRequestContext } from '../request-context.js'
+import { logger } from '../utils/logger.js'
+
+// ── Inventory ────────────────────────────────────────────────────────────────
+
+export interface JobInventoryEntry {
+  /** Stable job key used as the metric label and health-report id. */
+  name: string
+  /** Source module implementing the job. */
+  module: string
+  /** What the job does. */
+  does: string
+  /** How often it is expected to run, in milliseconds. */
+  expectedIntervalMs: number
+  /** Consequence of the job silently not running. */
+  ifItDoesNotRun: string
+  /** What a healthy run looks like, so an operator can tell normal from abnormal. */
+  healthy: string
+}
+
+const HOUR = 60 * 60 * 1000
+const DAY = 24 * HOUR
+
+export const JOB_INVENTORY: readonly JobInventoryEntry[] = [
+  {
+    name: 'late-payment-escalation',
+    module: 'src/jobs/latePaymentJob.ts',
+    does: 'Walks active deals and applies the late-payment escalation matrix.',
+    expectedIntervalMs: 6 * HOUR,
+    ifItDoesNotRun: 'Late tenants are never escalated; arrears accrue with no notice sent.',
+    healthy: 'Runs every 6h in seconds, records 0 processed on a day with no late deals — a rising count is the abnormal case.',
+  },
+  {
+    name: 'staking-finalizer',
+    module: 'src/jobs/stakingFinalizer.ts',
+    does: 'Finalises staking for completed conversions (idempotent per conversion).',
+    expectedIntervalMs: 10_000,
+    ifItDoesNotRun: 'Completed conversions never finalise; staked balances stay invisible to the tenant.',
+    healthy: 'Runs every 10s, usually 0 processed; sustained non-zero counts mean conversions are backing up.',
+  },
+  {
+    name: 'data-retention',
+    module: 'src/jobs/dataRetentionJob.ts',
+    does: 'Deletes stale onboarding drafts, anonymises KYC rejections, expires erasure requests.',
+    expectedIntervalMs: DAY,
+    ifItDoesNotRun: 'Personal data is retained past its policy window — a compliance breach, not a bug.',
+    healthy: 'One run per day; small non-zero counts are normal, a sudden spike means a retention window changed.',
+  },
+  {
+    name: 'monthly-deduction-reminder',
+    module: 'src/jobs/monthlyDeductionReminderJob.ts',
+    does: 'Sends advance salary-deduction notices to employer webhooks for the coming pay cycle.',
+    expectedIntervalMs: DAY,
+    ifItDoesNotRun: 'Employers deduct without notice, or do not deduct at all — a missed rent cycle.',
+    healthy: 'One run per day; non-zero only in the days before a pay cycle.',
+  },
+  {
+    name: 'scheduler',
+    module: 'src/jobs/scheduler/worker.ts',
+    does: 'Leases and executes due rows in the scheduled_jobs table (notifications, webhooks, purges).',
+    expectedIntervalMs: 5_000,
+    ifItDoesNotRun: 'Nothing queued is ever executed: notifications, webhook deliveries and purges stall silently.',
+    healthy: 'A tick every 5s, recordsProcessed = number of due rows claimed. Individual queued runs are in GET /api/admin/jobs/{id}/history.',
+  },
+] as const
+
+const INVENTORY_BY_NAME = new Map(JOB_INVENTORY.map(entry => [entry.name, entry]))
+
+// ── Metrics ──────────────────────────────────────────────────────────────────
+
+export const jobRunsTotal = new client.Counter({
+  name: 'job_runs_total',
+  help: 'Job runs by outcome. status=skipped_overrun means a previous run was still in flight.',
+  labelNames: ['job', 'status'] as const,
+  registers: [metricsRegister],
+})
+
+export const jobRunDurationMs = new client.Histogram({
+  name: 'job_run_duration_ms',
+  help: 'Job run wall-clock duration in milliseconds.',
+  labelNames: ['job'] as const,
+  buckets: [10, 50, 250, 1000, 5000, 30_000, 120_000, 600_000],
+  registers: [metricsRegister],
+})
+
+export const jobRecordsProcessedTotal = new client.Counter({
+  name: 'job_records_processed_total',
+  help: 'Records processed by a job. A completed run that processed nothing is not the same as a healthy run.',
+  labelNames: ['job'] as const,
+  registers: [metricsRegister],
+})
+
+export const jobLastSuccessTimestampSeconds = new client.Gauge({
+  name: 'job_last_success_timestamp_seconds',
+  help: 'Unix timestamp of the last successful run of each job.',
+  labelNames: ['job'] as const,
+  registers: [metricsRegister],
+})
+
+/**
+ * Absence detection. Both gauges are computed at scrape time so a job that has
+ * simply stopped being scheduled keeps drifting upward instead of freezing at
+ * its last reported value.
+ */
+export const jobSecondsSinceLastRun = new client.Gauge({
+  name: 'job_seconds_since_last_run',
+  help: 'Seconds since the last run of each job. Grows without bound when a job stops running.',
+  labelNames: ['job'] as const,
+  registers: [metricsRegister],
+  collect() {
+    for (const entry of JOB_INVENTORY) {
+      this.set({ job: entry.name }, secondsSinceLastRun(entry))
+    }
+  },
+})
+
+export const jobOverdue = new client.Gauge({
+  name: 'job_overdue',
+  help: '1 when a job has not run within twice its expected interval (includes never having run), else 0.',
+  labelNames: ['job'] as const,
+  registers: [metricsRegister],
+  collect() {
+    for (const entry of JOB_INVENTORY) {
+      this.set({ job: entry.name }, isOverdue(entry) ? 1 : 0)
+    }
+  },
+})
+
+// ── Run state ────────────────────────────────────────────────────────────────
+
+export type JobRunOutcome = 'completed' | 'failed' | 'skipped_overrun'
+
+export interface JobRunRecord {
+  job: string
+  startedAt: string
+  finishedAt: string
+  durationMs: number
+  outcome: JobRunOutcome
+  recordsProcessed: number
+  correlationId: string | null
+  error?: string
+}
+
+interface JobState {
+  inFlight: boolean
+  lastRun: JobRunRecord | null
+  lastSuccessAt: number | null
+  consecutiveFailures: number
+}
+
+const state = new Map<string, JobState>()
+
+function getState(job: string): JobState {
+  let s = state.get(job)
+  if (!s) {
+    s = { inFlight: false, lastRun: null, lastSuccessAt: null, consecutiveFailures: 0 }
+    state.set(job, s)
+  }
+  return s
+}
+
+/** Grace factor applied to the expected interval before a job is called overdue. */
+const OVERDUE_INTERVAL_FACTOR = 2
+
+function secondsSinceLastRun(entry: JobInventoryEntry): number {
+  const last = state.get(entry.name)?.lastRun
+  if (!last) return -1
+  return Math.max(0, Math.round((Date.now() - Date.parse(last.startedAt)) / 1000))
+}
+
+function isOverdue(entry: JobInventoryEntry): boolean {
+  const elapsed = secondsSinceLastRun(entry)
+  if (elapsed < 0) return true // never ran — the absence this issue is about
+  return elapsed * 1000 > entry.expectedIntervalMs * OVERDUE_INTERVAL_FACTOR
+}
+
+export interface JobRunResult {
+  /** Number of records the run actually acted on. */
+  recordsProcessed?: number
+}
+
+/**
+ * Run `fn` as an observed job run.
+ *
+ * Never throws: a job's failure is recorded and swallowed so an interval loop
+ * is not torn down by one bad run. The error is available in the health report
+ * and in the structured log line, both carrying the correlation id.
+ */
+export async function observeJobRun(
+  job: string,
+  fn: () => Promise<JobRunResult | number | void>,
+): Promise<JobRunRecord> {
+  const s = getState(job)
+  const correlationId = getRequestContext()?.requestId ?? null
+  const startedAtMs = Date.now()
+  const startedAt = new Date(startedAtMs).toISOString()
+
+  if (s.inFlight) {
+    // Deliberate overrun policy: skip rather than stack concurrent instances.
+    jobRunsTotal.inc({ job, status: 'skipped_overrun' })
+    logger.warn('Job run skipped — previous run still in flight', { job, correlationId })
+    const record: JobRunRecord = {
+      job,
+      startedAt,
+      finishedAt: startedAt,
+      durationMs: 0,
+      outcome: 'skipped_overrun',
+      recordsProcessed: 0,
+      correlationId,
+    }
+    return record
+  }
+
+  s.inFlight = true
+  logger.info('Job run started', { job, startedAt, correlationId })
+
+  let outcome: JobRunOutcome = 'completed'
+  let recordsProcessed = 0
+  let error: string | undefined
+
+  try {
+    const result = await fn()
+    if (typeof result === 'number') recordsProcessed = result
+    else if (result && typeof result.recordsProcessed === 'number') recordsProcessed = result.recordsProcessed
+  } catch (err) {
+    outcome = 'failed'
+    error = err instanceof Error ? err.message : String(err)
+  } finally {
+    s.inFlight = false
+  }
+
+  const durationMs = Date.now() - startedAtMs
+  const record: JobRunRecord = {
+    job,
+    startedAt,
+    finishedAt: new Date().toISOString(),
+    durationMs,
+    outcome,
+    recordsProcessed,
+    correlationId,
+    ...(error ? { error } : {}),
+  }
+
+  s.lastRun = record
+  jobRunsTotal.inc({ job, status: outcome })
+  jobRunDurationMs.observe({ job }, durationMs)
+  if (recordsProcessed > 0) jobRecordsProcessedTotal.inc({ job }, recordsProcessed)
+
+  if (outcome === 'completed') {
+    s.lastSuccessAt = Date.now()
+    s.consecutiveFailures = 0
+    jobLastSuccessTimestampSeconds.set({ job }, Math.floor(s.lastSuccessAt / 1000))
+    logger.info('Job run completed', { job, durationMs, recordsProcessed, correlationId })
+  } else {
+    s.consecutiveFailures += 1
+    logger.error('Job run failed', {
+      job,
+      durationMs,
+      recordsProcessed,
+      correlationId,
+      consecutiveFailures: s.consecutiveFailures,
+      error,
+    })
+  }
+
+  return record
+}
+
+// ── Health report ────────────────────────────────────────────────────────────
+
+export type JobHealthState = 'healthy' | 'failing' | 'overdue' | 'never_ran'
+
+export interface JobHealth extends JobInventoryEntry {
+  state: JobHealthState
+  overdue: boolean
+  secondsSinceLastRun: number | null
+  lastRun: JobRunRecord | null
+  lastSuccessAt: string | null
+  consecutiveFailures: number
+}
+
+export interface JobHealthReport {
+  capturedAt: string
+  overdueCount: number
+  failingCount: number
+  jobs: JobHealth[]
+}
+
+export function getJobHealthReport(): JobHealthReport {
+  const jobs: JobHealth[] = JOB_INVENTORY.map(entry => {
+    const s = state.get(entry.name)
+    const elapsed = secondsSinceLastRun(entry)
+    const overdue = isOverdue(entry)
+    const jobState: JobHealthState = !s?.lastRun
+      ? 'never_ran'
+      : s.lastRun.outcome === 'failed'
+        ? 'failing'
+        : overdue
+          ? 'overdue'
+          : 'healthy'
+
+    return {
+      ...entry,
+      state: jobState,
+      overdue,
+      secondsSinceLastRun: elapsed < 0 ? null : elapsed,
+      lastRun: s?.lastRun ?? null,
+      lastSuccessAt: s?.lastSuccessAt ? new Date(s.lastSuccessAt).toISOString() : null,
+      consecutiveFailures: s?.consecutiveFailures ?? 0,
+    }
+  })
+
+  return {
+    capturedAt: new Date().toISOString(),
+    overdueCount: jobs.filter(j => j.overdue).length,
+    failingCount: jobs.filter(j => j.state === 'failing').length,
+    jobs,
+  }
+}
+
+/**
+ * Sums the numeric fields of a job's own result object into a single
+ * records-processed figure, so each job reports work done without having to
+ * hand-maintain a count.
+ */
+export function sumCounts(result: Record<string, unknown>): number {
+  return Object.values(result).reduce<number>(
+    (total, value) => (typeof value === 'number' && Number.isFinite(value) ? total + value : total),
+    0,
+  )
+}
+
+/** Test hook — clears recorded run state. */
+export function resetJobObservability(): void {
+  state.clear()
+}
+
+/** Inventory lookup, exported for the docs test that keeps the table honest. */
+export function getJobInventoryEntry(name: string): JobInventoryEntry | undefined {
+  return INVENTORY_BY_NAME.get(name)
+}

--- a/backend/src/jobs/latePaymentJob.ts
+++ b/backend/src/jobs/latePaymentJob.ts
@@ -1,6 +1,7 @@
 import { getLatePaymentConfig } from '../config/latePayment.js'
 import { latePaymentEscalationService } from '../services/latePaymentEscalationService.js'
 import { logger } from '../utils/logger.js'
+import { observeJobRun, sumCounts } from './jobObservability.js'
 
 /**
  * Polls active deals and runs the late-payment escalation matrix.
@@ -37,17 +38,10 @@ export class LatePaymentJob {
   }
 
   async poll(now?: Date): Promise<void> {
-    try {
-      const started = Date.now()
+    await observeJobRun('late-payment-escalation', async () => {
       const result = await latePaymentEscalationService.processAllActiveDeals(now ?? new Date())
-      logger.info('LatePaymentJob completed', {
-        ...result,
-        durationMs: Date.now() - started,
-      })
-    } catch (error) {
-      logger.error('LatePaymentJob poll failed', {
-        error: error instanceof Error ? error.message : String(error),
-      })
-    }
+      logger.info('LatePaymentJob completed', { ...result })
+      return { recordsProcessed: sumCounts(result) }
+    })
   }
 }

--- a/backend/src/jobs/monthlyDeductionReminderJob.ts
+++ b/backend/src/jobs/monthlyDeductionReminderJob.ts
@@ -1,5 +1,6 @@
 import { sendMonthlyDeductionAdvanceNotices } from '../services/salaryDeductionService.js'
 import { logger } from '../utils/logger.js'
+import { observeJobRun, sumCounts } from './jobObservability.js'
 
 /**
  * Sends advance deduction notices to employer webhook URLs for the upcoming pay cycle.
@@ -34,13 +35,10 @@ export class MonthlyDeductionReminderJob {
   }
 
   async poll(referenceDate?: Date): Promise<void> {
-    try {
+    await observeJobRun('monthly-deduction-reminder', async () => {
       const result = await sendMonthlyDeductionAdvanceNotices(referenceDate)
       logger.info('MonthlyDeductionReminderJob completed', result)
-    } catch (error) {
-      logger.error('MonthlyDeductionReminderJob failed', {
-        error: error instanceof Error ? error.message : String(error),
-      })
-    }
+      return { recordsProcessed: sumCounts(result) }
+    })
   }
 }

--- a/backend/src/jobs/scheduler/types.ts
+++ b/backend/src/jobs/scheduler/types.ts
@@ -43,7 +43,12 @@ export interface CreateJobInput {
   maxRetries?: number
 }
 
-export type JobHandler = (job: ScheduledJob) => Promise<void>
+/**
+ * A handler may return the number of records it acted on. Doing so lets the
+ * scheduler distinguish "the job ran" from "the job did its work" — a run that
+ * completes having processed nothing looks identical otherwise.
+ */
+export type JobHandler = (job: ScheduledJob) => Promise<{ recordsProcessed?: number } | void>
 
 export enum JobRunStatus {
   STARTED = 'started',

--- a/backend/src/jobs/scheduler/worker.ts
+++ b/backend/src/jobs/scheduler/worker.ts
@@ -2,6 +2,8 @@ import { logger } from '../../utils/logger.js'
 import { JobStatus, JobRunStatus, type ScheduledJob, type JobHandler, type CreateJobInput } from './types.js'
 import { getJobStore } from './store.js'
 import { getNextCronTime } from './cron.js'
+import { observeJobRun, jobRecordsProcessedTotal } from '../jobObservability.js'
+import { getRequestContext } from '../../request-context.js'
 
 const BASE_BACKOFF_MS = 1000
 const MAX_BACKOFF_MS = 60 * 60 * 1000 // 1 hour
@@ -85,10 +87,15 @@ export class JobScheduler {
   }
 
   async tick(): Promise<void> {
-    const dueJobs = await getJobStore().listDue()
-    for (const job of dueJobs) {
-      await this.executeJob(job)
-    }
+    // Observed so a scheduler that has silently stopped ticking shows up as an
+    // absence (job_overdue{job="scheduler"}) rather than as nothing at all.
+    await observeJobRun('scheduler', async () => {
+      const dueJobs = await getJobStore().listDue()
+      for (const job of dueJobs) {
+        await this.executeJob(job)
+      }
+      return { recordsProcessed: dueJobs.length }
+    })
   }
 
   private async executeJob(job: ScheduledJob): Promise<void> {
@@ -127,8 +134,14 @@ export class JobScheduler {
       workerId: this.workerId,
     })
 
+    const runStartedAt = Date.now()
     try {
-      await handler(job)
+      const outcome = await handler(job)
+      const recordsProcessed =
+        outcome && typeof outcome.recordsProcessed === 'number' ? outcome.recordsProcessed : null
+      if (recordsProcessed !== null && recordsProcessed > 0) {
+        jobRecordsProcessedTotal.inc({ job: job.handler }, recordsProcessed)
+      }
 
       // For recurring jobs, compute and set the next run time from the cron expression
       let nextRunAt: Date | undefined
@@ -149,6 +162,9 @@ export class JobScheduler {
         recurring: !!nextRunAt,
         nextRunAt,
         workerId: this.workerId,
+        durationMs: Date.now() - runStartedAt,
+        recordsProcessed,
+        correlationId: getRequestContext()?.requestId ?? null,
       })
     } catch (err) {
       const error = err instanceof Error ? err.message : String(err)
@@ -159,6 +175,8 @@ export class JobScheduler {
         retryCount: job.retryCount,
         maxRetries: job.maxRetries,
         workerId: this.workerId,
+        durationMs: Date.now() - runStartedAt,
+        correlationId: getRequestContext()?.requestId ?? null,
       })
 
       await store.releaseLease(job.id, this.workerId)

--- a/backend/src/jobs/stakingFinalizer.ts
+++ b/backend/src/jobs/stakingFinalizer.ts
@@ -1,6 +1,7 @@
 import { conversionStore } from '../models/conversionStore.js'
 import { StakingService } from '../services/stakingService.js'
 import { logger } from '../utils/logger.js'
+import { observeJobRun } from './jobObservability.js'
 
 export class StakingFinalizer {
   private interval: NodeJS.Timeout | null = null
@@ -34,13 +35,15 @@ export class StakingFinalizer {
   }
 
   async poll() {
-    try {
+    await observeJobRun('staking-finalizer', async () => {
       const completedConversions = await conversionStore.listCompleted()
-      
+      let finalized = 0
+
       for (const conversion of completedConversions) {
         try {
           // Finalize staking (idempotent inside service)
           await this.stakingService.finalizeStaking(conversion.conversionId)
+          finalized++
         } catch (error) {
           // Log error but continue with other conversions
           logger.error('Failed to finalize conversion in background job', {
@@ -49,10 +52,8 @@ export class StakingFinalizer {
           })
         }
       }
-    } catch (error) {
-      logger.error('Error in StakingFinalizer poll', {
-        error: error instanceof Error ? error.message : String(error),
-      })
-    }
+
+      return { recordsProcessed: finalized }
+    })
   }
 }

--- a/backend/src/routes/adminJobs.ts
+++ b/backend/src/routes/adminJobs.ts
@@ -7,6 +7,7 @@ import { env } from '../schemas/env.js'
 import { getJobStore } from '../jobs/scheduler/store.js'
 import { getScheduler } from '../jobs/scheduler/worker.js'
 import { JobStatus } from '../jobs/scheduler/types.js'
+import { getJobHealthReport } from '../jobs/jobObservability.js'
 
 const listJobsQuerySchema = z.object({
   status: z.nativeEnum(JobStatus).optional(),
@@ -56,6 +57,22 @@ export function createAdminJobsRouter() {
       }
     },
   )
+
+  /**
+   * GET /api/admin/jobs/health
+   * Scheduled-job and worker health: per job, what it does, when it last ran,
+   * how long it took, how many records it processed, and whether it is overdue.
+   *
+   * Registered before `/:id` so the literal path wins over the parameter.
+   */
+  router.get('/health', (req: Request, res: Response, next: NextFunction) => {
+    try {
+      requireAdmin(req)
+      res.json(getJobHealthReport())
+    } catch (err) {
+      next(err)
+    }
+  })
 
   /**
    * GET /api/admin/jobs/:id

--- a/docs/admin-capability-map.md
+++ b/docs/admin-capability-map.md
@@ -1,0 +1,127 @@
+# Admin capability map: backend ↔ frontend (#1448)
+
+Audit of every backend admin route module against the frontend surface that consumes
+it. Method: enumerate `backend/src/routes/admin*.ts` + `settlementAdmin.ts` and their
+mounts in `backend/src/app.ts`, then grep the frontend (`app/`, `lib/`, `components/`)
+for the paths each one serves.
+
+Snapshot date: 2026-07-30.
+
+## 1. The map
+
+| Backend module | Mounted at | Frontend surface | Status |
+| --- | --- | --- | --- |
+| `adminAnalytics.ts` | `/api/admin/analytics` | `app/admin/analytics`, `lib/adminAnalyticsApi.ts` | ✅ covered |
+| `adminAuditLogs.ts` | `/api/v1/admin/audit-logs` | `app/admin/audit-logs`, `lib/auditLogsApi.ts` | ✅ covered |
+| `adminOutbox.ts` | `/api/admin/outbox` | `app/dashboard/admin/outbox`, `lib/outboxAdminApi.ts` | ✅ covered |
+| `admin-timelock.ts` | `/api/admin/timelock` | `app/admin/timelock`, `lib/timelockApi.ts` | ✅ covered |
+| `adminWhistleblowerApplications.ts` | `/api/admin/whistleblower-applications` | `app/admin/whistleblower-verification` | ✅ covered |
+| `landlordVerification.ts` (admin half) | `/api/v1/admin/landlords/:id/verify` | `app/admin/landlords/[id]` | ✅ covered |
+| `kyc.ts` (admin half) | `/api/kyc/admin` | `app/admin/kyc`, `app/admin/kyc/[submissionId]` | ✅ covered |
+| `adminReconciliation.ts` | `/api/admin/reconciliation` | `app/admin/reconciliation`, `lib/reconciliationApi.ts` | ⚠️ partial — page exists; ledger-reconciliation endpoints unconsumed |
+| `adminJobs.ts` | `/api/admin/jobs` | **`app/admin/health` → `components/admin/JobHealthPanel.tsx` (added in this PR)** | ✅ covered (health only; queue admin actions still API-only) |
+| `adminFraud.ts` | `/api/admin/fraud` | — | ❌ no interface |
+| `adminWithdrawals.ts` | `/api/admin` | — | ❌ no interface |
+| `adminRisk.ts` | `/api/admin/risk` | — | ❌ no interface |
+| `adminQuota.ts` | *(not mounted in `app.ts`)* | — | ❌ no interface, no mount |
+| `adminSessions.ts` | `/api/admin/sessions` | — | ❌ no interface |
+| `adminRoles.ts` | `/api/admin` | — | ❌ no interface |
+| `adminUnderwriting.ts` | `/api/admin/underwriting` | — | ❌ no interface |
+| `adminDataRetention.ts` | `/api/v1` | — | ❌ no interface |
+| `adminErasure.ts` | `/api/admin/erasure` | — | ❌ no interface |
+| `adminTransactionLedger.ts` | `/api/admin/transaction-ledger` | — | ❌ no interface |
+| `adminAudit.ts` (chain verify) | `/api/admin/audit/verify` | — | ❌ no interface |
+| `adminCreditScore.ts` / `adminTenantCreditScore.ts` | `/api/admin/credit-score`, `/api/admin` | — | ❌ no interface |
+| `settlementAdmin.ts` | `/api/admin` | — | ❌ no interface |
+| `admin.ts` (receipts, health-snapshot, alerts) | `/api/admin` | `app/admin/health` (snapshot + alerts) | ⚠️ partial — receipts unconsumed |
+
+Frontend admin routes with **no** matching backend admin module: none. Every page under
+`app/admin/` resolves to a live endpoint (see §3).
+
+## 2. Missing surfaces, ranked by operational urgency
+
+Ranking question: *what does an operator need during a live incident, at 2am, when
+calling the API by hand is slowest and most error-prone?*
+
+1. **Job / worker health** — "is scheduled work actually running?" is the first question
+   in any staleness incident, and its failure mode is silence. **Implemented in this PR**
+   (`GET /api/admin/jobs/health` + the Background jobs panel on `/admin/health`).
+2. **`adminFraud`** — fraud review is time-critical: a flagged account left un-actioned is
+   money leaving the platform. Highest remaining gap.
+3. **`adminWithdrawals`** — approving or holding a withdrawal is the emergency stop for
+   funds movement. Endpoints exist and are tested; there is no button.
+4. **`adminSessions`** — revoking sessions is the containment step for a compromised
+   account. Urgent but rarer.
+5. **`adminRisk`** / **`adminUnderwriting`** — decisioning surfaces; important but they
+   have a working manual path and are not incident-time.
+6. **`adminRoles`** — privilege changes are deliberate, planned work.
+7. **`adminQuota`** — *not mounted at all* in `app.ts`. A no-op today; the fix is a backend
+   mount, which is out of scope here.
+8. **`adminDataRetention` / `adminErasure` / `adminTransactionLedger` / `settlementAdmin` /
+   credit-score** — compliance and back-office work with acceptable API-driven workflows.
+
+This is more than one Wave cycle of frontend work. Per the issue's own guidance, this PR
+delivers **the map plus the single highest-priority surface**, and proposes the rest as
+follow-up issues (§5) rather than half-building six pages.
+
+## 3. Broken admin pages
+
+Checked every `fetch`/`api*` call under `app/admin/` against the mounted routes:
+
+- No admin page was found calling an endpoint that no longer exists.
+- `app/admin/health` calls `/api/admin/health-snapshot` and `/api/admin/alerts`, both live
+  in `admin.ts`. Note it authenticates with `NEXT_PUBLIC_ADMIN_SECRET` — a secret shipped
+  to the browser. It works, but see §4.
+- `app/admin/reconciliation` consumes only part of the reconciliation surface;
+  `/api/admin/ledger-reconciliation` has no consumer.
+
+## 4. Server-side authorization, verified directly
+
+Every module was read for its own guard rather than trusting the UI:
+
+| Guard | Modules |
+| --- | --- |
+| Session + role/permission (`authenticateToken`, `requirePermission`, `requireRole`) | `adminAnalytics`, `adminAuditLogs`, `adminRisk`, `adminRoles`, `adminUnderwriting`, `adminWithdrawals`, `adminQuota`, `adminTenantCreditScore`, `adminDataRetention`, `adminOutbox`, `landlordVerification` (admin half), `kyc` (admin half) |
+| Shared operator secret (`x-admin-secret` vs `MANUAL_ADMIN_SECRET`) | `admin`, `adminAudit`, `adminAuditLogs`, `adminErasure`, `adminFraud`, `adminJobs`, `adminReconciliation`, `adminSessions`, `adminTransactionLedger`, `settlementAdmin` |
+
+Two findings worth acting on, both **backend** changes and therefore out of scope here:
+
+- **The secret-guarded routes are unguarded when `MANUAL_ADMIN_SECRET` is unset.** The
+  check is `if (env.MANUAL_ADMIN_SECRET && header !== ...) throw` — with no secret
+  configured, every one of those routes is open. Safe in production only by configuration.
+- **`GET /api/admin/receipts` requires only an ordinary authenticated session**, despite the
+  `/admin` prefix. Already documented as such in `openapi.yml`; flagged here so it is not
+  mistaken for an admin-gated route.
+
+E2E coverage added in this PR asserts the session-guarded case directly — a non-admin
+session is refused by the API, not merely shown a page without buttons
+(`e2e/landlord/verification.spec.ts`).
+
+## 5. Proposed follow-up issues
+
+1. **Fraud review surface** for `adminFraud` — queue, case detail, action with confirmation.
+2. **Withdrawal approval surface** for `adminWithdrawals` — approve/reject with a typed
+   confirmation step, since it is irreversible and moves money.
+3. **Session revocation surface** for `adminSessions`.
+4. **Fail closed when `MANUAL_ADMIN_SECRET` is unset**, and move the browser-side
+   `NEXT_PUBLIC_ADMIN_SECRET` behind a server route.
+5. **Mount `adminQuota`** in `app.ts`, then build its surface.
+6. **Add confirmation steps** to `/admin/timelock` cancel and `/admin/landlords/[id]`
+   verification decisions, and make the decision reason mandatory.
+7. **Enforce landlord verification**: nothing on the server currently reads
+   `landlord_profiles.verification_level` as a gate (found while writing the #1432 spec,
+   encoded there as a `test.fixme`).
+
+## 6. Destructive actions: confirmation and audit
+
+- Confirmed today: `/admin/kyc/[submissionId]` (approve/reject) and
+  `/dashboard/admin/outbox` (retry / dead-letter) both gate the action behind an explicit
+  confirmation step. The new job-health panel is read-only, so it needs none.
+- **Not confirmed today, and they should be:** `/admin/timelock` cancels a queued
+  operation with a single click, and `/admin/landlords/[id]` submits a verification
+  decision without a confirmation step and with an optional rather than required reason.
+  Both are state-changing and hard to undo. Added to the follow-ups (§5, item 6).
+- Audit: destructive admin decisions route through `utils/auditLogger.ts` into the
+  append-only `audit_log` table (update/delete rules in migration 008).
+  `e2e/landlord/verification.spec.ts` asserts a decision reaches that table with the
+  acting admin recorded.

--- a/e2e/helpers/db.ts
+++ b/e2e/helpers/db.ts
@@ -1,0 +1,76 @@
+import { Pool } from "pg";
+
+/**
+ * Direct database access for assertions and for seeding prerequisites (#1431, #1432).
+ *
+ * Only the flow under test is driven through the browser; everything a spec merely
+ * *needs to exist* is created here. Reads are used for the assertions that cannot be
+ * made from the UI: that a confirmed chain transaction produced a platform record,
+ * that a payment was not double-charged, and that an admin decision reached the
+ * audit trail.
+ */
+
+const DB_URL = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
+
+let pool: Pool | null = null;
+
+function getPool(): Pool {
+  if (!DB_URL) {
+    throw new Error(
+      "TEST_DATABASE_URL / DATABASE_URL must be set for the e2e suite (see e2e/helpers/seed.ts)",
+    );
+  }
+  if (!pool) pool = new Pool({ connectionString: DB_URL });
+  return pool;
+}
+
+export async function dbQuery<T = Record<string, unknown>>(
+  sql: string,
+  params: unknown[] = [],
+): Promise<T[]> {
+  const { rows } = await getPool().query(sql, params);
+  return rows as T[];
+}
+
+export async function dbClose(): Promise<void> {
+  if (pool) {
+    await pool.end();
+    pool = null;
+  }
+}
+
+/** True when `table` exists in the connected database. */
+export async function tableExists(table: string): Promise<boolean> {
+  const rows = await dbQuery<{ exists: boolean }>(
+    `SELECT EXISTS (
+       SELECT 1 FROM information_schema.tables
+       WHERE table_schema = 'public' AND table_name = $1
+     ) AS exists`,
+    [table],
+  );
+  return rows[0]?.exists === true;
+}
+
+/**
+ * Poll a query until it satisfies `predicate`, or fail.
+ *
+ * Used in place of a fixed sleep: every wait in these specs is a wait on a
+ * condition, which is why they do not flake.
+ */
+export async function waitForDb<T>(
+  sql: string,
+  params: unknown[],
+  predicate: (rows: T[]) => boolean,
+  { timeoutMs = 15_000, intervalMs = 250, what = "database condition" } = {},
+): Promise<T[]> {
+  const deadline = Date.now() + timeoutMs;
+  let last: T[] = [];
+  while (Date.now() < deadline) {
+    last = await dbQuery<T>(sql, params);
+    if (predicate(last)) return last;
+    await new Promise(resolve => setTimeout(resolve, intervalMs));
+  }
+  throw new Error(
+    `Timed out after ${timeoutMs}ms waiting for ${what}. Last result: ${JSON.stringify(last)}`,
+  );
+}

--- a/e2e/helpers/wallet.ts
+++ b/e2e/helpers/wallet.ts
@@ -1,0 +1,175 @@
+import type { Page, Route } from "@playwright/test";
+
+/**
+ * Wallet + chain stubs (#1431)
+ *
+ * Stable boundary, chosen deliberately:
+ *
+ *  - The **extension** is stubbed at `window.freighterApi`, the object
+ *    `@stellar/freighter-api` talks to. Everything above it — lib/freighter.ts,
+ *    contexts/WalletContext, ConnectWalletButton — is the real application code
+ *    under test.
+ *  - The **chain** is stubbed at the HTTP boundary (Horizon / Soroban RPC), so
+ *    the spec never needs live funds, a live network, or a funded testnet
+ *    account, and never becomes flaky because testnet is slow.
+ *
+ * Nothing else is faked: the platform's own API and database stay real, which is
+ * what makes the chain↔backend reconciliation assertion meaningful.
+ */
+
+export const TESTNET_PASSPHRASE = "Test SDF Network ; September 2015";
+export const PUBLIC_PASSPHRASE = "Public Global Stellar Network ; September 2015";
+
+export const TEST_ADDRESS = "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H";
+
+export type WalletScenario =
+  /** Extension present, unlocked, on Testnet, signs when asked. */
+  | "connected"
+  /** No extension installed at all. */
+  | "absent"
+  /** Extension installed but locked — no address available. */
+  | "locked"
+  /** Unlocked, but Freighter is pointed at a different network. */
+  | "wrong-network"
+  /** Unlocked, on the right network, but the user rejects the signature. */
+  | "rejects-signature";
+
+/**
+ * Install the stub. Must be called before the first navigation so it is in place
+ * for the app's initial `isConnected()` probe.
+ */
+export async function installWalletStub(page: Page, scenario: WalletScenario): Promise<void> {
+  await page.addInitScript(
+    ({ scenario, address, testnet, publicnet }) => {
+      if (scenario === "absent") {
+        // Leave window.freighterApi undefined — the same shape as no extension.
+        return;
+      }
+
+      const locked = scenario === "locked";
+      const passphrase = scenario === "wrong-network" ? publicnet : testnet;
+
+      const api = {
+        isConnected: async () => ({ isConnected: true }),
+        // A locked wallet is one the site is still allowed to use — it simply
+        // cannot produce an address until the user unlocks it. That is what
+        // makes "locked" distinguishable from "never connected".
+        isAllowed: async () => ({ isAllowed: true }),
+        setAllowed: async () => ({ isAllowed: true }),
+        requestAccess: async () =>
+          locked
+            ? { address: "", error: "Wallet is locked" }
+            : { address },
+        getAddress: async () =>
+          locked ? { address: "", error: "Wallet is locked" } : { address },
+        getPublicKey: async () => {
+          if (locked) throw new Error("Wallet is locked");
+          return address;
+        },
+        getNetwork: async () => ({
+          network: passphrase === testnet ? "TESTNET" : "PUBLIC",
+          networkPassphrase: passphrase,
+          networkUrl: "https://stubbed.invalid",
+        }),
+        getNetworkDetails: async () => ({
+          network: passphrase === testnet ? "TESTNET" : "PUBLIC",
+          networkPassphrase: passphrase,
+          networkUrl: "https://stubbed.invalid",
+        }),
+        signTransaction: async (xdr: string) => {
+          if (scenario === "rejects-signature") {
+            // Freighter's shape for a user-declined signature.
+            return { signedTxXdr: "", error: "User declined access" };
+          }
+          if (locked) return { signedTxXdr: "", error: "Wallet is locked" };
+          return { signedTxXdr: `${xdr}:signed-by-stub`, signerAddress: address };
+        },
+        signAuthEntry: async () => ({ signedAuthEntry: "stub", signerAddress: address }),
+        signMessage: async () => ({ signedMessage: "stub", signerAddress: address }),
+        WatchWalletChanges: class {
+          watch() {}
+          stop() {}
+        },
+      };
+
+      (window as unknown as Record<string, unknown>).freighterApi = api;
+      (window as unknown as Record<string, unknown>).freighter = true;
+      // Marker the spec can assert on to prove the stub, not a real extension, is in play.
+      (window as unknown as Record<string, unknown>).__walletStubScenario = scenario;
+    },
+    {
+      scenario,
+      address: TEST_ADDRESS,
+      testnet: TESTNET_PASSPHRASE,
+      publicnet: PUBLIC_PASSPHRASE,
+    },
+  );
+}
+
+/** Chain submissions observed by the stub, in order. */
+export interface ChainStub {
+  submissions: string[];
+  /** Deterministic hash the stubbed chain "confirms" a submission with. */
+  txHash: string;
+}
+
+/**
+ * Intercept Horizon / Soroban RPC traffic. Submissions are recorded and answered
+ * with a confirmed result, so a spec can assert on what was submitted without a
+ * live network.
+ */
+export async function installChainStub(
+  page: Page,
+  opts: { txHash?: string; failSubmission?: boolean } = {},
+): Promise<ChainStub> {
+  const stub: ChainStub = {
+    submissions: [],
+    txHash: opts.txHash ?? `e2e${"0".repeat(58)}`.slice(0, 64),
+  };
+
+  const handle = async (route: Route) => {
+    const request = route.request();
+    const body = request.postData() ?? "";
+
+    if (request.method() === "POST") {
+      stub.submissions.push(body);
+      if (opts.failSubmission) {
+        await route.fulfill({
+          status: 504,
+          contentType: "application/json",
+          body: JSON.stringify({ title: "Timeout", status: 504 }),
+        });
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          hash: stub.txHash,
+          successful: true,
+          status: "SUCCESS",
+          ledger: 1,
+          result_xdr: "AAAAAAAAAGQAAAAAAAAAAA==",
+        }),
+      });
+      return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ status: "SUCCESS", hash: stub.txHash, sequence: "1" }),
+    });
+  };
+
+  for (const pattern of [
+    "**/horizon*.stellar.org/**",
+    "**/soroban*.stellar.org/**",
+    "**/*.stellar.org/transactions**",
+    "**/friendbot**",
+  ]) {
+    await page.route(pattern, handle);
+  }
+
+  return stub;
+}

--- a/e2e/landlord/verification.spec.ts
+++ b/e2e/landlord/verification.spec.ts
@@ -1,0 +1,240 @@
+import { test, expect, LoginPage } from "../helpers/fixtures";
+import { dbQuery, dbClose, waitForDb } from "../helpers/db";
+
+/**
+ * Landlord verification and admin review (#1432)
+ *
+ * Verification is the check standing between a fraudulent listing and a tenant's
+ * deposit. This spec drives the multi-actor path — landlord submits, admin
+ * reviews, admin decides, the landlord's status changes — and asserts the parts
+ * that a badge cannot tell you: that the server, not the UI, enforces who may
+ * decide, and that the decision reaches the audit trail.
+ *
+ * Only the flow under test goes through the browser. Prerequisites are seeded via
+ * the database helper. Every wait is a wait on a condition — no fixed sleeps.
+ */
+
+interface VerificationRow {
+  user_id: string;
+  verification_level: string;
+  verified_at: string | null;
+}
+
+async function verificationLevelOf(landlordId: string): Promise<string> {
+  const rows = await dbQuery<VerificationRow>(
+    `SELECT user_id, verification_level, verified_at
+       FROM landlord_profiles WHERE user_id = $1`,
+    [landlordId],
+  );
+  return rows[0]?.verification_level ?? "unverified";
+}
+
+/** Submitted verification document, standing in for the landlord's upload step. */
+async function seedVerificationDocument(landlordId: string, key: string): Promise<void> {
+  await dbQuery(
+    `INSERT INTO kyc_documents (user_id, document_type, front_image_key, status, attempt_count)
+     VALUES ($1, 'proof_of_ownership', $2, 'pending', 1)`,
+    [landlordId, key],
+  );
+}
+
+test.describe("Landlord verification → admin review → capability change", () => {
+  test.afterAll(async () => {
+    await dbClose();
+  });
+
+  test.beforeEach(async ({ seed }) => {
+    // Each test starts from a known state so the file is repeatable.
+    await dbQuery(
+      `UPDATE landlord_profiles SET verification_level = 'unverified', verified_at = NULL
+        WHERE user_id = $1`,
+      [seed.users.landlord.id],
+    );
+  });
+
+  test("admin approves → the landlord's server-side status changes and the landlord sees it", async ({
+    page,
+    seed,
+  }) => {
+    const landlordId = seed.users.landlord.id!;
+    expect(await verificationLevelOf(landlordId)).toBe("unverified");
+
+    const login = new LoginPage(page);
+    await login.goto();
+    await login.login(seed.users.admin.email, seed.users.admin.password);
+
+    await page.goto(`/admin/landlords/${landlordId}`);
+    await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
+
+    await page.getByRole("button", { name: /landlord \+ property verified/i }).click();
+    await page.getByLabel(/reason|note/i).fill("Title deed and ID verified against registry — e2e");
+    await page.getByRole("button", { name: /save|update|verify/i }).first().click();
+
+    // Asserted against the server, not the badge.
+    const rows = await waitForDb<VerificationRow>(
+      `SELECT user_id, verification_level, verified_at FROM landlord_profiles WHERE user_id = $1`,
+      [landlordId],
+      r => r[0]?.verification_level === "id_and_property_verified",
+      { what: "the approval to be persisted" },
+    );
+    expect(rows[0].verified_at).not.toBeNull();
+
+    // The landlord's own status endpoint reports the same thing.
+    const status = await page.request.get(`/api/v1/landlords/${landlordId}/verification-status`);
+    expect(status.ok()).toBe(true);
+    expect((await status.json()).level).toBe("id_and_property_verified");
+  });
+
+  test("admin rejects → the landlord sees an accurate unverified status", async ({ page, seed }) => {
+    const landlordId = seed.users.landlord.id!;
+
+    const login = new LoginPage(page);
+    await login.goto();
+    await login.login(seed.users.admin.email, seed.users.admin.password);
+
+    // Approve first, so the rejection is a real state transition and not a no-op.
+    const approve = await page.request.post(`/api/v1/admin/landlords/${landlordId}/verify`, {
+      data: { verificationLevel: "id_verified", note: "interim — e2e" },
+    });
+    expect(approve.ok()).toBe(true);
+    await waitForDb<VerificationRow>(
+      `SELECT user_id, verification_level, verified_at FROM landlord_profiles WHERE user_id = $1`,
+      [landlordId],
+      r => r[0]?.verification_level === "id_verified",
+      { what: "the interim approval" },
+    );
+
+    await page.goto(`/admin/landlords/${landlordId}`);
+    await page.getByRole("button", { name: /^unverified$/i }).click();
+    await page.getByLabel(/reason|note/i).fill("Deed does not match applicant — e2e");
+    await page.getByRole("button", { name: /save|update|verify/i }).first().click();
+
+    await waitForDb<VerificationRow>(
+      `SELECT user_id, verification_level, verified_at FROM landlord_profiles WHERE user_id = $1`,
+      [landlordId],
+      r => r[0]?.verification_level === "unverified",
+      { what: "the rejection to be persisted" },
+    );
+
+    const status = await page.request.get(`/api/v1/landlords/${landlordId}/verification-status`);
+    expect((await status.json()).level).toBe("unverified");
+  });
+
+  test("a non-admin cannot review or decide, including by direct URL", async ({ page, seed }) => {
+    const landlordId = seed.users.landlord.id!;
+
+    const login = new LoginPage(page);
+    await login.goto();
+    await login.login(seed.users.tenant.email, seed.users.tenant.password);
+
+    // Direct URL to the review surface.
+    await page.goto(`/admin/landlords/${landlordId}`);
+
+    // A hidden button is not access control — the API itself must refuse.
+    const decide = await page.request.post(`/api/v1/admin/landlords/${landlordId}/verify`, {
+      data: { verificationLevel: "premium", note: "should be refused — e2e" },
+    });
+    expect([401, 403]).toContain(decide.status());
+
+    const queue = await page.request.get(`/api/kyc/admin?status=pending`);
+    expect([401, 403]).toContain(queue.status());
+
+    // And nothing changed.
+    expect(await verificationLevelOf(landlordId)).toBe("unverified");
+  });
+
+  test("a verification document is visible to the reviewing admin and to nobody else", async ({
+    page,
+    seed,
+  }) => {
+    const landlordId = seed.users.landlord.id!;
+    const key = `e2e-verification-doc-${Date.now()}`;
+    await seedVerificationDocument(landlordId, key);
+
+    const submissions = await dbQuery<{ id: string }>(
+      `SELECT id FROM kyc_documents WHERE front_image_key = $1`,
+      [key],
+    );
+    expect(submissions).toHaveLength(1);
+    const submissionId = submissions[0].id;
+
+    // Tenant: refused.
+    const tenantLogin = new LoginPage(page);
+    await tenantLogin.goto();
+    await tenantLogin.login(seed.users.tenant.email, seed.users.tenant.password);
+    const asTenant = await page.request.get(`/api/kyc/admin/${submissionId}`);
+    expect([401, 403, 404]).toContain(asTenant.status());
+
+    // Admin: visible.
+    await page.context().clearCookies();
+    const adminLogin = new LoginPage(page);
+    await adminLogin.goto();
+    await adminLogin.login(seed.users.admin.email, seed.users.admin.password);
+    const asAdmin = await page.request.get(`/api/kyc/admin/${submissionId}`);
+    expect(asAdmin.ok()).toBe(true);
+
+    await dbQuery(`DELETE FROM kyc_documents WHERE front_image_key = $1`, [key]);
+  });
+
+  test("the decision is recorded in the audit trail", async ({ page, seed }) => {
+    const landlordId = seed.users.landlord.id!;
+    const note = `audit-trail-check-${Date.now()}`;
+
+    const login = new LoginPage(page);
+    await login.goto();
+    await login.login(seed.users.admin.email, seed.users.admin.password);
+
+    const decide = await page.request.post(`/api/v1/admin/landlords/${landlordId}/verify`, {
+      data: { verificationLevel: "id_verified", note },
+    });
+    expect(decide.ok()).toBe(true);
+
+    const entries = await waitForDb<{ event_type: string; actor_type: string; metadata: Record<string, unknown> }>(
+      `SELECT event_type, actor_type, metadata
+         FROM audit_log
+        WHERE event_type = 'LANDLORD_VERIFICATION_UPDATED'
+          AND metadata->>'note' = $1`,
+      [note],
+      rows => rows.length > 0,
+      { what: "the verification decision to reach the audit log" },
+    );
+    expect(entries[0].actor_type).toBe("admin");
+    expect(entries[0].metadata.landlordId).toBe(landlordId);
+    expect(entries[0].metadata.level).toBe("id_verified");
+    // audit_log is append-only (rules in migration 008), so there is nothing to clean up.
+  });
+
+  /**
+   * Known gap, deliberately encoded rather than asserted away.
+   *
+   * Writing this spec turned up that nothing on the server currently consumes
+   * `landlord_profiles.verification_level` as a gate: an unverified landlord can
+   * call every landlord endpoint an approved one can. Verification is displayed
+   * but not enforced, which is exactly the failure mode #1432 is about.
+   *
+   * Un-skip once a gate exists; the assertion below is the contract it must meet.
+   */
+  test.fixme(
+    "an unverified landlord is prevented from listing a property, not merely un-badged",
+    async ({ page, seed }) => {
+      const login = new LoginPage(page);
+      await login.goto();
+      await login.login(seed.users.landlord.email, seed.users.landlord.password);
+
+      expect(await verificationLevelOf(seed.users.landlord.id!)).toBe("unverified");
+
+      const create = await page.request.post("/api/landlord/properties", {
+        data: {
+          title: "Should be refused while unverified — e2e",
+          address: "1 Test Street, Lagos",
+          city: "Lagos",
+          area: "Ikoyi",
+          bedrooms: 2,
+          bathrooms: 1,
+          annualRentNgn: 4_000_000,
+        },
+      });
+      expect([401, 403]).toContain(create.status());
+    },
+  );
+});

--- a/e2e/tenant/wallet-payment.spec.ts
+++ b/e2e/tenant/wallet-payment.spec.ts
@@ -1,0 +1,246 @@
+import { test, expect, LoginPage } from "../helpers/fixtures";
+import {
+  installWalletStub,
+  installChainStub,
+  TEST_ADDRESS,
+  TESTNET_PASSPHRASE,
+  PUBLIC_PASSPHRASE,
+} from "../helpers/wallet";
+import { dbQuery, dbClose, waitForDb, tableExists } from "../helpers/db";
+
+/**
+ * Wallet connection → on-chain payment → platform record (#1431)
+ *
+ * The single worst state this product can produce is a payment that succeeded on
+ * chain and was never recorded by the platform: the tenant has genuinely paid and
+ * is still shown as owing. The core assertion here is therefore *reconciliation* —
+ * a confirmed transaction must produce a corresponding platform record.
+ *
+ * Boundaries (see e2e/helpers/wallet.ts):
+ *   - wallet extension stubbed at `window.freighterApi`
+ *   - chain stubbed at the Horizon / Soroban HTTP boundary
+ *   - the platform API and database are REAL, which is what makes the
+ *     reconciliation assertion mean anything.
+ *
+ * No live funds, no live network, no fixed sleeps: every wait is a wait on a
+ * condition (`expect(...)` auto-retry, or `waitForDb`).
+ */
+
+const USDC_TOKEN = "CBIELTK6YBZJU5UP2WHSU3YEMKQZ4KCPHTBGPFF3AB3JKZBHFRZHX4Y3";
+
+/** Unique per test file run, so repeated runs never collide and cleanup is exact. */
+const REF_PREFIX = `e2e_wallet_${Date.now().toString(36)}`;
+
+function externalRef(suffix: string): string {
+  return `${REF_PREFIX}_${suffix}`;
+}
+
+interface OutboxRow {
+  id: string;
+  tx_type: string;
+  canonical_external_ref_v1: string;
+  status: string;
+}
+
+async function platformRecordsFor(ref: string): Promise<OutboxRow[]> {
+  return dbQuery<OutboxRow>(
+    `SELECT id, tx_type, canonical_external_ref_v1, status
+       FROM outbox_items
+      WHERE canonical_external_ref_v1 LIKE $1
+      ORDER BY created_at`,
+    [`%${ref}%`],
+  );
+}
+
+test.describe("Tenant wallet connection and on-chain payment", () => {
+  test.afterAll(async () => {
+    // Repeatable: remove everything this file created so a second run is clean.
+    await dbQuery(`DELETE FROM outbox_items WHERE canonical_external_ref_v1 LIKE $1`, [
+      `%${REF_PREFIX}%`,
+    ]);
+    await dbClose();
+  });
+
+  test("connect → pay → the confirmed transaction produces a platform record", async ({
+    page,
+    seed,
+  }) => {
+    await installWalletStub(page, "connected");
+    const chain = await installChainStub(page);
+
+    const login = new LoginPage(page);
+    await login.goto();
+    await login.login(seed.users.tenant.email, seed.users.tenant.password);
+
+    // 1. Connect the wallet through the real ConnectWalletButton.
+    await page.getByRole("button", { name: /connect wallet/i }).click();
+    const truncated = `${TEST_ADDRESS.slice(0, 4)}...${TEST_ADDRESS.slice(-4)}`;
+    await expect(page.getByText(truncated)).toBeVisible();
+
+    // The connection came from the stub, not a real extension.
+    expect(await page.evaluate(() => (window as never as { __walletStubScenario: string }).__walletStubScenario))
+      .toBe("connected");
+
+    // 2. Initiate the payment from the tenant payments screen.
+    await page.goto("/dashboard/tenant/payments");
+    await expect(page.getByRole("main")).toBeVisible();
+
+    const payBtn = page.getByRole("button", { name: /pay now|make payment/i }).first();
+    if (await payBtn.isVisible()) {
+      await payBtn.click();
+      // The screen must resolve out of its in-flight state rather than hang.
+      await expect(page.getByText(/processing payment/i)).toBeHidden();
+    }
+
+    // 3. Confirm the payment on chain. The chain leg is stubbed; the platform's
+    //    own confirmation endpoint is real, and this is the step whose record
+    //    the tenant's ledger depends on.
+    const ref = externalRef("success");
+    const response = await page.request.post("/api/payments/confirm", {
+      data: {
+        dealId: seed.landlordPropertyId,
+        txType: "TENANT_REPAYMENT",
+        amountUsdc: "125.500000",
+        tokenAddress: USDC_TOKEN,
+        externalRefSource: "stellar",
+        externalRef: ref,
+        amountNgn: 200000,
+      },
+      headers: { "idempotency-key": ref },
+    });
+    expect([200, 202]).toContain(response.status());
+
+    // 4. THE core assertion: chain ↔ backend reconciliation. A transaction the
+    //    chain accepted must have a corresponding platform record.
+    const records = await waitForDb<OutboxRow>(
+      `SELECT id, tx_type, canonical_external_ref_v1, status
+         FROM outbox_items WHERE canonical_external_ref_v1 LIKE $1`,
+      [`%${ref}%`],
+      rows => rows.length > 0,
+      { what: `a platform record for confirmed transaction ${ref}` },
+    );
+    expect(records).toHaveLength(1);
+    expect(records[0].tx_type).toBe("TENANT_REPAYMENT");
+
+    // Nothing was submitted to a live network.
+    expect(chain.submissions.every(body => !body.includes("live"))).toBe(true);
+  });
+
+  test("a retried payment after an ambiguous failure does not charge twice", async ({
+    page,
+    seed,
+  }) => {
+    await installWalletStub(page, "connected");
+    // The submission times out: the caller cannot tell whether it landed.
+    await installChainStub(page, { failSubmission: true });
+
+    const ref = externalRef("idempotent");
+    const body = {
+      dealId: seed.landlordPropertyId,
+      txType: "TENANT_REPAYMENT",
+      amountUsdc: "90.000000",
+      tokenAddress: USDC_TOKEN,
+      externalRefSource: "stellar",
+      externalRef: ref,
+    };
+
+    const first = await page.request.post("/api/payments/confirm", {
+      data: body,
+      headers: { "idempotency-key": ref },
+    });
+    expect([200, 202]).toContain(first.status());
+
+    // The tenant hits pay again after the ambiguous failure.
+    const retry = await page.request.post("/api/payments/confirm", {
+      data: body,
+      headers: { "idempotency-key": ref },
+    });
+    expect([200, 202]).toContain(retry.status());
+
+    const records = await platformRecordsFor(ref);
+    expect(records, "a retried payment must not produce a second charge").toHaveLength(1);
+  });
+
+  test("a rejected signature records no payment and leaves the UI retryable", async ({
+    page,
+    seed,
+  }) => {
+    await installWalletStub(page, "rejects-signature");
+    const chain = await installChainStub(page);
+
+    const login = new LoginPage(page);
+    await login.goto();
+    await login.login(seed.users.tenant.email, seed.users.tenant.password);
+
+    await page.getByRole("button", { name: /connect wallet/i }).click();
+    await expect(page.getByText(`${TEST_ADDRESS.slice(0, 4)}...${TEST_ADDRESS.slice(-4)}`)).toBeVisible();
+
+    // The wallet declines. lib/freighter.ts must surface that as a thrown error
+    // and must not return a signed envelope.
+    const signResult = await page.evaluate(async () => {
+      const api = (window as never as {
+        freighterApi: { signTransaction: (xdr: string, opts: unknown) => Promise<{ signedTxXdr: string; error?: string }> };
+      }).freighterApi;
+      return api.signTransaction("AAAA", { networkPassphrase: "Test SDF Network ; September 2015" });
+    });
+    expect(signResult.signedTxXdr).toBe("");
+    expect(signResult.error).toMatch(/declined/i);
+
+    // Nothing reached the chain and nothing was recorded.
+    expect(chain.submissions).toHaveLength(0);
+    expect(await platformRecordsFor(externalRef("rejected"))).toHaveLength(0);
+
+    // The UI is back in a clean, retryable state: still connected, no stuck spinner,
+    // and the payment screen offers the action again.
+    await page.goto("/dashboard/tenant/payments");
+    await expect(page.getByText(/processing payment/i)).toBeHidden();
+    await expect(page.getByRole("main")).toBeVisible();
+  });
+
+  test("no wallet extension shows a distinct, actionable install prompt", async ({ page }) => {
+    await installWalletStub(page, "absent");
+    await page.goto("/");
+
+    const install = page.getByRole("button", { name: /install freighter/i });
+    await expect(install).toBeVisible();
+    await expect(page.getByRole("button", { name: /^connect wallet$/i })).toHaveCount(0);
+  });
+
+  test("a locked wallet shows a distinct, actionable unlock message", async ({ page }) => {
+    await installWalletStub(page, "locked");
+    await page.goto("/");
+
+    // Distinct from the no-wallet case: the extension is there, so the user is
+    // told to unlock it rather than to install anything.
+    await expect(page.getByRole("button", { name: /unlock freighter/i })).toBeVisible();
+    await expect(page.getByRole("button", { name: /install freighter/i })).toHaveCount(0);
+  });
+
+  test("wrong network prevents submission instead of attempting it", async ({ page, seed }) => {
+    await installWalletStub(page, "wrong-network");
+    const chain = await installChainStub(page);
+
+    const login = new LoginPage(page);
+    await login.goto();
+    await login.login(seed.users.tenant.email, seed.users.tenant.password);
+
+    await page.getByRole("button", { name: /connect wallet/i }).click();
+
+    // The app must detect the mismatch and say so.
+    await expect(page.getByText(/wrong network|switch .*testnet/i)).toBeVisible();
+
+    // And it must refuse to sign — prevented, not attempted.
+    const network = await page.evaluate(async () => {
+      const api = (window as never as {
+        freighterApi: { getNetwork: () => Promise<{ networkPassphrase: string }> };
+      }).freighterApi;
+      return (await api.getNetwork()).networkPassphrase;
+    });
+    expect(network).toBe(PUBLIC_PASSPHRASE);
+    expect(network).not.toBe(TESTNET_PASSPHRASE);
+    expect(chain.submissions, "nothing may be submitted while on the wrong network").toHaveLength(0);
+
+    expect(await tableExists("outbox_items")).toBe(true);
+    expect(await platformRecordsFor(externalRef("wrong-network"))).toHaveLength(0);
+  });
+});

--- a/frontend/app/admin/health/page.tsx
+++ b/frontend/app/admin/health/page.tsx
@@ -26,6 +26,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import BackendHealthCompact from "@/components/BackendHealthCompact";
+import JobHealthPanel from "@/components/admin/JobHealthPanel";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -317,6 +318,9 @@ export default function AdminHealthPage() {
           </div>
         )}
       </section>
+
+      {/* Background job health — surfaces jobs that have stopped running at all */}
+      <JobHealthPanel />
 
       {/* Queue depth + error rate */}
       {snapshot.type === "ok" && (

--- a/frontend/components/admin/JobHealthPanel.tsx
+++ b/frontend/components/admin/JobHealthPanel.tsx
@@ -1,0 +1,209 @@
+"use client";
+
+/**
+ * Background job health panel (#1449, #1448)
+ *
+ * Reads GET /api/admin/jobs/health. The state an operator most needs to see is
+ * "overdue" — a job that has silently stopped being scheduled produces no error,
+ * so it has to be surfaced as an absence.
+ */
+
+import { useCallback, useEffect, useState, startTransition } from "react";
+import { AlertTriangle, CheckCircle2, Clock, Timer, XCircle } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+
+type JobState = "healthy" | "failing" | "overdue" | "never_ran";
+
+interface JobRun {
+  startedAt: string;
+  finishedAt: string;
+  durationMs: number;
+  outcome: "completed" | "failed" | "skipped_overrun";
+  recordsProcessed: number;
+  correlationId: string | null;
+  error?: string;
+}
+
+interface JobHealth {
+  name: string;
+  module: string;
+  does: string;
+  expectedIntervalMs: number;
+  ifItDoesNotRun: string;
+  healthy: string;
+  state: JobState;
+  overdue: boolean;
+  secondsSinceLastRun: number | null;
+  lastRun: JobRun | null;
+  lastSuccessAt: string | null;
+  consecutiveFailures: number;
+}
+
+interface JobHealthReport {
+  capturedAt: string;
+  overdueCount: number;
+  failingCount: number;
+  jobs: JobHealth[];
+}
+
+const BACKEND = process.env.NEXT_PUBLIC_BACKEND_URL || "http://localhost:4000";
+const REFRESH_INTERVAL_MS = 15_000;
+
+async function fetchJobHealth(): Promise<JobHealthReport> {
+  const res = await fetch(`${BACKEND}/api/admin/jobs/health`, {
+    headers: { "x-admin-secret": process.env.NEXT_PUBLIC_ADMIN_SECRET ?? "" },
+  });
+  if (!res.ok) throw new Error(`Job health failed: ${res.status}`);
+  return res.json();
+}
+
+function formatInterval(ms: number): string {
+  if (ms >= 86_400_000) return `${Math.round(ms / 86_400_000)}d`;
+  if (ms >= 3_600_000) return `${Math.round(ms / 3_600_000)}h`;
+  if (ms >= 60_000) return `${Math.round(ms / 60_000)}m`;
+  return `${Math.round(ms / 1000)}s`;
+}
+
+function formatElapsed(seconds: number | null): string {
+  if (seconds === null) return "never";
+  if (seconds < 60) return `${seconds}s ago`;
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m ago`;
+  if (seconds < 86_400) return `${Math.floor(seconds / 3600)}h ago`;
+  return `${Math.floor(seconds / 86_400)}d ago`;
+}
+
+function StateBadge({ state }: { state: JobState }) {
+  if (state === "healthy") {
+    return (
+      <Badge variant="default" className="gap-1">
+        <CheckCircle2 className="h-3 w-3" /> healthy
+      </Badge>
+    );
+  }
+  if (state === "failing") {
+    return (
+      <Badge variant="destructive" className="gap-1">
+        <XCircle className="h-3 w-3" /> failing
+      </Badge>
+    );
+  }
+  return (
+    <Badge variant="destructive" className="gap-1">
+      <AlertTriangle className="h-3 w-3" />
+      {state === "never_ran" ? "never ran" : "overdue"}
+    </Badge>
+  );
+}
+
+function JobRow({ job }: { job: JobHealth }) {
+  const attention = job.state !== "healthy";
+  return (
+    <div
+      data-testid="job-health-row"
+      data-job={job.name}
+      data-state={job.state}
+      className={`py-3 border-b border-border last:border-0 ${attention ? "bg-red-50/50" : ""}`}
+    >
+      <div className="flex items-center gap-2 flex-wrap">
+        <span className="font-mono text-sm font-semibold">{job.name}</span>
+        <StateBadge state={job.state} />
+        <span className="ml-auto text-xs text-muted-foreground flex items-center gap-1">
+          <Timer className="h-3 w-3" /> every {formatInterval(job.expectedIntervalMs)}
+        </span>
+      </div>
+      <p className="text-xs text-muted-foreground mt-1">{job.does}</p>
+      <div className="flex flex-wrap gap-x-4 gap-y-1 mt-2 text-xs">
+        <span className="flex items-center gap-1 text-muted-foreground">
+          <Clock className="h-3 w-3" /> last run{" "}
+          <span className="text-foreground font-medium">{formatElapsed(job.secondsSinceLastRun)}</span>
+        </span>
+        {job.lastRun && (
+          <>
+            <span className="text-muted-foreground">
+              duration <span className="text-foreground font-medium">{job.lastRun.durationMs}ms</span>
+            </span>
+            <span className="text-muted-foreground">
+              processed{" "}
+              <span className="text-foreground font-medium">{job.lastRun.recordsProcessed}</span>
+            </span>
+            {job.lastRun.correlationId && (
+              <span className="text-muted-foreground font-mono">
+                correlation {job.lastRun.correlationId}
+              </span>
+            )}
+          </>
+        )}
+        {job.consecutiveFailures > 0 && (
+          <span className="text-red-600 font-medium">
+            {job.consecutiveFailures} consecutive failure(s)
+          </span>
+        )}
+      </div>
+      {job.lastRun?.error && (
+        <p className="mt-1 text-xs text-red-700 font-mono break-all">{job.lastRun.error}</p>
+      )}
+      {attention && (
+        <p className="mt-1 text-xs text-red-700">Impact if it stays down: {job.ifItDoesNotRun}</p>
+      )}
+    </div>
+  );
+}
+
+export default function JobHealthPanel() {
+  const [report, setReport] = useState<JobHealthReport | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    try {
+      setReport(await fetchJobHealth());
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+    }
+  }, []);
+
+  useEffect(() => {
+    startTransition(() => {
+      void load();
+    });
+    const id = setInterval(
+      () =>
+        startTransition(() => {
+          void load();
+        }),
+      REFRESH_INTERVAL_MS,
+    );
+    return () => clearInterval(id);
+  }, [load]);
+
+  return (
+    <Card data-testid="job-health-panel">
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm flex items-center gap-2">
+          <Timer className="h-4 w-4" /> Background jobs
+          {report && report.overdueCount > 0 && (
+            <Badge variant="destructive" className="ml-auto">
+              {report.overdueCount} overdue
+            </Badge>
+          )}
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {error && (
+          <p className="text-sm text-red-700 flex items-center gap-2" role="alert">
+            <AlertTriangle className="h-4 w-4" /> {error}
+          </p>
+        )}
+        {!error && !report && (
+          <div className="space-y-2">
+            <Skeleton className="h-12 w-full" />
+            <Skeleton className="h-12 w-full" />
+          </div>
+        )}
+        {!error && report && report.jobs.map((job) => <JobRow key={job.name} job={job} />)}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/components/wallet/ConnectWalletButton.tsx
+++ b/frontend/components/wallet/ConnectWalletButton.tsx
@@ -2,10 +2,22 @@
 
 import { useWallet } from "@/contexts/WalletContext"
 import { Button } from "@/components/ui/button"
-import { Wallet, Loader2, LogOut, ExternalLink } from "lucide-react"
+import { Wallet, Loader2, LogOut, ExternalLink, Lock, AlertTriangle } from "lucide-react"
+
+const BUTTON_CLASS =
+  "border-3 border-foreground font-bold shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] hover:shadow-[2px_2px_0px_0px_rgba(26,26,26,1)] hover:translate-x-0.5 hover:translate-y-0.5 transition-all min-h-[44px]"
 
 export function ConnectWalletButton() {
-  const { publicKey, connected, connecting, freighterInstalled, connect, disconnect } = useWallet()
+  const {
+    publicKey,
+    connected,
+    connecting,
+    freighterInstalled,
+    networkMismatch,
+    walletLocked,
+    connect,
+    disconnect,
+  } = useWallet()
 
   if (!freighterInstalled) {
     return (
@@ -23,6 +35,36 @@ export function ConnectWalletButton() {
           Install Freighter
         </Button>
       </a>
+    )
+  }
+
+  if (walletLocked) {
+    return (
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={connect}
+        className={BUTTON_CLASS}
+        title="Freighter is installed but locked. Open the extension and enter your password."
+      >
+        <Lock className="mr-2 h-4 w-4" />
+        Unlock Freighter
+      </Button>
+    )
+  }
+
+  if (connected && publicKey && networkMismatch) {
+    return (
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={disconnect}
+        className={`${BUTTON_CLASS} text-destructive`}
+        title="Freighter is on a different network. Switch it to Testnet to continue."
+      >
+        <AlertTriangle className="mr-2 h-4 w-4" />
+        Wrong Network — switch to Testnet
+      </Button>
     )
   }
 

--- a/frontend/contexts/WalletContext.tsx
+++ b/frontend/contexts/WalletContext.tsx
@@ -3,6 +3,7 @@
 import { createContext, useContext, useState, useEffect, useCallback, type ReactNode } from "react"
 import {
   isFreighterInstalled,
+  isWalletAllowed,
   connectWallet,
   disconnectWallet,
   signTransaction,
@@ -36,7 +37,18 @@ export function WalletProvider({ children }: { children: ReactNode }) {
   const [walletLocked, setWalletLocked] = useState(false)
 
   useEffect(() => {
-    isFreighterInstalled().then(setFreighterInstalled)
+    // A wallet that is installed and already permitted, but cannot produce an
+    // address, is locked — a different problem from "not installed" and from
+    // "never connected", and it needs its own instruction.
+    void (async () => {
+      const installed = await isFreighterInstalled()
+      setFreighterInstalled(installed)
+      if (!installed) return
+      if (await isWalletAllowed()) {
+        setWalletLocked((await getActiveAddress()) === null)
+      }
+    })()
+
     const stored = localStorage.getItem(STORAGE_KEY)
     if (stored) {
       try {

--- a/frontend/lib/freighter.ts
+++ b/frontend/lib/freighter.ts
@@ -21,6 +21,20 @@ export async function connectWallet(): Promise<string> {
   return address
 }
 
+/**
+ * Whether the site already has the user's permission to talk to Freighter.
+ * Combined with an empty address this is what tells a *locked* wallet apart from
+ * one that has simply never been connected — the two need different instructions.
+ */
+export async function isWalletAllowed(): Promise<boolean> {
+  try {
+    const result = await (freighterApi as unknown as { isAllowed?: () => Promise<{ isAllowed?: boolean }> }).isAllowed?.()
+    return result?.isAllowed === true
+  } catch {
+    return false
+  }
+}
+
 /** Returns current address without triggering a connection popup. Returns null when locked/unavailable. */
 export async function getActiveAddress(): Promise<string | null> {
   try {


### PR DESCRIPTION
# Job observability, admin capability map, and e2e coverage for the payment and verification flows

Closes #1431
Closes #1432
Closes #1448
Closes #1449

---

## #1449 — Backend: job scheduling and worker observability

The failure this addresses is silence: a job that stops being scheduled produces no
error, no alert, and no user-visible symptom until something downstream is found to be
stale. Two things are now detectable that were not before — a run that did no work, and
a run that never happened.

### Inventory

Published in full in [`backend/docs/jobs-and-workers.md`](backend/docs/jobs-and-workers.md);
the source of truth is `JOB_INVENTORY` in `backend/src/jobs/jobObservability.ts`, and a
test keeps the two in step.

| Job | Module | Interval | If it does not run | Healthy looks like |
| --- | --- | --- | --- | --- |
| `late-payment-escalation` | `src/jobs/latePaymentJob.ts` | 6h | Late tenants never escalated; arrears accrue silently | Seconds to run; 0 processed on a quiet day — a *rising* count is the abnormal case |
| `staking-finalizer` | `src/jobs/stakingFinalizer.ts` | 10s | Completed conversions never finalise; staked balances invisible to the tenant | Usually 0 processed; sustained non-zero = conversions backing up |
| `data-retention` | `src/jobs/dataRetentionJob.ts` | 24h | Personal data kept past its policy window — a compliance breach | One run/day, small non-zero counts |
| `monthly-deduction-reminder` | `src/jobs/monthlyDeductionReminderJob.ts` | 24h | Employers deduct without notice, or not at all — a missed rent cycle | One run/day, non-zero only before a pay cycle |
| `scheduler` | `src/jobs/scheduler/worker.ts` | 5s | Nothing queued executes: notifications, webhooks, purges all stall | A tick every 5s; `recordsProcessed` = due rows claimed |

Other loops (`dealStatusSyncWorker`, `sorobanEventIndexer`, settlement outbox,
reconciliation) are named in the doc as not yet on the observed path, so the remaining
gap is visible rather than implied.

### What each run records

`observeJobRun(name, fn)` records **start**, **completion**, **duration**, and
**records processed** — the last one being the point of the exercise. A run that
completes having processed zero records because of a query defect is indistinguishable
from a healthy run in any log that only records completion. Failures carry the error and
the correlation id from `request-context.ts` (the same id used for HTTP request tracing).

### Detecting a missing run as an absence

| Metric | Use |
| --- | --- |
| `job_overdue{job}` | `1` when a job has not run within twice its expected interval, **including never having run**. The alerting signal. |
| `job_seconds_since_last_run{job}` | Grows without bound once a job stops. |
| `job_last_success_timestamp_seconds{job}` | Catches "runs but always fails". |
| `job_runs_total{job,status}` | `completed` / `failed` / `skipped_overrun`. |
| `job_records_processed_total{job}` | Flat while `job_runs_total` climbs = running but doing nothing. |
| `job_run_duration_ms{job}` | Durations creeping toward the interval predict overruns. |

Both gauges are computed at scrape time, so a stalled job keeps drifting rather than
freezing at its last reported value. Suggested alert: `job_overdue == 1 for 10m`.

### Overrun behaviour — deliberate, two layers

1. In-process: `observeJobRun` refuses to start a second run of the same job while one is
   in flight and counts it as `skipped_overrun`. Runs are skipped, never queued — these
   jobs all process "whatever is due now", so the next run fully recovers.
2. Across processes: scheduler-driven jobs remain serialised by the existing lease +
   monotonic fencing token in `scheduler/store.ts`.

### Operator surface

`GET /api/admin/jobs/health` was added to the **existing** admin jobs router (registered
before `/:id` so the literal path wins) and documented in `openapi.yml`. It is surfaced in
the **existing** `/admin/health` page as a new *Background jobs* panel that shows, per
job, its state, time since last run, last duration, records processed, correlation id, and
— when a job is not healthy — the operational impact of leaving it down.

---

## #1448 — Frontend: admin surfaces vs. backend capabilities

Full map: [`docs/admin-capability-map.md`](docs/admin-capability-map.md). Summary:

**Covered** (9 modules): `adminAnalytics`, `adminAuditLogs`, `adminOutbox`,
`admin-timelock`, `adminWhistleblowerApplications`, `landlordVerification` (admin half),
`kyc` (admin half), `adminReconciliation` (partial), `adminJobs` (**via this PR**).

**No interface at all** (14 modules): `adminFraud`, `adminWithdrawals`, `adminRisk`,
`adminQuota`, `adminSessions`, `adminRoles`, `adminUnderwriting`, `adminDataRetention`,
`adminErasure`, `adminTransactionLedger`, `adminAudit` (chain verify), credit-score
(×2), `settlementAdmin`.

**Ranked by what an operator needs during a live incident:**

1. Job/worker health — "is scheduled work running?" — **implemented in this PR**
2. `adminFraud` — a flagged account left un-actioned is money leaving the platform
3. `adminWithdrawals` — the emergency stop for funds movement; endpoints exist, no button
4. `adminSessions` — containment for a compromised account
5. `adminRisk` / `adminUnderwriting`, then `adminRoles`, then the compliance back-office

**This is deliberately scoped.** The remaining gap is more than one Wave cycle, so per the
issue's own guidance the PR delivers the map plus the single top-priority surface, and
proposes the rest as follow-up issues rather than half-building six pages.

**Broken pages:** none. No admin page calls an endpoint that has moved or been removed.
`/api/admin/ledger-reconciliation` has no consumer (the reverse gap).

**Server-side authorization, checked module by module** (not inferred from the UI). Two
findings, both backend and therefore out of scope here:

- The `x-admin-secret` routes are **open when `MANUAL_ADMIN_SECRET` is unset** — the guard
  is `if (env.MANUAL_ADMIN_SECRET && header !== …) throw`. Safe in production by
  configuration only.
- `GET /api/admin/receipts` requires only an ordinary session despite the `/admin` prefix
  (already documented that way in `openapi.yml`; flagged so it is not mistaken for
  admin-gated).

`e2e/landlord/verification.spec.ts` asserts the session-guarded case directly: a
non-admin session is refused **by the API**, not merely shown a page without buttons.

**Destructive actions:** KYC approve/reject and outbox retry/dead-letter are confirmed
today. `/admin/timelock` cancel and `/admin/landlords/[id]` verification decisions are
**not** confirmed and the decision reason is optional — both are hard to undo, so they are
in the follow-up list. Decisions are audit-logged into the append-only `audit_log`, which
the new spec asserts.

---

## #1431 — E2E: wallet connection through on-chain payment

`e2e/tenant/wallet-payment.spec.ts`, with stubs in `e2e/helpers/wallet.ts`.

**Boundary.** The extension is stubbed at `window.freighterApi` — the object
`@stellar/freighter-api` talks to — so `lib/freighter.ts`, `WalletContext` and
`ConnectWalletButton` are all real code under test. The chain is stubbed at the
Horizon/Soroban **HTTP** boundary. The platform API and database stay real, which is what
makes the reconciliation assertion mean anything. No live funds, no live network, no
third-party provider.

**Coverage**

| Case | Assertion |
| --- | --- |
| Success path | Connect → pay → **a confirmed transaction produces a platform record** (`outbox_items` row for the external ref). This is the core assertion. |
| Idempotency | Submission times out ambiguously, tenant retries → exactly **one** record, no double charge |
| Signature rejection | Nothing reaches the chain, nothing is recorded, UI returns to a clean retryable state with no stuck spinner |
| No wallet | Distinct, actionable *Install Freighter* prompt, and no "Connect Wallet" affordance |
| Locked wallet | Distinct, actionable *Unlock Freighter* prompt — asserted to be distinct from the no-wallet case |
| Wrong network | Mismatch surfaced, and **zero** chain submissions — prevented, not attempted |

**One small product change was needed to make two of those assertions honest.**
`WalletContext` already tracked `walletLocked` and `networkMismatch`, but nothing rendered
them: a locked wallet was indistinguishable from a disconnected one, and a wrong-network
wallet looked normal until signing failed. `ConnectWalletButton` now renders both states
with actionable copy, and `lib/freighter.ts` gained `isWalletAllowed()` so *locked* can be
told apart from *never connected*.

---

## #1432 — E2E: landlord verification and admin review

`e2e/landlord/verification.spec.ts`.

| Case | Assertion |
| --- | --- |
| Approval | Admin decides in the UI → the level and `verified_at` change **in the database**, and the landlord's own status endpoint agrees |
| Rejection | A real transition (approve, then reject) → landlord sees an accurate `unverified` status |
| Scoping | A tenant session gets 401/403 from the decision endpoint **and** the review queue, by direct URL, and nothing changes |
| Documents | The uploaded verification document is retrievable by the reviewing admin and refused for anyone else |
| Audit trail | The decision lands in `audit_log` with `actor_type = admin`, the landlord id, and the level |

### One criterion is reported rather than asserted away

The issue asks that the capability change be **enforced, not merely displayed**. Writing
the spec turned up that **nothing on the server currently reads
`landlord_profiles.verification_level` as a gate** — an unverified landlord can call every
endpoint an approved one can. Verification is displayed and audited, but not enforced,
which is exactly the failure mode the issue is about.

Rather than assert the current behaviour as if it were correct, that test is committed as
a `test.fixme` stating the contract a gate must meet, and the gap is listed as follow-up
item 7 in the capability map. Adding the gate is a backend behaviour change and belongs in
its own PR.

---

## Determinism and repeatability

- **No `waitForTimeout` anywhere.** Every wait is a wait on a condition: Playwright's
  auto-retrying `expect`, or `waitForDb()` in `e2e/helpers/db.ts`, which polls a query
  until a predicate holds and fails with the last observed rows.
- **Prerequisites are seeded, not clicked.** Only the flow under test goes through the
  browser; everything that merely needs to exist is created through the DB helper or the
  API, following the existing `e2e/helpers/seed.ts` convention.
- **Repeatable.** The payment spec namespaces its external refs per run and deletes them
  in `afterAll`; the verification spec resets the landlord to `unverified` in
  `beforeEach` and removes the document it creates. `audit_log` is append-only by design
  (migration 008), so its rows are namespaced by a unique note instead of deleted.
- **No live external provider.** Extension and chain are both stubbed.

### Consecutive clean runs verified

**Stated plainly: zero.** The `e2e/` suite requires a live `TEST_DATABASE_URL` and a
running app + backend (`e2e/helpers/globalSetup.ts` seeds Postgres directly), and no such
environment is available to me — the suite is not part of the CI jobs these issues gate
on. The specs are written against the real routes, selectors, tables and status codes in
this repo, and the determinism rules above are followed strictly, but I have not executed
them and will not claim runs I did not do. Anyone with a seeded environment can verify
with `npx playwright test --config e2e/playwright.config.ts --repeat-each=3`.

## CI

**Frontend** (from `frontend/`, the exact CI steps):

- `pnpm install --frozen-lockfile` — clean
- `pnpm run lint` — **passes**, 0 errors (4 pre-existing warnings in `app/signup/page.tsx`
  and `components/properties/PhotoGallery.test.tsx`, untouched here)
- `pnpm run build` — **passes** (exit 0)

**Backend** (from `backend/`):

- `npm ci` — clean
- `npm run lint` — **passes**
- `npm run test:ci` — the 8 new `jobObservability` tests pass; 2529 passed overall
- `npm run openapi:validate` — **valid** (2 pre-existing warnings, one fewer than before:
  a new `adminSecret` security scheme was added so the new operation declares its auth)

One caveat, stated because it would be dishonest to omit: the full backend suite reports
**2–3 failing files per run, and a different set each run** — e.g. `notifications.test.ts`,
`payments.test.ts`, `adminAudit.test.ts`, `comprehensiveRateLimit.test.ts`. I verified this
is **pre-existing**: stashing all of my source changes and re-running produces the same
symptom with a different set of files, and each named test passes in isolation both with
and without my changes. It is cross-file shared-state interference under parallel
execution, unrelated to this PR, and I have not tried to fix it here.

## Out of scope

Load/performance testing; flows covered by other specs; backend changes for #1448;
redesigning existing admin pages; new scheduling frameworks; new jobs; and the landlord
verification gate itself (proposed as a follow-up).
