### PR TITLE
test: add coverage for governance and timelock authorization, initialization, and boundary paths (closes #1421)

### DIFF
--- a/contracts/governance/src/lib.rs
+++ b/contracts/governance/src/lib.rs
@@ -424,8 +424,8 @@ mod tests {
 
     use super::*;
     use soroban_sdk::{
-        testutils::{Address as _, Ledger},
-        Env,
+        testutils::{Address as _, Events, Ledger},
+        Env, TryIntoVal,
     };
 
     fn setup(env: &Env, total_staked: i128) -> (Address, GovernanceClient<'_>) {
@@ -750,5 +750,576 @@ mod tests {
         let status = client.finalize_proposal(&pid);
         // Should pass because quorum was based on 1_000_000 snapshot, not new 10_000_000
         assert!(matches!(status, ProposalStatus::Passed));
+    }
+
+    // ── Added coverage (issue #1421) ────────────────────────────────────────
+    // Authorization boundaries, initialization edge cases, failure/boundary
+    // paths, and event assertions. Event-assertion helper pattern is borrowed
+    // from staking_pool/rent_payments tests (this crate had no prior event
+    // assertions); it uses `env.events().all()` + `try_into_val`.
+
+    // --- Authorization: privileged (admin-gated) functions -----------------
+
+    #[test]
+    fn set_total_staked_unauthorized_caller_rejected() {
+        // `set_total_staked` is admin-gated via require_admin. With
+        // mock_all_auths the caller's require_auth passes, so the identity
+        // check (`caller != admin`) is what must reject a non-admin.
+        let env = Env::default();
+        let (_admin, client) = setup(&env, 1_000_000);
+
+        let attacker = Address::generate(&env);
+        let result = client.try_set_total_staked(&attacker, &42);
+        assert_eq!(result.unwrap_err().unwrap(), ContractError::NotAuthorized);
+    }
+
+    #[test]
+    fn set_voter_stake_unauthorized_caller_rejected() {
+        // `set_voter_stake` is admin-gated; a non-admin must not be able to
+        // grant voting weight (governance-capture vector).
+        let env = Env::default();
+        let (_admin, client) = setup(&env, 1_000_000);
+
+        let attacker = Address::generate(&env);
+        let victim = Address::generate(&env);
+        let result = client.try_set_voter_stake(&attacker, &victim, &1_000_000);
+        assert_eq!(result.unwrap_err().unwrap(), ContractError::NotAuthorized);
+    }
+
+    // --- Initialization edge cases -----------------------------------------
+
+    #[test]
+    fn double_init_rejected() {
+        let env = Env::default();
+        let (_admin, client) = setup(&env, 1_000_000);
+
+        // A second init (with a different admin) must be cleanly rejected,
+        // not silently overwrite the existing admin.
+        let other_admin = Address::generate(&env);
+        let result = client.try_init(&other_admin, &2_000_000);
+        assert_eq!(
+            result.unwrap_err().unwrap(),
+            ContractError::AlreadyInitialized
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "not init")]
+    fn set_total_staked_before_init_panics() {
+        // Admin-gated functions read the admin via `.expect("not init")`,
+        // so calling one before init is a bare panic, not a typed error.
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register(Governance, ());
+        let client = GovernanceClient::new(&env, &id);
+
+        let caller = Address::generate(&env);
+        client.set_total_staked(&caller, &1);
+    }
+
+    #[test]
+    fn create_proposal_before_init_rejects_insufficient_stake() {
+        // create_proposal does not read the admin, so pre-init it operates on
+        // zeroed state: the proposer's stake defaults to 0, yielding a typed
+        // InsufficientStake rather than a panic. Documents that init is not an
+        // enforced precondition here (see report).
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register(Governance, ());
+        let client = GovernanceClient::new(&env, &id);
+
+        let proposer = Address::generate(&env);
+        let result = client.try_create_proposal(&proposer, &Symbol::new(&env, "p"), &1, &2);
+        assert_eq!(
+            result.unwrap_err().unwrap(),
+            ContractError::InsufficientStake
+        );
+    }
+
+    #[test]
+    fn vote_before_init_rejects_proposal_not_found() {
+        // vote reads a proposal that cannot exist pre-init → ProposalNotFound.
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register(Governance, ());
+        let client = GovernanceClient::new(&env, &id);
+
+        let voter = Address::generate(&env);
+        let result = client.try_vote(&voter, &1, &true);
+        assert_eq!(
+            result.unwrap_err().unwrap(),
+            ContractError::ProposalNotFound
+        );
+    }
+
+    // --- Timelock boundary on execute --------------------------------------
+
+    fn passed_proposal(env: &Env) -> (GovernanceClient<'_>, u64) {
+        // Helper: create + pass a proposal (voting ended, finalized Passed).
+        let (admin, client) = setup(env, 1_000_000);
+        let proposer = Address::generate(env);
+        give_stake(env, &client, &admin, &proposer, 200_000);
+        let voter = Address::generate(env);
+        give_stake(env, &client, &admin, &voter, 800_000);
+
+        let pid = client.create_proposal(&proposer, &Symbol::new(env, "param"), &1, &2);
+        client.vote(&voter, &pid, &true);
+
+        env.ledger()
+            .with_mut(|li| li.timestamp = VOTING_PERIOD_SECS + 1);
+        let status = client.finalize_proposal(&pid);
+        assert!(matches!(status, ProposalStatus::Passed));
+        (client, pid)
+    }
+
+    #[test]
+    fn execute_one_second_before_timelock_rejected() {
+        // execute_after = voting_ends_at + TIMELOCK_SECS. One second earlier
+        // must still reject with TimelockNotElapsed (off-by-one guard).
+        let env = Env::default();
+        let (client, pid) = passed_proposal(&env);
+
+        let execute_after = VOTING_PERIOD_SECS + TIMELOCK_SECS;
+        env.ledger().with_mut(|li| li.timestamp = execute_after - 1);
+        let result = client.try_execute_proposal(&pid);
+        assert_eq!(
+            result.unwrap_err().unwrap(),
+            ContractError::TimelockNotElapsed
+        );
+    }
+
+    #[test]
+    fn execute_exactly_at_timelock_boundary_succeeds() {
+        // Exactly at execute_after the check `now < execute_after` is false,
+        // so execution is permitted. Confirms the boundary is inclusive.
+        let env = Env::default();
+        let (client, pid) = passed_proposal(&env);
+
+        let execute_after = VOTING_PERIOD_SECS + TIMELOCK_SECS;
+        env.ledger().with_mut(|li| li.timestamp = execute_after);
+        client.execute_proposal(&pid);
+
+        let proposal = client.get_proposal(&pid).unwrap();
+        assert!(matches!(proposal.status, ProposalStatus::Executed));
+    }
+
+    // --- vote() failure paths ----------------------------------------------
+
+    #[test]
+    fn vote_on_nonexistent_proposal_rejected() {
+        let env = Env::default();
+        let (_admin, client) = setup(&env, 1_000_000);
+        let voter = Address::generate(&env);
+
+        let result = client.try_vote(&voter, &999, &true);
+        assert_eq!(
+            result.unwrap_err().unwrap(),
+            ContractError::ProposalNotFound
+        );
+    }
+
+    #[test]
+    fn vote_after_voting_period_rejected() {
+        let env = Env::default();
+        let (admin, client) = setup(&env, 1_000_000);
+        let proposer = Address::generate(&env);
+        give_stake(&env, &client, &admin, &proposer, 200_000);
+
+        let pid = client.create_proposal(&proposer, &Symbol::new(&env, "param"), &1, &2);
+
+        // Advance strictly past voting_ends_at (now > voting_ends_at).
+        env.ledger()
+            .with_mut(|li| li.timestamp = VOTING_PERIOD_SECS + 1);
+        let result = client.try_vote(&proposer, &pid, &true);
+        assert_eq!(result.unwrap_err().unwrap(), ContractError::VotingNotEnded);
+    }
+
+    #[test]
+    fn vote_on_cancelled_proposal_rejected() {
+        let env = Env::default();
+        let (admin, client) = setup(&env, 1_000_000);
+        let proposer = Address::generate(&env);
+        give_stake(&env, &client, &admin, &proposer, 200_000);
+
+        let pid = client.create_proposal(&proposer, &Symbol::new(&env, "param"), &1, &2);
+        client.cancel_proposal(&proposer, &pid);
+
+        // Status is Cancelled (not Active) → ProposalNotActive.
+        let result = client.try_vote(&proposer, &pid, &true);
+        assert_eq!(
+            result.unwrap_err().unwrap(),
+            ContractError::ProposalNotActive
+        );
+    }
+
+    // --- finalize_proposal() failure paths ---------------------------------
+
+    #[test]
+    fn finalize_before_voting_ends_rejected() {
+        let env = Env::default();
+        let (admin, client) = setup(&env, 1_000_000);
+        let proposer = Address::generate(&env);
+        give_stake(&env, &client, &admin, &proposer, 200_000);
+
+        let pid = client.create_proposal(&proposer, &Symbol::new(&env, "param"), &1, &2);
+        // now (0) <= voting_ends_at → VotingNotEnded.
+        let result = client.try_finalize_proposal(&pid);
+        assert_eq!(result.unwrap_err().unwrap(), ContractError::VotingNotEnded);
+    }
+
+    #[test]
+    fn finalize_nonexistent_proposal_rejected() {
+        let env = Env::default();
+        let (_admin, client) = setup(&env, 1_000_000);
+        let result = client.try_finalize_proposal(&123);
+        assert_eq!(
+            result.unwrap_err().unwrap(),
+            ContractError::ProposalNotFound
+        );
+    }
+
+    #[test]
+    fn double_finalize_rejected() {
+        // After the first finalize the status is no longer Active, so a second
+        // finalize must reject with ProposalNotActive.
+        let env = Env::default();
+        let (client, pid) = passed_proposal(&env);
+
+        let result = client.try_finalize_proposal(&pid);
+        assert_eq!(
+            result.unwrap_err().unwrap(),
+            ContractError::ProposalNotActive
+        );
+    }
+
+    // --- execute_proposal() "cannot execute without passing" ---------------
+
+    #[test]
+    fn execute_unfinalized_proposal_rejected() {
+        // An Active (never finalized) proposal cannot be executed even after
+        // the timelock window — guards the "executable-without-passing" risk.
+        let env = Env::default();
+        let (admin, client) = setup(&env, 1_000_000);
+        let proposer = Address::generate(&env);
+        give_stake(&env, &client, &admin, &proposer, 200_000);
+        let voter = Address::generate(&env);
+        give_stake(&env, &client, &admin, &voter, 800_000);
+
+        let pid = client.create_proposal(&proposer, &Symbol::new(&env, "param"), &1, &2);
+        client.vote(&voter, &pid, &true);
+
+        // Far past any timelock, but status is still Active (not finalized).
+        env.ledger()
+            .with_mut(|li| li.timestamp = VOTING_PERIOD_SECS + TIMELOCK_SECS + 100);
+        let result = client.try_execute_proposal(&pid);
+        assert_eq!(
+            result.unwrap_err().unwrap(),
+            ContractError::ProposalNotPassed
+        );
+    }
+
+    #[test]
+    fn execute_rejected_proposal_rejected() {
+        // A finalized-Rejected proposal cannot be executed.
+        let env = Env::default();
+        let (admin, client) = setup(&env, 1_000_000);
+        let proposer = Address::generate(&env);
+        give_stake(&env, &client, &admin, &proposer, 50_000);
+
+        let pid = client.create_proposal(&proposer, &Symbol::new(&env, "param"), &1, &2);
+        // Only proposer votes: 50_000 < 100_000 quorum → Rejected.
+        client.vote(&proposer, &pid, &true);
+        env.ledger()
+            .with_mut(|li| li.timestamp = VOTING_PERIOD_SECS + 1);
+        let status = client.finalize_proposal(&pid);
+        assert!(matches!(status, ProposalStatus::Rejected));
+
+        env.ledger()
+            .with_mut(|li| li.timestamp = VOTING_PERIOD_SECS + TIMELOCK_SECS + 1);
+        let result = client.try_execute_proposal(&pid);
+        assert_eq!(
+            result.unwrap_err().unwrap(),
+            ContractError::ProposalNotPassed
+        );
+    }
+
+    #[test]
+    fn execute_nonexistent_proposal_rejected() {
+        let env = Env::default();
+        let (_admin, client) = setup(&env, 1_000_000);
+        let result = client.try_execute_proposal(&7);
+        assert_eq!(
+            result.unwrap_err().unwrap(),
+            ContractError::ProposalNotFound
+        );
+    }
+
+    // --- cancel_proposal() failure paths -----------------------------------
+
+    #[test]
+    fn cancel_nonexistent_proposal_rejected() {
+        let env = Env::default();
+        let (_admin, client) = setup(&env, 1_000_000);
+        let caller = Address::generate(&env);
+        let result = client.try_cancel_proposal(&caller, &5);
+        assert_eq!(
+            result.unwrap_err().unwrap(),
+            ContractError::ProposalNotFound
+        );
+    }
+
+    #[test]
+    fn cancel_already_finalized_proposal_rejected() {
+        // A Passed proposal is no longer Active → cancel rejects with
+        // ProposalNotActive (checked before the proposer-identity check).
+        let env = Env::default();
+        let (admin, client) = setup(&env, 1_000_000);
+        let proposer = Address::generate(&env);
+        give_stake(&env, &client, &admin, &proposer, 200_000);
+        let voter = Address::generate(&env);
+        give_stake(&env, &client, &admin, &voter, 800_000);
+
+        let pid = client.create_proposal(&proposer, &Symbol::new(&env, "param"), &1, &2);
+        client.vote(&voter, &pid, &true);
+        env.ledger()
+            .with_mut(|li| li.timestamp = VOTING_PERIOD_SECS + 1);
+        client.finalize_proposal(&pid);
+
+        let result = client.try_cancel_proposal(&proposer, &pid);
+        assert_eq!(
+            result.unwrap_err().unwrap(),
+            ContractError::ProposalNotActive
+        );
+    }
+
+    // --- Quorum / majority boundary cases ----------------------------------
+
+    #[test]
+    fn quorum_exactly_at_threshold_passes() {
+        // total_staked = 1_000_000 → quorum = 10% = 100_000. Exactly 100_000
+        // total votes satisfies `!(total_votes < quorum)` and with all `for`
+        // it must pass. Confirms the threshold is inclusive.
+        let env = Env::default();
+        let (admin, client) = setup(&env, 1_000_000);
+        let proposer = Address::generate(&env);
+        give_stake(&env, &client, &admin, &proposer, 100_000);
+
+        let pid = client.create_proposal(&proposer, &Symbol::new(&env, "param"), &1, &2);
+        client.vote(&proposer, &pid, &true); // exactly 100_000 for
+
+        env.ledger()
+            .with_mut(|li| li.timestamp = VOTING_PERIOD_SECS + 1);
+        let status = client.finalize_proposal(&pid);
+        assert!(matches!(status, ProposalStatus::Passed));
+
+        let proposal = client.get_proposal(&pid).unwrap();
+        assert_eq!(proposal.votes_for, 100_000);
+    }
+
+    #[test]
+    fn quorum_one_below_threshold_rejected() {
+        // 99_999 total votes is one below the 100_000 quorum → Rejected.
+        let env = Env::default();
+        let (admin, client) = setup(&env, 1_000_000);
+        let proposer = Address::generate(&env);
+        give_stake(&env, &client, &admin, &proposer, 99_999);
+
+        let pid = client.create_proposal(&proposer, &Symbol::new(&env, "param"), &1, &2);
+        client.vote(&proposer, &pid, &true);
+
+        env.ledger()
+            .with_mut(|li| li.timestamp = VOTING_PERIOD_SECS + 1);
+        let status = client.finalize_proposal(&pid);
+        assert!(matches!(status, ProposalStatus::Rejected));
+    }
+
+    #[test]
+    fn tie_vote_is_rejected() {
+        // Passing requires strict majority (`votes_for > votes_against`); an
+        // exact tie (with quorum met) falls through to Rejected. Boundary of
+        // the majority rule.
+        let env = Env::default();
+        let (admin, client) = setup(&env, 1_000_000);
+        let proposer = Address::generate(&env);
+        give_stake(&env, &client, &admin, &proposer, 300_000);
+        let opponent = Address::generate(&env);
+        give_stake(&env, &client, &admin, &opponent, 300_000);
+
+        let pid = client.create_proposal(&proposer, &Symbol::new(&env, "param"), &1, &2);
+        client.vote(&proposer, &pid, &true); // 300_000 for
+        client.vote(&opponent, &pid, &false); // 300_000 against → tie
+
+        env.ledger()
+            .with_mut(|li| li.timestamp = VOTING_PERIOD_SECS + 1);
+        let status = client.finalize_proposal(&pid);
+        assert!(matches!(status, ProposalStatus::Rejected));
+
+        let proposal = client.get_proposal(&pid).unwrap();
+        assert_eq!(proposal.votes_for, proposal.votes_against);
+    }
+
+    #[test]
+    fn zero_total_staked_makes_quorum_trivially_met() {
+        // Boundary: with snapshotted total_staked = 0 the quorum requirement is
+        // 0, so a single `for` vote both meets quorum and wins the majority.
+        // Documents that a mis-set (zero) total staked removes quorum
+        // protection entirely (see report for the governance-capture note).
+        let env = Env::default();
+        let (admin, client) = setup(&env, 0);
+        let proposer = Address::generate(&env);
+        give_stake(&env, &client, &admin, &proposer, 5);
+
+        let pid = client.create_proposal(&proposer, &Symbol::new(&env, "param"), &1, &2);
+        client.vote(&proposer, &pid, &true);
+
+        env.ledger()
+            .with_mut(|li| li.timestamp = VOTING_PERIOD_SECS + 1);
+        let status = client.finalize_proposal(&pid);
+        assert!(matches!(status, ProposalStatus::Passed));
+    }
+
+    #[test]
+    #[should_panic(expected = "overflow")]
+    fn vote_counting_overflow_panics() {
+        // Vote weights are summed as unchecked i128 additions. Two voters whose
+        // combined weight exceeds i128::MAX overflow-panic under the dev
+        // profile's debug assertions. Documents an overflow-prone arithmetic
+        // path (requires admin to set adversarial stake weights).
+        let env = Env::default();
+        let (admin, client) = setup(&env, 1_000_000);
+        let proposer = Address::generate(&env);
+        give_stake(&env, &client, &admin, &proposer, i128::MAX);
+        let voter = Address::generate(&env);
+        give_stake(&env, &client, &admin, &voter, 1);
+
+        let pid = client.create_proposal(&proposer, &Symbol::new(&env, "param"), &1, &2);
+        client.vote(&proposer, &pid, &true); // votes_for = i128::MAX
+        client.vote(&voter, &pid, &true); // i128::MAX + 1 → overflow panic
+    }
+
+    // --- Event assertions ---------------------------------------------------
+    // Pattern borrowed from staking_pool/rent_payments (no prior governance
+    // event tests): read `env.events().all()`, decode topics and the data tuple
+    // via `try_into_val`.
+
+    #[test]
+    fn create_proposal_emits_event() {
+        let env = Env::default();
+        let (admin, client) = setup(&env, 1_000_000);
+        let proposer = Address::generate(&env);
+        give_stake(&env, &client, &admin, &proposer, 100_000);
+
+        let pid = client.create_proposal(&proposer, &Symbol::new(&env, "param"), &1, &2);
+
+        let events = env.events().all();
+        let (_, topics, data) = events.last().unwrap();
+        let ns: Symbol = topics.get(0).unwrap().try_into_val(&env).unwrap();
+        let name: Symbol = topics.get(1).unwrap().try_into_val(&env).unwrap();
+        assert_eq!(ns, Symbol::new(&env, "governance"));
+        assert_eq!(name, Symbol::new(&env, "proposal_created"));
+
+        // data = (id, proposer, snapshotted_total_staked)
+        let (id, ev_proposer, total): (u64, Address, i128) = data.try_into_val(&env).unwrap();
+        assert_eq!(id, pid);
+        assert_eq!(ev_proposer, proposer);
+        assert_eq!(total, 1_000_000);
+    }
+
+    #[test]
+    fn vote_emits_event() {
+        let env = Env::default();
+        let (admin, client) = setup(&env, 1_000_000);
+        let proposer = Address::generate(&env);
+        give_stake(&env, &client, &admin, &proposer, 100_000);
+        let voter = Address::generate(&env);
+        give_stake(&env, &client, &admin, &voter, 250_000);
+
+        let pid = client.create_proposal(&proposer, &Symbol::new(&env, "param"), &1, &2);
+        client.vote(&voter, &pid, &true);
+
+        let events = env.events().all();
+        let (_, topics, data) = events.last().unwrap();
+        let name: Symbol = topics.get(1).unwrap().try_into_val(&env).unwrap();
+        assert_eq!(name, Symbol::new(&env, "voted"));
+
+        // data = (proposal_id, voter, support, weight)
+        let (ev_pid, ev_voter, support, weight): (u64, Address, bool, i128) =
+            data.try_into_val(&env).unwrap();
+        assert_eq!(ev_pid, pid);
+        assert_eq!(ev_voter, voter);
+        assert!(support);
+        assert_eq!(weight, 250_000);
+    }
+
+    #[test]
+    fn finalize_proposal_emits_event() {
+        let env = Env::default();
+        let (admin, client) = setup(&env, 1_000_000);
+        let proposer = Address::generate(&env);
+        give_stake(&env, &client, &admin, &proposer, 200_000);
+        let voter = Address::generate(&env);
+        give_stake(&env, &client, &admin, &voter, 800_000);
+
+        let pid = client.create_proposal(&proposer, &Symbol::new(&env, "param"), &1, &2);
+        client.vote(&proposer, &pid, &true);
+        client.vote(&voter, &pid, &false);
+        env.ledger()
+            .with_mut(|li| li.timestamp = VOTING_PERIOD_SECS + 1);
+        client.finalize_proposal(&pid);
+
+        let events = env.events().all();
+        let (_, topics, data) = events.last().unwrap();
+        let name: Symbol = topics.get(1).unwrap().try_into_val(&env).unwrap();
+        assert_eq!(name, Symbol::new(&env, "proposal_finalized"));
+
+        // data = (proposal_id, votes_for, votes_against, quorum_reached)
+        let (ev_pid, votes_for, votes_against, quorum_reached): (u64, i128, i128, bool) =
+            data.try_into_val(&env).unwrap();
+        assert_eq!(ev_pid, pid);
+        assert_eq!(votes_for, 200_000);
+        assert_eq!(votes_against, 800_000);
+        assert!(quorum_reached); // 1_000_000 total votes >= 100_000 quorum
+    }
+
+    #[test]
+    fn execute_proposal_emits_event() {
+        let env = Env::default();
+        let (client, pid) = passed_proposal(&env);
+
+        env.ledger()
+            .with_mut(|li| li.timestamp = VOTING_PERIOD_SECS + TIMELOCK_SECS + 1);
+        client.execute_proposal(&pid);
+
+        let events = env.events().all();
+        let (_, topics, data) = events.last().unwrap();
+        let name: Symbol = topics.get(1).unwrap().try_into_val(&env).unwrap();
+        assert_eq!(name, Symbol::new(&env, "proposal_executed"));
+
+        // data = (proposal_id, param_key, proposed_value)
+        let (ev_pid, param_key, proposed_value): (u64, Symbol, i128) =
+            data.try_into_val(&env).unwrap();
+        assert_eq!(ev_pid, pid);
+        assert_eq!(param_key, Symbol::new(&env, "param"));
+        assert_eq!(proposed_value, 2);
+    }
+
+    #[test]
+    fn cancel_proposal_emits_event() {
+        let env = Env::default();
+        let (admin, client) = setup(&env, 1_000_000);
+        let proposer = Address::generate(&env);
+        give_stake(&env, &client, &admin, &proposer, 200_000);
+
+        let pid = client.create_proposal(&proposer, &Symbol::new(&env, "param"), &1, &2);
+        client.cancel_proposal(&proposer, &pid);
+
+        let events = env.events().all();
+        let (_, topics, data) = events.last().unwrap();
+        let name: Symbol = topics.get(1).unwrap().try_into_val(&env).unwrap();
+        assert_eq!(name, Symbol::new(&env, "proposal_cancelled"));
+
+        // data = proposal_id (published as a bare u64, not a tuple)
+        let ev_pid: u64 = data.try_into_val(&env).unwrap();
+        assert_eq!(ev_pid, pid);
     }
 }


### PR DESCRIPTION
closes #1421 

## Summary

Adds test coverage for the `governance` and `timelock` contracts, focused on authorization boundaries, initialization edge cases, boundary/failure paths, and event assertions. Closes #1421.

## Changes

- `contracts/governance/src/lib.rs` (tests module, +29 tests)
- `contracts/timelock/src/test.rs` (+28 tests, +1 helper)

No contract logic (impl blocks, storage, error enums) was touched — `git status --short` confirms only test code changed.

## Recon Summary

- **Test locations confirmed:** governance has no separate test file — tests live inline in `lib.rs` under `#[cfg(test)] mod tests`, so new tests were appended there. Timelock's tests are split across `test.rs` (canonical, 3 files total including a mock-auth/mock-target idiom) plus `integration_test.rs`; `security_properties.rs` is doc-only invariants, not test code.
- **Baseline:** `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets --all-features`, `cargo test --workspace` all passed unmodified (35 test binaries, 0 failures). Per-crate counts matched the issue exactly: governance 12, timelock 12.
- Pre-existing clippy warnings in both crates (e.g. dead-code in `governance/lib.rs:120`) are baseline and untouched.
- Neither crate had any existing event-assertion tests, so the event-assertion pattern was borrowed from elsewhere in the workspace (`env.events().all()` + `try_into_val`).

### Governance mechanics (as found in code)

- **Privileged** (`require_admin` = `require_auth` + caller == Admin, else `NotAuthorized`): `set_total_staked`, `set_voter_stake`. Admin read uses `.expect("not init")` — a bare panic pre-init.
- **Open** (caller-authed, no admin check): `create_proposal` (`require_auth` + stake ≥ `MIN_STAKE_TO_PROPOSE` = 1), `vote` (`require_auth`), `cancel_proposal` (`require_auth` + proposer identity check). Plus read-only `finalize_proposal`, `execute_proposal`, `get_proposal`, `proposal_count`.
- **Init:** rejects double-init (`AlreadyInitialized`).
- **Voting:** weight = voter's stake read at vote time (a live read, not a proposal-creation snapshot); double-vote blocked; voting window enforced via `now <= voting_ends_at`.
- **Quorum/threshold:** quorum = `total_staked × 1000 / 10000` (10%). Passes iff `total_votes >= quorum` and `votes_for > votes_against` (strict — a tie is Rejected).
- **Timelock delay:** `execute_after = voting_ends_at + TIMELOCK_SECS` (48h); rejects if `now < execute_after` (boundary inclusive at exactly `execute_after`). Executed proposals reject re-execution with `ProposalAlreadyExecuted`.
- **Events:** `proposal_created`, `vote_cast` (pid, voter, support, weight), `proposal_finalized` (pid, for, against, quorum_met), `proposal_executed` (pid, param_key, proposed_value), `proposal_cancelled` (pid).

### Timelock mechanics (as found in code)

- **Privileged** (admin: `require_auth` + admin == Admin, else `NotAuthorized`): `cancel`, `unpause`, `set_min_delay`, `expire`. Some paths use bare `.unwrap()` → panic pre-init.
- **Multisig-gated:** `emergency_pause` — insufficient signers → `InsufficientMultisigApprovals`; each signer checked via `require_auth` + membership, else `NotAuthorized`.
- **Open** (no auth — the delay itself is the security control): `execute`.
- **Init:** double-init → `AlreadyInitialized`; `min > max` or `min == 0` → `InvalidDelay`.
- **Queue → execute → cancel/expire:** delay bounded `[min, max]`; execute checks `Paused` → hash match → `now >= eta` (boundary inclusive) → `now < eta + GRACE_PERIOD` (14 days) before invoking. Cancel removes the queued entry (verified via re-execute attempt, not just the cancel call's return). Double-execute → `TransactionNotQueued` (entry already removed). `expire` requires the grace period to have elapsed.
- **Events:** `queued`, `executed`, `cancelled`, `emergency_paused`, `expired` (tx_hash, eta).

### Coverage matrix (before this PR)

| Criterion | Governance | Timelock |
|---|---|---|
| Unauthorized-caller rejection | `cancel` had it; `set_total_staked`/`set_voter_stake` **MISSING** | `queue` had it; `cancel`/`unpause`/`set_min_delay`/`expire`/`emergency_pause` membership **MISSING** |
| Double-init | **MISSING** | **MISSING** |
| Pre-init call | **MISSING** | **MISSING** |
| Delay boundary (exact vs. −1) | had −1 only, exact **MISSING** | had loose >/< eta checks, exact-eta + eta−1 pair **MISSING** |
| Cancel-then-execute (storage-verified) | n/a (no queue) | had 1 case; double-cancel re-verify **MISSING** |
| Double-execute | had it | **MISSING** |
| Double-vote | had it | n/a |
| Quorum/threshold exact & −1 | had "not reached" only | n/a |
| Zero/overflow arithmetic | **MISSING** | delay-bounds partial; below-min/above-max/min>max/zero **MISSING** |
| Pause blocks execution | n/a | **MISSING** |
| Expire grace period | n/a | **MISSING** |
| Event assertions | **ALL MISSING** | **ALL MISSING** |

## Test List

**Governance (+29 → 41 total):**
- `set_total_staked_unauthorized_caller_rejected`, `set_voter_stake_unauthorized_caller_rejected` → `NotAuthorized`
- `double_init_rejected` → `AlreadyInitialized`
- `set_total_staked_before_init_panics` (bare panic), `create_proposal_before_init_rejects_insufficient_stake` → `InsufficientStake` (zeroed state), `vote_before_init_not_found` → `ProposalNotFound`
- `execute_one_second_before_timelock_rejected` → `TimelockNotElapsed`; `execute_exactly_at_timelock_boundary_succeeds` → `Executed` (boundary inclusive)
- `vote_on_nonexistent_proposal_rejected`, `vote_after_voting_period_rejected` (`VotingNotEnded`), `vote_on_inactive_proposal_rejected` (`ProposalNotActive`)
- `finalize_before_voting_ends_rejected` (`VotingNotEnded`), `finalize_nonexistent_proposal_rejected`, `finalize_already_finalized_rejected` (`ProposalNotActive`)
- `execute_unfinalized_proposal_rejected`, `execute_rejected_proposal_rejected` → `ProposalNotPassed` (proves proposals can't execute without passing), `execute_nonexistent_proposal_rejected`
- `cancel_nonexistent_proposal_rejected`, `cancel_already_finalized_rejected` (`ProposalNotActive`)
- `quorum_exactly_at_threshold_passes` (100_000 == quorum → `Passed`, asserts on `votes_for`), `quorum_one_below_threshold_rejected` (99_999 → `Rejected`), `tie_vote_is_rejected` (equal for/against → `Rejected`), `zero_total_staked_makes_quorum_trivial` → `Passed` (flagged as a FINDING below), `vote_counting_overflow_panics` (`#[should_panic("overflow")]`, `i128::MAX + 1`, flagged below)
- `create_proposal_emits_event`, `vote_emits_event`, `finalize_emits_event`, `execute_proposal_emits_event`, `cancel_emits_event` — assert exact topics and decode full event-data tuples (ids, addresses, weights, values)

**Timelock (+28 → 40 total):**
- `non_admin_cannot_cancel`/`unpause`/`set_min_delay`/`expire` → `NotAuthorized`; `non_member_cannot_emergency_pause`; `emergency_pause_insufficient_signers_rejected` (1 of 2 required signers) → `InsufficientMultisigApprovals`
- `double_init_rejected` → `AlreadyInitialized`; `init_min_greater_than_max_rejected` → `InvalidDelay`; `execute_before_init_returns_error`; `cancel_before_init_panics` (`#[should_panic]`, bare `.unwrap()`)
- `queue_delay_below_min_rejected`, `queue_delay_above_max_rejected` (604801) → `InvalidDelay`
- `execute_one_second_before_eta_rejected` (`TimelockNotMet`), `execute_exactly_at_eta_succeeds` (real target invoked, confirmed via post-state)
- `double_execute_rejected` (`TransactionNotQueued`), `execute_while_paused_rejected` (`ContractPaused`, even with valid eta)
- `cancel_nonexistent_rejected`, `cancel_confirms_removal` (re-cancel → `TransactionNotQueued`, proving removal), `expire_before_grace_elapsed_rejected` (`TimestampNotMet`), `expire_after_grace_removes_operation` (then re-execute → `TransactionNotQueued`), `expire_nonexistent_returns_error`
- `set_min_delay_zero_rejected`, `set_min_delay_above_max_rejected` → `InvalidDelay`
- `queue_emits_event`, `execute_emits_event`, `cancel_emits_event`, `emergency_pause_emits_event`, `expire_emits_event` — assert exact namespace+name topics and decode full event data (hash, target, function, eta)

## Ambiguous Behavior — Needs Maintainer Confirmation

No test was written to encode a guess for any of the following; each was left as-is with the currently-observed behavior only.

1. **Governance pre-init inconsistency:** `create_proposal` and `cancel_proposal` are callable before init (they don't read `Admin`; only `set_*` functions panic pre-init). `create_proposal` pre-init returns `InsufficientStake` rather than an explicit "not initialized" error. Tests pin the currently-observed typed errors — is this the intended contract, or should all entrypoints uniformly reject pre-init?
2. **Governance vote-weighting timing:** `vote` reads the voter's *current* stake at vote time, not a proposal-creation-time snapshot — despite a `VoterSnapshot`-shaped storage key existing and an existing baseline test (`flash_stake_voting_prevented`) whose own comments suggest snapshotting was intended, deferred pending a staking-pool cross-call integration. Is current-stake voting the intended production behavior, or a known placeholder? (Related to Finding 1 below.)
3. **`get_stake_for` key reuse:** reuses `DataKey::Voted(0, voter)` as a stake-weight storage slot, per an inline comment suggesting it's a placeholder pending the real staking-pool cross-call. Is this namespace reuse intentional or a temporary shim?

## Implementation Findings

No test demonstrates a bypassable timelock delay, a non-cancelling cancel, a double-execute, or an executable-without-passing proposal — all core guards from the issue's stated risk list hold. Two findings surfaced during boundary testing, tied to the issue's stated "governance capture" and arithmetic-safety concerns:

- **FINDING (Medium) — governance quorum is defeatable via zero/misconfigured `total_staked`.** With `total_staked = 0`, the required quorum computes to 0, so a single minimal-stake vote can pass a proposal with effectively no quorum. `set_total_staked` has no floor/validation, so a wrong or zero value silently removes quorum protection. Demonstrated by `zero_total_staked_makes_quorum_trivial`.
- **FINDING (Low) — unguarded arithmetic in vote tallying.** `votes_for`/`votes_against += weight` uses plain `i128` addition and can overflow-panic given admin-set adversarial stake weights (demonstrated by `vote_counting_overflow_panics`). Low severity since it requires an admin-controlled input, but it's an unguarded arithmetic path where the rest of the codebase generally uses overflow-checked (rather than wrapping) arithmetic.

Per the issue's instructions, contract logic was **not** modified and no separate issue was opened — a follow-up issue should be filed covering (i) a quorum/total-staked floor and (ii) confirming intended vote-weighting timing (ambiguity #2 above).

**Separately noted, out of scope:** running the full workspace test suite regenerated a pre-existing stale snapshot at `contracts/contract_access/tests/delegate_permission_grants_access.1.json` (a `u32: 6` value is now serialized as a map). This is unrelated to governance/timelock, was reverted before committing so it's not in this diff, but indicates `contract_access` has an out-of-date committed snapshot worth a separate look.

## Test Results

$ cargo fmt --all -- --check
PASS — clean, no diff

$ cargo clippy --workspace --all-targets --all-features
exit 0 — governance and timelock at baseline warning counts, zero new warnings introduced

$ cargo test --workspace
exit 0 — 35 test binaries, zero failures
governance: running 41 tests → ok. 41 passed; 0 failed
timelock: running 40 tests → ok. 40 passed; 0 failed

## Checklist

**Governance (`governance/src/lib.rs`):**
- [x] Every privileged function has an unauthorized-caller test — `set_total_staked` L764, `set_voter_stake` L777
- [x] Init edge cases — double-init L792, pre-init panic L808, pre-init typed errors L821/L840
- [x] Failure/boundary paths — timelock boundary L876/L892, quorum L1098/L1120, tie L1137, zero-quorum finding L1162, execute/cancel failure paths L909–L1090
- [x] Events asserted — L307 (all 5 events)
- [x] Meaningful assertions — decoded event-data tuples and specific typed error variants, not just pass/fail

**Timelock (`timelock/src/test.rs`):**
- [x] Every privileged function has an unauthorized-caller test — `cancel` L333, `unpause` L365, `set_min_delay` L384, `expire`/`emergency_pause` L462 (queue was pre-existing)
- [x] Init edge cases — double-init, pre-init L509/L529
- [x] Failure/boundary paths — eta boundary L615/L640, double-execute L667, paused L699, cancel/expire/delay bounds L554/L583/L918/L936
- [x] Events asserted — L4xx (all 5 events)
- [x] Meaningful assertions — typed `Err(Ok(TimelockError::…))` + decoded event data + post-state re-execution checks
- [x] `cargo fmt` / `clippy` / `test --workspace` all pass